### PR TITLE
Update Kairos handler to only log metrics payload on 4XX error from server.

### DIFF
--- a/src/fullerite/handler/kairos.go
+++ b/src/fullerite/handler/kairos.go
@@ -138,10 +138,17 @@ func (k *Kairos) emitMetrics(metrics []metric.Metric) bool {
 	}
 
 	body, _ := ioutil.ReadAll(rsp.Body)
-	k.log.Error("Failed to post to Kairos @", apiURL,
-		" status was ", rsp.Status,
-		" rsp body was ", string(body),
-		" payload was ", string(payload))
+	if (rsp.StatusCode / 100) == 4 {
+		k.log.Error("Failed to post to Kairos @", apiURL,
+			" status was ", rsp.Status,
+			" rsp body was ", string(body),
+			" payload was ", string(payload))
+	} else {
+		k.log.Error("Failed to post to Kairos @", apiURL,
+			" status was ", rsp.Status,
+			" rsp body was ", string(body))
+	}
+
 	return false
 }
 

--- a/src/fullerite/internalserver/internal_metrics_server.go
+++ b/src/fullerite/internalserver/internal_metrics_server.go
@@ -36,7 +36,7 @@ type ResponseFormat struct {
 // New createse a new internal server instance
 func New(cfg config.Config, handlers *[]handler.Handler) *InternalServer {
 	srv := new(InternalServer)
-	srv.log = l.WithFields(l.Fields{"app": "fullerite", "pkg": "internalserver["})
+	srv.log = l.WithFields(l.Fields{"app": "fullerite", "pkg": "internalserver"})
 	srv.handlers = handlers
 	srv.configure(cfg.InternalServerConfig)
 	return srv


### PR DESCRIPTION
This change will make the handler only output the metrics payload to log on 4XX errors indicating a client error of some kind where the payload data might be suspect.