### PR TITLE
Do not use system library path for go cover tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ $(BEATIT): $(BEATIT_SOURCES)
 test: tests
 tests: deps
 	@echo Testing $(FULLERITE)
-	@go get golang.org/x/tools/cmd/cover
+	@go get -d golang.org/x/tools/cmd/cover
 	@$(foreach pkg, $(PKGS), go test -cover $(pkg);)
 
 coverage_report: deps

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ $(BEATIT): $(BEATIT_SOURCES)
 test: tests
 tests: deps
 	@echo Testing $(FULLERITE)
-	@go get -d golang.org/x/tools/cmd/cover
 	@$(foreach pkg, $(PKGS), go test -cover $(pkg);)
 
 coverage_report: deps


### PR DESCRIPTION
Instead of trying to install to system libraries, install go cover tests in local directory