### PR TITLE
Adding more juice to the ProcStatus collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/github.com/*
 src/golang.org/*
 *.deb
 *.secret
+*.swp
 *.pyc
 *.DS_Store
 .project

--- a/src/fullerite/collector/procstatus.go
+++ b/src/fullerite/collector/procstatus.go
@@ -11,9 +11,8 @@ import (
 // ProcStatus collector type
 type ProcStatus struct {
 	baseCollector
-	compiledRegex       map[string]*regexp.Regexp
-	generatedDimensions map[string]string
-	processName         string
+	compiledRegex map[string]*regexp.Regexp
+	processName   string
 }
 
 // ProcessName returns ProcStatus collectors process name
@@ -31,7 +30,6 @@ func NewProcStatus(channel chan metric.Metric, initialInterval int, log *l.Entry
 
 	ps.name = "ProcStatus"
 	ps.processName = ""
-	ps.generatedDimensions = make(map[string]string)
 	ps.compiledRegex = make(map[string]*regexp.Regexp)
 
 	return ps
@@ -44,15 +42,14 @@ func (ps *ProcStatus) Configure(configMap map[string]interface{}) {
 	}
 
 	if generatedDimensions, exists := configMap["generatedDimensions"]; exists == true {
-		ps.generatedDimensions = generatedDimensions.(map[string]string)
-
-		for _, generator := range ps.generatedDimensions {
+		for dimension, generator := range generatedDimensions.(map[string]string) {
 			//don't use MustCompile otherwise program will panic due to misformated regex
 			re, err := regexp.Compile(generator)
 			if err != nil {
-				continue
+				ps.log.Warn("Failed to compile regex: ", generator, err)
+			} else {
+				ps.compiledRegex[dimension] = re
 			}
-			ps.compiledRegex[generator] = re
 		}
 	}
 

--- a/src/fullerite/collector/procstatus.go
+++ b/src/fullerite/collector/procstatus.go
@@ -41,7 +41,7 @@ func (ps *ProcStatus) Configure(configMap map[string]interface{}) {
 		ps.processName = processName.(string)
 	}
 
-	if generatedDimensions, exists := configMap["generatedDimensions"]; exists == true {
+	if generatedDimensions, exists := configMap["generatedDimensions"]; exists {
 		for dimension, generator := range generatedDimensions.(map[string]string) {
 			//don't use MustCompile otherwise program will panic due to misformated regex
 			re, err := regexp.Compile(generator)

--- a/src/fullerite/collector/procstatus.go
+++ b/src/fullerite/collector/procstatus.go
@@ -9,12 +9,18 @@ import (
 // ProcStatus collector type
 type ProcStatus struct {
 	baseCollector
-	processName string
+	processName         string
+	generatedDimensions map[string][2]string
 }
 
 // ProcessName returns ProcStatus collectors process name
 func (ps ProcStatus) ProcessName() string {
 	return ps.processName
+}
+
+// GeneratedDimensions returns ProcStatus collectors generated dimensions
+func (ps ProcStatus) GeneratedDimensions() map[string][2]string {
+	return ps.generatedDimensions
 }
 
 // NewProcStatus creates a new Test collector.
@@ -27,6 +33,7 @@ func NewProcStatus(channel chan metric.Metric, initialInterval int, log *l.Entry
 
 	ps.name = "ProcStatus"
 	ps.processName = ""
+	ps.generatedDimensions = make(map[string][2]string)
 
 	return ps
 }
@@ -36,5 +43,10 @@ func (ps *ProcStatus) Configure(configMap map[string]interface{}) {
 	if processName, exists := configMap["processName"]; exists == true {
 		ps.processName = processName.(string)
 	}
+
+	if generatedDimensions, exists := configMap["generatedDimensions"]; exists == true {
+		ps.generatedDimensions = generatedDimensions.(map[string][2]string)
+	}
+
 	ps.configureCommonParams(configMap)
 }

--- a/src/fullerite/collector/procstatus.go
+++ b/src/fullerite/collector/procstatus.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fullerite/config"
 	"fullerite/metric"
 
 	"regexp"
@@ -42,7 +43,7 @@ func (ps *ProcStatus) Configure(configMap map[string]interface{}) {
 	}
 
 	if generatedDimensions, exists := configMap["generatedDimensions"]; exists {
-		for dimension, generator := range generatedDimensions.(map[string]string) {
+		for dimension, generator := range config.GetAsMap(generatedDimensions) {
 			//don't use MustCompile otherwise program will panic due to misformated regex
 			re, err := regexp.Compile(generator)
 			if err != nil {

--- a/src/fullerite/collector/procstatus_linux.go
+++ b/src/fullerite/collector/procstatus_linux.go
@@ -49,6 +49,7 @@ func (ps ProcStatus) getMetrics(proc procfs.Proc) []metric.Metric {
 
 	if err != nil {
 		ps.log.Warn("Error getting command line: ", err)
+		return nil
 	}
 
 	if len(cmdOutput) > 0 {
@@ -86,12 +87,7 @@ func (ps ProcStatus) procStatusMetrics() []metric.Metric {
 func (ps ProcStatus) extractDimensions(cmd string) map[string]string {
 	ret := map[string]string{}
 
-	for dimension, generator := range ps.generatedDimensions {
-		procRegex, exists := ps.compiledRegex[generator]
-		if exists == false {
-			continue
-		}
-
+	for dimension, procRegex := range ps.compiledRegex {
 		subMatch := procRegex.FindStringSubmatch(cmd)
 		if len(subMatch) > 1 {
 			ret[dimension] = subMatch[1]

--- a/src/fullerite/collector/procstatus_linux.go
+++ b/src/fullerite/collector/procstatus_linux.go
@@ -49,7 +49,7 @@ func (ps ProcStatus) getMetrics(proc procfs.Proc) []metric.Metric {
 
 	if err != nil {
 		ps.log.Warn("Error getting command line: ", err)
-		return nil
+		return ret
 	}
 
 	if len(cmdOutput) > 0 {

--- a/src/fullerite/collector/procstatus_linux_test.go
+++ b/src/fullerite/collector/procstatus_linux_test.go
@@ -7,15 +7,23 @@ import (
 
 	"testing"
 	"time"
+
+	l "github.com/Sirupsen/logrus"
 )
 
 func TestProcStatusCollect(t *testing.T) {
 	config := make(map[string]interface{})
 	config["interval"] = 9999
 
+	dims := make(map[string][2]string)
+	dims["module"] = [2]string{"cmdline", ".*"}
+
+	config["generatedDimensions"] = dims
+
 	channel := make(chan metric.Metric)
 
-	ps := NewProcStatus(channel, 12, nil)
+	testLog = l.WithFields(l.Fields{"testing": "procstatus_linux"})
+	ps := NewProcStatus(channel, 12, testLog)
 	ps.Configure(config)
 
 	go ps.Collect()

--- a/src/fullerite/collector/procstatus_linux_test.go
+++ b/src/fullerite/collector/procstatus_linux_test.go
@@ -9,14 +9,16 @@ import (
 	"time"
 
 	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProcStatusCollect(t *testing.T) {
 	config := make(map[string]interface{})
 	config["interval"] = 9999
 
-	dims := make(map[string][2]string)
-	dims["module"] = [2]string{"cmdline", ".*"}
+	dims := map[string]string{
+		"module": ".*",
+	}
 
 	config["generatedDimensions"] = dims
 
@@ -26,6 +28,21 @@ func TestProcStatusCollect(t *testing.T) {
 	ps := NewProcStatus(channel, 12, testLog)
 	ps.Configure(config)
 
+	assert.Equal(t,
+		9999,
+		ps.Interval(),
+	)
+
+	assert.Equal(t,
+		"",
+		ps.ProcessName(),
+	)
+
+	assert.Equal(t,
+		dims,
+		ps.generatedDimensions,
+	)
+
 	go ps.Collect()
 
 	select {
@@ -34,4 +51,31 @@ func TestProcStatusCollect(t *testing.T) {
 	case <-time.After(2 * time.Second):
 		t.Fail()
 	}
+}
+
+func TestProcStatusExtractDimensions(t *testing.T) {
+	testLog = l.WithFields(l.Fields{"testing": "procstatus_linux"})
+
+	config := make(map[string]interface{})
+
+	dims := map[string]string{
+		"module": "^python.*?test.*?\\.([^\\.]*)?\\-\\[\\d+\\]$",
+		"order":  "^python.*?test.*?\\.[^\\.]*?\\-\\[(\\d+)\\]$",
+	}
+	config["generatedDimensions"] = dims
+
+	ps := NewProcStatus(nil, 12, testLog)
+	ps.Configure(config)
+
+	dim := map[string]string{
+		"module": "bond",
+		"order":  "007",
+	}
+
+	extracted := ps.extractDimensions("python -m test.my.function.bond-[007]")
+
+	assert.Equal(t,
+		dim,
+		extracted,
+	)
 }

--- a/src/fullerite/collector/procstatus_linux_test.go
+++ b/src/fullerite/collector/procstatus_linux_test.go
@@ -28,21 +28,6 @@ func TestProcStatusCollect(t *testing.T) {
 	ps := NewProcStatus(channel, 12, testLog)
 	ps.Configure(config)
 
-	assert.Equal(t,
-		9999,
-		ps.Interval(),
-	)
-
-	assert.Equal(t,
-		"",
-		ps.ProcessName(),
-	)
-
-	assert.Equal(t,
-		dims,
-		ps.generatedDimensions,
-	)
-
 	go ps.Collect()
 
 	select {
@@ -73,9 +58,5 @@ func TestProcStatusExtractDimensions(t *testing.T) {
 	}
 
 	extracted := ps.extractDimensions("python -m test.my.function.bond-[007]")
-
-	assert.Equal(t,
-		dim,
-		extracted,
-	)
+	assert.Equal(t, dim, extracted)
 }

--- a/src/fullerite/collector/procstatus_test.go
+++ b/src/fullerite/collector/procstatus_test.go
@@ -29,6 +29,11 @@ func TestProcStatusConfigure(t *testing.T) {
 	config["interval"] = 9999
 	config["processName"] = "fullerite"
 
+	dims := map[string][2]string{
+		"currentDirectory": [2]string{"pwd", ".*"},
+	}
+	config["generatedDimensions"] = dims
+
 	ps := NewProcStatus(nil, 123, nil)
 	ps.Configure(config)
 
@@ -42,5 +47,11 @@ func TestProcStatusConfigure(t *testing.T) {
 		ps.ProcessName(),
 		"fullerite",
 		"should be the defined process name",
+	)
+
+	assert.Equal(t,
+		ps.GeneratedDimensions(),
+		dims,
+		"should be the defined generated dimensions",
 	)
 }

--- a/src/fullerite/collector/procstatus_test.go
+++ b/src/fullerite/collector/procstatus_test.go
@@ -13,14 +13,12 @@ func TestProcStatusConfigureEmptyConfig(t *testing.T) {
 	ps.Configure(config)
 
 	assert.Equal(t,
-		ps.Interval(),
 		123,
-		"should be the default collection interval",
+		ps.Interval(),
 	)
 	assert.Equal(t,
-		ps.ProcessName(),
 		"",
-		"should be the default process name",
+		ps.ProcessName(),
 	)
 }
 
@@ -29,8 +27,8 @@ func TestProcStatusConfigure(t *testing.T) {
 	config["interval"] = 9999
 	config["processName"] = "fullerite"
 
-	dims := map[string][2]string{
-		"currentDirectory": [2]string{"pwd", ".*"},
+	dims := map[string]string{
+		"currentDirectory": ".*",
 	}
 	config["generatedDimensions"] = dims
 
@@ -38,20 +36,17 @@ func TestProcStatusConfigure(t *testing.T) {
 	ps.Configure(config)
 
 	assert.Equal(t,
-		ps.Interval(),
 		9999,
-		"should be the defined interval",
+		ps.Interval(),
 	)
 
 	assert.Equal(t,
-		ps.ProcessName(),
 		"fullerite",
-		"should be the defined process name",
+		ps.ProcessName(),
 	)
 
 	assert.Equal(t,
-		ps.GeneratedDimensions(),
 		dims,
-		"should be the defined generated dimensions",
+		ps.generatedDimensions,
 	)
 }

--- a/src/fullerite/collector/procstatus_test.go
+++ b/src/fullerite/collector/procstatus_test.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,14 +13,8 @@ func TestProcStatusConfigureEmptyConfig(t *testing.T) {
 	ps := NewProcStatus(nil, 123, nil)
 	ps.Configure(config)
 
-	assert.Equal(t,
-		123,
-		ps.Interval(),
-	)
-	assert.Equal(t,
-		"",
-		ps.ProcessName(),
-	)
+	assert.Equal(t, 123, ps.Interval())
+	assert.Equal(t, "", ps.ProcessName())
 }
 
 func TestProcStatusConfigure(t *testing.T) {
@@ -32,21 +27,15 @@ func TestProcStatusConfigure(t *testing.T) {
 	}
 	config["generatedDimensions"] = dims
 
+	regex, _ := regexp.Compile(".*")
+	compRegex := map[string]*regexp.Regexp{
+		"currentDirectory": regex,
+	}
+
 	ps := NewProcStatus(nil, 123, nil)
 	ps.Configure(config)
 
-	assert.Equal(t,
-		9999,
-		ps.Interval(),
-	)
-
-	assert.Equal(t,
-		"fullerite",
-		ps.ProcessName(),
-	)
-
-	assert.Equal(t,
-		dims,
-		ps.generatedDimensions,
-	)
+	assert.Equal(t, 9999, ps.Interval())
+	assert.Equal(t, "fullerite", ps.ProcessName())
+	assert.Equal(t, compRegex, ps.compiledRegex)
 }

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -103,6 +103,8 @@ func GetAsMap(value interface{}) (result map[string]string) {
 				log.Warn("Expected a string but got", reflect.TypeOf(value), ". Discarding handler level metric: ", k)
 			}
 		}
+	case map[string]string:
+		result = value.(map[string]string)
 	default:
 		log.Warn("Expected a string but got", reflect.TypeOf(value), ". Returning empty map!")
 	}


### PR DESCRIPTION
The fullerite collector ProcStatus now adds by default the CPUTime
metric. It also now has support for custom dimensions on your processes.
Imagine you want to add a dimention that is the part of the command
running the process. You need to get the data from /proc/PID/cmdline
and parse that output to extract the data you need from it.

This can now be done through your fullerite config file as per the needs
mentioned in issue #55, however in a different format.:-
{
....
"collectors": {
  "ProcStatus": {
    generatedDimensions:{
      "stream": ["cmdline", "REGEXP_GOES_HERE"],
      "somethingelse": ["....."],
    }
  },
},

cmdline is one example of a proc attribute that we support, I also
support running data against `filedescriptors`, we can extrend this
further to support more and more as we wish, we just need to handle it
in the procstatus collector.