### PR TITLE
Capturing the commandline argument and using correct processName

### DIFF
--- a/src/fullerite/collector/procstatus_linux.go
+++ b/src/fullerite/collector/procstatus_linux.go
@@ -34,13 +34,9 @@ func (ps ProcStatus) getMetrics(proc procfs.Proc, cmdOutput []string) []metric.M
 	}
 
 	pid := strconv.Itoa(stat.PID)
-	processName := stat.Comm
-	if len(ps.processName) > 0 {
-		processName = ps.processName
-	}
 
 	dim := map[string]string{
-		"processName": processName,
+		"processName": stat.Comm,
 		"pid":         pid,
 	}
 

--- a/src/fullerite/collector/procstatus_linux_test.go
+++ b/src/fullerite/collector/procstatus_linux_test.go
@@ -60,3 +60,32 @@ func TestProcStatusExtractDimensions(t *testing.T) {
 	extracted := ps.extractDimensions("python -m test.my.function.bond-[007]")
 	assert.Equal(t, dim, extracted)
 }
+
+func TestProcStatusMetrics(t *testing.T) {
+	testLog = l.WithFields(l.Fields{"testing": "procstatus_linux"})
+
+	config := make(map[string]interface{})
+
+	dims := map[string]string{
+		"seven":  "(.......)",
+		"eleven": "(...........)",
+	}
+	config["generatedDimensions"] = dims
+
+	ps := NewProcStatus(nil, 12, testLog)
+	ps.Configure(config)
+
+	count := 0
+	for _, m := range ps.procStatusMetrics() {
+		mDims := m.Dimensions
+		_, existsSeven := mDims["seven"]
+		_, existsEleven := mDims["eleven"]
+		if existsSeven == false || existsEleven == false {
+			continue
+		}
+		count++
+	}
+	if count == 0 {
+		t.Fail()
+	}
+}


### PR DESCRIPTION
cmdLine() was not working as expected since the process would not still
be there when the command line is being read. Now passing it forward
correctly, with tests :)
ProcessName was not being used anywhere so I am using that now if it is
set not always stat.Comm, that should only be the default if no
processName is defined