### PR TITLE
Migrate collector functionality from ganglia

### DIFF
--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -77,9 +77,9 @@ class NetworkCollector(diamond.collector.Collector):
                    + '(?P<tx_errors>\d+)(?:\s*)'
                    + '(?P<tx_drop>\d+)(?:\s*)'
                    + '(?P<tx_fifo>\d+)(?:\s*)'
-                   + '(?P<tx_frame>\d+)(?:\s*)'
-                   + '(?P<tx_compressed>\d+)(?:\s*)'
-                   + '(?P<tx_multicast>\d+)(?:.*)$') % (
+                   + '(?P<tx_colls>\d+)(?:\s*)'
+                   + '(?P<tx_carrier>\d+)(?:\s*)'
+                   + '(?P<tx_compressed>\d+)(?:.*)$') % (
                 ('|'.join(self.config['interfaces'])), greed)
             reg = re.compile(exp)
             # Match Interfaces

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -40,7 +40,7 @@ class NetworkCollector(diamond.collector.Collector):
         config = super(NetworkCollector, self).get_default_config()
         config.update({
             'path':         'network',
-            'interfaces':   ['eth', 'bond', 'em', 'p1p'],
+            'interfaces':   ['eth', 'bond', 'em', 'p1p', 'tun'],
             'byte_unit':    ['bit', 'byte'],
             'greedy':       'true',
         })

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -30,7 +30,6 @@ class NetworkCollector(diamond.collector.Collector):
         config_help.update({
             'interfaces': 'List of interface types to collect',
             'greedy': 'Greedy match interfaces',
-            'fields': 'List or comma-separated string of metrics to collect'
         })
         return config_help
 
@@ -41,9 +40,9 @@ class NetworkCollector(diamond.collector.Collector):
         config = super(NetworkCollector, self).get_default_config()
         config.update({
             'path':         'network',
-            'interfaces':   [''],
+            'interfaces':   ['eth', 'bond', 'em', 'p1p'],
+            'byte_unit':    ['bit', 'byte'],
             'greedy':       'true',
-            'fields':       ['rx_errors', 'rx_drop', 'tx_errors', 'tx_drop']
         })
         return config
 
@@ -51,12 +50,6 @@ class NetworkCollector(diamond.collector.Collector):
         """
         Collect network interface stats.
         """
-
-        # Initialize fields list
-        if isinstance(self.config['fields'], basestring):
-            fields = [f.strip() for f in self.config['fields'].split(',')]
-        elif isinstance(self.config['fields'], list):
-            fields = self.config['fields']
 
         # Initialize results
         results = {}
@@ -72,7 +65,7 @@ class NetworkCollector(diamond.collector.Collector):
 
             exp = ('^(?:\s*)((?:%s)%s):(?:\s*)'
                    + '(?P<rx_bytes>\d+)(?:\s*)'
-                   + '(?P<rx_packets>[\d\w]+)(?:\s*)'
+                   + '(?P<rx_packets>\w+)(?:\s*)'
                    + '(?P<rx_errors>\d+)(?:\s*)'
                    + '(?P<rx_drop>\d+)(?:\s*)'
                    + '(?P<rx_fifo>\d+)(?:\s*)'
@@ -80,13 +73,13 @@ class NetworkCollector(diamond.collector.Collector):
                    + '(?P<rx_compressed>\d+)(?:\s*)'
                    + '(?P<rx_multicast>\d+)(?:\s*)'
                    + '(?P<tx_bytes>\d+)(?:\s*)'
-                   + '(?P<tx_packets>[\d\w]+)(?:\s*)'
+                   + '(?P<tx_packets>\w+)(?:\s*)'
                    + '(?P<tx_errors>\d+)(?:\s*)'
                    + '(?P<tx_drop>\d+)(?:\s*)'
                    + '(?P<tx_fifo>\d+)(?:\s*)'
-                   + '(?P<tx_colls>\d+)(?:\s*)'
-                   + '(?P<tx_carrier>\d+)(?:\s*)'
-                   + '(?P<tx_compressed>\d+)(?:.*)$') % (
+                   + '(?P<tx_frame>\d+)(?:\s*)'
+                   + '(?P<tx_compressed>\d+)(?:\s*)'
+                   + '(?P<tx_multicast>\d+)(?:.*)$') % (
                 ('|'.join(self.config['interfaces'])), greed)
             reg = re.compile(exp)
             # Match Interfaces
@@ -114,18 +107,25 @@ class NetworkCollector(diamond.collector.Collector):
 
         for device in results:
             stats = results[device]
-            for s in fields:
-                if s in stats:
-                    # Get Metric Name
-                    metric_name = '.'.join([device, s])
-                    # Get Metric Value
-                    metric_value = self.derivative(metric_name,
-                                                   long(stats[s]),
-                                                   diamond.collector.MAX_COUNTER)
+            for s, v in stats.items():
+                # Get Metric Name
+                metric_name = '.'.join([device, s])
+                # Get Metric Value
+                metric_value = self.derivative(metric_name,
+                                               long(v),
+                                               diamond.collector.MAX_COUNTER)
 
+                # Convert rx_bytes and tx_bytes
+                if s == 'rx_bytes' or s == 'tx_bytes':
+                    convertor = diamond.convertor.binary(value=metric_value,
+                                                         unit='byte')
+
+                    for u in self.config['byte_unit']:
+                        # Public Converted Metric
+                        self.publish(metric_name.replace('bytes', u),
+                                     convertor.get(unit=u), precision=2)
+                else:
                     # Publish Metric Derivative
                     self.publish(metric_name, metric_value)
-                else:
-                    self.log.warn('{0} is not a valid metric field'.format(s))
 
         return None

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -42,7 +42,6 @@ class NetworkCollector(diamond.collector.Collector):
         config.update({
             'path':         'network',
             'interfaces':   [''],
-            'byte_unit':    ['bit', 'byte'],
             'greedy':       'true',
             'fields':       ['rx_errors', 'rx_drop', 'tx_errors', 'tx_drop']
         })

--- a/src/diamond/collectors/vmstat/vmstat.py
+++ b/src/diamond/collectors/vmstat/vmstat.py
@@ -22,6 +22,7 @@ class VMStatCollector(diamond.collector.Collector):
         'pgpgout': diamond.collector.MAX_COUNTER,
         'pswpin': diamond.collector.MAX_COUNTER,
         'pswpout': diamond.collector.MAX_COUNTER,
+        'pgmajfault': diamond.collector.MAX_COUNTER,
     }
 
     def get_default_config_help(self):
@@ -47,7 +48,7 @@ class VMStatCollector(diamond.collector.Collector):
         results = {}
         # open file
         file = open(self.PROC)
-        exp = '^(pgpgin|pgpgout|pswpin|pswpout)\s(\d+)'
+        exp = '^(pgpgin|pgpgout|pswpin|pswpout|pgmajfault)\s(\d+)'
         reg = re.compile(exp)
         # Build regex
         for line in file:

--- a/src/fullerite/handler/kairos.go
+++ b/src/fullerite/handler/kairos.go
@@ -144,7 +144,7 @@ func (k *Kairos) emitMetrics(metrics []metric.Metric) bool {
 		k.log.Error("Failed to post to Kairos @", apiURL,
 			" status was ", rsp.Status,
 			" rsp body was ", string(body),
-			" malformed metrics are ", k.parseServerError(string(body), metrics))
+			" malformed metrics are ", k.parseServerError(string(body), series))
 	} else {
 		k.log.Error("Failed to post to Kairos @", apiURL,
 			" status was ", rsp.Status,
@@ -158,7 +158,7 @@ func (k *Kairos) dialTimeout(network, addr string) (net.Conn, error) {
 	return net.DialTimeout(network, addr, k.timeout)
 }
 
-func (k *Kairos) parseServerError(errMsg string, metrics []metric.Metric) string {
+func (k *Kairos) parseServerError(errMsg string, metrics []KairosMetric) string {
 	re, err := regexp.Compile(`metric\[([0-9]+)\]`)
 	if err != nil {
 		return ""
@@ -169,15 +169,15 @@ func (k *Kairos) parseServerError(errMsg string, metrics []metric.Metric) string
 		return ""
 	}
 
-	series := make([]KairosMetric, 0, len(result))
+	errMetrics := make([]KairosMetric, 0, len(result))
 	for i := range result {
 		v, err := strconv.Atoi(result[i][1])
 		if err == nil {
-			series = append(series, k.convertToKairos(metrics[v]))
+			errMetrics = append(errMetrics, metrics[v])
 		}
 	}
 
-	retData, err := json.Marshal(series)
+	retData, err := json.Marshal(errMetrics)
 	if err != nil {
 		return ""
 	}

--- a/src/fullerite/handler/kairos.go
+++ b/src/fullerite/handler/kairos.go
@@ -9,6 +9,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"regexp"
+	"strconv"
 	"time"
 
 	l "github.com/Sirupsen/logrus"
@@ -142,7 +144,7 @@ func (k *Kairos) emitMetrics(metrics []metric.Metric) bool {
 		k.log.Error("Failed to post to Kairos @", apiURL,
 			" status was ", rsp.Status,
 			" rsp body was ", string(body),
-			" payload was ", string(payload))
+			" malformed metrics are ", k.parseServerError(string(body), metrics))
 	} else {
 		k.log.Error("Failed to post to Kairos @", apiURL,
 			" status was ", rsp.Status,
@@ -154,4 +156,31 @@ func (k *Kairos) emitMetrics(metrics []metric.Metric) bool {
 
 func (k *Kairos) dialTimeout(network, addr string) (net.Conn, error) {
 	return net.DialTimeout(network, addr, k.timeout)
+}
+
+func (k *Kairos) parseServerError(errMsg string, metrics []metric.Metric) string {
+	re, err := regexp.Compile(`metric\[([0-9]+)\]`)
+	if err != nil {
+		return ""
+	}
+
+	result := re.FindAllStringSubmatch(errMsg, -1)
+	if len(result) == 0 {
+		return ""
+	}
+
+	series := make([]KairosMetric, 0, len(result))
+	for i := range result {
+		v, err := strconv.Atoi(result[i][1])
+		if err == nil {
+			series = append(series, k.convertToKairos(metrics[v]))
+		}
+	}
+
+	retData, err := json.Marshal(series)
+	if err != nil {
+		return ""
+	}
+
+	return string(retData)
 }

--- a/src/fullerite/handler/kairos_test.go
+++ b/src/fullerite/handler/kairos_test.go
@@ -126,14 +126,19 @@ func TestKairosServerErrorParse(t *testing.T) {
 	metrics[1].AddDimension("somedim", "working")
 	metrics[2].AddDimension("somedime", "")
 
-	series := make([]KairosMetric, 0, 2)
-	series = append(series, k.convertToKairos(metrics[0]))
-	series = append(series, k.convertToKairos(metrics[2]))
+	series := make([]KairosMetric, 0, len(metrics))
+	for i := range metrics {
+		series = append(series, k.convertToKairos(metrics[i]))
+	}
 
-	expectByt, _ := json.Marshal(series)
+	expectMetrics := make([]KairosMetric, 0, 2)
+	expectMetrics = append(expectMetrics, k.convertToKairos(metrics[0]))
+	expectMetrics = append(expectMetrics, k.convertToKairos(metrics[2]))
+
+	expectByt, _ := json.Marshal(expectMetrics)
 
 	errByt := []byte(`{\"errors\":[\"metric[0](name=Test1).tag[somedim].value may not be empty.\",` +
 		`\"metric[2](name=Test3).tag[somedim].value may not be empty.\"]}`)
 
-	assert.Equal(t, k.parseServerError(string(errByt), metrics), string(expectByt))
+	assert.Equal(t, k.parseServerError(string(errByt), series), string(expectByt))
 }


### PR DESCRIPTION
This pull request updates the VMStatCollector and NetworkCollector to reflect the behavior of respective ganglia collectors, as well as adding error handling to the Kairos handler for 4XX errors.

VMStatCollector: Added major page faults statistic to be emitted.

NetworkCollector: All ganglia statistics are available. Fix improperly named transmit statistics. (This will affect current SFX time series data)

Kairos Handler: Updated the logging behavior to only log those metrics which generated an error from kairos rather than the entire metrics payload. 
