### PR TITLE
Referencing correct travis build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fullerite
 
-[![Build Status](https://travis-ci.org/baris/fullerite.svg?branch=master)](https://travis-ci.org/baris/fullerite)
+[![Build Status](https://travis-ci.org/Yelp/fullerite.svg?branch=master)](https://travis-ci.org/Yelp/fullerite)
 
 
 *Fullerite is a metrics collection tool*. It is different than other collection tools (e.g. diamond, collectd) in that it supports multidimensional metrics from its core. It is also meant to innately support easy concurrency. Collectors and handler are sufficiently isolated to avoid having one misbehaving component affect the rest of the system. Generally, an instance of fullerite runs as an upstart daemon on a box collecting the configured metrics and reports them via different handlers to endpoints such as graphite, signalfx, or datadog. 


### PR DESCRIPTION
Broken link while referencing wrong travis link. Should be fixed now.