### PR TITLE
Add dimensions reporting from diamond collectors

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -66,6 +66,7 @@ class Collector(object):
 
         self._socket = None
         self._reconnect = False
+        self.dimensions = None
         self.handlers = handlers
         self.last_values = {}
 
@@ -268,11 +269,16 @@ class Collector(object):
         ttl = float(self.config['interval']) * float(
             self.config['ttl_multiplier'])
 
+        dimensions = None
+        if self.dimensions is not None:
+            dimensions = self.dimensions
+            self.dimensions = None
+
         # Create Metric
         try:
             metric = Metric(path, value, raw_value=raw_value, timestamp=None,
                             precision=precision,
-                            metric_type=metric_type, ttl=ttl)
+                            metric_type=metric_type, ttl=ttl, dimensions=dimensions)
         except DiamondException:
             self.log.error(('Error when creating new Metric: path=%r, '
                             'value=%r'), path, value)
@@ -303,6 +309,9 @@ class Collector(object):
             }
         }
 
+        payload['dimensions'].update(
+            metric.dimensions or {}
+        )
         payloadStr = "%s\n" % json.dumps(payload)
         success = False
 

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -66,7 +66,7 @@ class Collector(object):
 
         self._socket = None
         self._reconnect = False
-        self.dimensions = None
+        self.dimensions = {}
         self.handlers = handlers
         self.last_values = {}
 
@@ -270,9 +270,8 @@ class Collector(object):
             self.config['ttl_multiplier'])
 
         dimensions = None
-        if self.dimensions is not None:
-            dimensions = self.dimensions
-            self.dimensions = None
+        if self.dimensions and self.dimensions.get(name, None) is not None:
+            dimensions = self.dimensions[name]
 
         # Create Metric
         try:
@@ -398,6 +397,7 @@ class Collector(object):
 
             # Collect Data
             self.collect()
+            self.dimensions = {}
 
             end_time = time.time()
             collector_time = int((end_time - start_time) * 1000)

--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -11,7 +11,7 @@ class Metric(object):
     _METRIC_TYPES = ['COUNTER', 'GAUGE']
 
     def __init__(self, path, value, raw_value=None, timestamp=None, precision=0,
-                 metric_type='COUNTER', ttl=None, host="ignored"):
+                 metric_type='COUNTER', ttl=None, host="ignored", dimensions=None):
         """
         Create new instance of the Metric class
 
@@ -55,6 +55,14 @@ class Metric(object):
                 raise DiamondException(("Invalid value when creating new "
                                         "Metric %r: %s") % (path, e))
 
+        # If dimensions were passed in make sure they are a dict
+        if dimensions is not None:
+            if not isinstance(dimensions, dict):
+                raise DiamondException(("Invalid dimensions when "
+                                        "creating new Metric %r: %s")
+                                       % (path, dimensions))
+
+        self.dimensions = dimensions
         self.path = path
         self.value = value
         self.raw_value = raw_value

--- a/src/diamond/metric.py
+++ b/src/diamond/metric.py
@@ -61,6 +61,11 @@ class Metric(object):
                 raise DiamondException(("Invalid dimensions when "
                                         "creating new Metric %r: %s")
                                        % (path, dimensions))
+            else:
+                dimensions = dict(
+                    (k, str(v)) for k, v in dimensions.iteritems()
+                    if v is not None and isinstance(v, (int, float, str)) and k is not None and isinstance(k, str)
+                )
 
         self.dimensions = dimensions
         self.path = path


### PR DESCRIPTION
This controversial commit adds the ability to define dimensions in the
diamond collectors. The reason this is being done the way it is `as a
collector attribute` is to make the collectors still behve in their plug
and play nature. If you plug in a collector and you collectorpy does not
support dimensions, well who cares it is just an extra instance variable
that will not affect anything. If you want to catch the result of that
value to send it through to any backend well, you have it in memory. So
it's a win-win!