### PR TITLE
Diamond core tests

### DIFF
--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -283,6 +283,7 @@ if __name__ == "__main__":
                       action="count",
                       help="verbose")
     parser.add_option("-d",
+                      "--diamond-only",
                       action="store_true",
                       dest="diamond_only",
                       default=False,

--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python
+# coding=utf-8
+###############################################################################
+
+import os
+import sys
+import unittest
+import inspect
+import traceback
+import optparse
+import logging
+import configobj
+
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle as pickle
+
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from StringIO import StringIO
+
+try:
+    from setproctitle import setproctitle
+except ImportError:
+    setproctitle = None
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__))))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                            '..')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                            'collectors')))
+
+
+def run_only(func, predicate):
+    if predicate():
+        return func
+    else:
+        def f(arg):
+            pass
+        return f
+
+
+def get_collector_config(key, value):
+    config = configobj.ConfigObj()
+    config['server'] = {}
+    config['server']['collectors_config_path'] = ''
+    config['collectors'] = {}
+    config['collectors']['default'] = {}
+    config['collectors']['default']['hostname_method'] = "uname_short"
+    config['collectors'][key] = value
+    return config
+
+
+class CollectorTestCase(unittest.TestCase):
+
+    def setDocExample(self, collector, metrics, defaultpath=None):
+        if not len(metrics):
+            return False
+
+        filePath = os.path.join(os.path.dirname(os.path.realpath(__file__)),
+                                'docs', 'collectors-' + collector + '.md')
+
+        if not os.path.exists(filePath):
+            return False
+
+        if not os.access(filePath, os.W_OK):
+            return False
+
+        if not os.access(filePath, os.R_OK):
+            return False
+
+        try:
+            fp = open(filePath, 'Ur')
+            content = fp.readlines()
+            fp.close()
+
+            fp = open(filePath, 'w')
+            for line in content:
+                if line.strip() == '__EXAMPLESHERE__':
+                    for metric in sorted(metrics.iterkeys()):
+
+                        metricPath = 'servers.hostname.'
+
+                        if defaultpath:
+                            metricPath += defaultpath + '.'
+
+                        metricPath += metric
+
+                        metricPath = metricPath.replace('..', '.')
+                        fp.write('%s %s\n' % (metricPath, metrics[metric]))
+                else:
+                    fp.write(line)
+            fp.close()
+
+        except IOError:
+            return False
+        return True
+
+    def getFixtureDirPath(self):
+        path = os.path.join(
+            os.path.dirname(inspect.getfile(self.__class__)),
+            'fixtures')
+        return path
+
+    def getFixturePath(self, fixture_name):
+        path = os.path.join(self.getFixtureDirPath(),
+                            fixture_name)
+        if not os.access(path, os.R_OK):
+            print "Missing Fixture " + path
+        return path
+
+    def getFixture(self, fixture_name):
+        try:
+            f = open(self.getFixturePath(fixture_name), 'r')
+            data = StringIO(f.read())
+            return data
+        finally:
+            f.close()
+
+    def getFixtures(self):
+        fixtures = []
+        for root, dirnames, filenames in os.walk(self.getFixtureDirPath()):
+            fixtures.append(os.path.join(root, dirnames, filenames))
+        return fixtures
+
+    def getPickledResults(self, results_name):
+        try:
+            f = open(self.getFixturePath(results_name), 'r')
+            data = pickle.load(f)
+            return data
+        finally:
+            f.close()
+
+    def setPickledResults(self, results_name, data):
+        pickle.dump(data, open(self.getFixturePath(results_name), "w+b"))
+
+    def assertUnpublished(self, mock, key, value, expected_value=0):
+        return self.assertPublished(mock, key, value, expected_value)
+
+    def assertPublished(self, mock, key, value, expected_value=1):
+        if type(mock) is list:
+            for m in mock:
+                calls = (filter(lambda x: x[0][0] == key, m.call_args_list))
+                if len(calls) > 0:
+                    break
+        else:
+            calls = filter(lambda x: x[0][0] == key, mock.call_args_list)
+
+        actual_value = len(calls)
+        message = '%s: actual number of calls %d, expected %d' % (
+            key, actual_value, expected_value)
+
+        self.assertEqual(actual_value, expected_value, message)
+
+        if expected_value:
+            actual_value = calls[0][0][1]
+            expected_value = value
+            precision = 0
+
+            if isinstance(value, tuple):
+                expected_value, precision = expected_value
+
+            message = '%s: actual %r, expected %r' % (key,
+                                                      actual_value,
+                                                      expected_value)
+
+            if precision is not None:
+                self.assertAlmostEqual(float(actual_value),
+                                       float(expected_value),
+                                       places=precision,
+                                       msg=message)
+            else:
+                self.assertEqual(actual_value, expected_value, message)
+
+    def assertUnpublishedMany(self, mock, dict, expected_value=0):
+        return self.assertPublishedMany(mock, dict, expected_value)
+
+    def assertPublishedMany(self, mock, dict, expected_value=1):
+        for key, value in dict.iteritems():
+            self.assertPublished(mock, key, value, expected_value)
+
+        if type(mock) is list:
+            for m in mock:
+                m.reset_mock()
+        else:
+            mock.reset_mock()
+
+    def assertUnpublishedMetric(self, mock, key, value, expected_value=0):
+        return self.assertPublishedMetric(mock, key, value, expected_value)
+
+    def assertPublishedMetric(self, mock, key, value, expected_value=1):
+        calls = filter(lambda x: x[0][0].path.find(key) != -1,
+                       mock.call_args_list)
+
+        actual_value = len(calls)
+        message = '%s: actual number of calls %d, expected %d' % (
+            key, actual_value, expected_value)
+
+        self.assertEqual(actual_value, expected_value, message)
+
+        actual_value = calls[0][0][0].value
+        expected_value = value
+        precision = 0
+
+        if isinstance(value, tuple):
+            expected_value, precision = expected_value
+
+        message = '%s: actual %r, expected %r' % (key,
+                                                  actual_value,
+                                                  expected_value)
+
+        if precision is not None:
+            self.assertAlmostEqual(float(actual_value),
+                                   float(expected_value),
+                                   places=precision,
+                                   msg=message)
+        else:
+            self.assertEqual(actual_value, expected_value, message)
+
+    def assertUnpublishedMetricMany(self, mock, dict, expected_value=0):
+        return self.assertPublishedMetricMany(mock, dict, expected_value)
+
+    def assertPublishedMetricMany(self, mock, dict, expected_value=1):
+        for key, value in dict.iteritems():
+            self.assertPublishedMetric(mock, key, value, expected_value)
+
+        mock.reset_mock()
+
+collectorTests = {}
+
+
+def getCollectorTests(path):
+    for f in os.listdir(path):
+        cPath = os.path.abspath(os.path.join(path, f))
+
+        if (os.path.isfile(cPath)
+                and len(f) > 3
+                and f[-3:] == '.py'
+                and f[0:4] == 'test'):
+            sys.path.append(os.path.dirname(cPath))
+            sys.path.append(os.path.dirname(os.path.dirname(cPath)))
+            modname = f[:-3]
+            try:
+                # Import the module
+                collectorTests[modname] = __import__(modname,
+                                                     globals(),
+                                                     locals(),
+                                                     ['*'])
+            except Exception:
+                print "Failed to import module: %s. %s" % (
+                    modname, traceback.format_exc())
+                continue
+
+    for f in os.listdir(path):
+        cPath = os.path.abspath(os.path.join(path, f))
+        if os.path.isdir(cPath):
+            getCollectorTests(cPath)
+
+###############################################################################
+
+if __name__ == "__main__":
+    if setproctitle:
+        setproctitle('test.py')
+
+    # Disable log output for the unit tests
+    log = logging.getLogger("diamond")
+    log.addHandler(logging.StreamHandler(sys.stderr))
+    log.disabled = True
+
+    # Initialize Options
+    parser = optparse.OptionParser()
+    parser.add_option("-c",
+                      "--collector",
+                      dest="collector",
+                      default="",
+                      help="Run a single collector's unit tests")
+    parser.add_option("-v",
+                      "--verbose",
+                      dest="verbose",
+                      default=1,
+                      action="count",
+                      help="verbose")
+
+    # Parse Command Line Args
+    (options, args) = parser.parse_args()
+
+    cPath = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         'collectors',
+                                         options.collector))
+
+    getCollectorTests(cPath)
+
+    loader = unittest.TestLoader()
+    tests = []
+    for test in collectorTests:
+        for name, c in inspect.getmembers(collectorTests[test],
+                                          inspect.isclass):
+            if not issubclass(c, unittest.TestCase):
+                continue
+            tests.append(loader.loadTestsFromTestCase(c))
+    suite = unittest.TestSuite(tests)
+    results = unittest.TextTestRunner(verbosity=options.verbose).run(suite)
+
+    results = str(results)
+    results = results.replace('>', '').split()[1:]
+    resobj = {}
+    for result in results:
+        result = result.split('=')
+        resobj[result[0]] = int(result[1])
+
+    if resobj['failures'] > 0:
+        sys.exit(1)
+    if resobj['errors'] > 0:
+        sys.exit(2)
+
+    sys.exit(0)

--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -282,6 +282,11 @@ if __name__ == "__main__":
                       default=1,
                       action="count",
                       help="verbose")
+    parser.add_option("-d",
+                      action="store_true",
+                      dest="diamond_only",
+                      default=False,
+                      help="Run diamond tests only")
 
     # Parse Command Line Args
     (options, args) = parser.parse_args()
@@ -289,8 +294,12 @@ if __name__ == "__main__":
     cPath = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                          'collectors',
                                          options.collector))
-
-    getCollectorTests(cPath)
+    dPath = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         'tests',))
+    if options.diamond_only:
+        getCollectorTests(dPath)
+    else:
+        getCollectorTests(cPath)
 
     loader = unittest.TestLoader()
     tests = []

--- a/src/diamond/tests/testcollector.py
+++ b/src/diamond/tests/testcollector.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from mock import patch
+from test import unittest
+import configobj
+
+from diamond.collector import Collector
+
+
+class BaseCollectorTest(unittest.TestCase):
+
+    @patch('diamond.collector.Collector.publish_metric')
+    def test_SetDimensions(self, mock_publish):
+        """
+        config = configobj.ConfigObj()
+        config['server'] = {}
+        config['server']['collectors_config_path'] = ''
+        config['collectors'] = {}
+        c = Collector(config, [])
+        c.dimensions = {
+            'metric1': {'dim1':'alice'},
+            'metric2': {'dim2':'bob', 'foo':'bar'}
+        }
+        c.publish('metric1', 1)
+        c.publish('bat', 2)
+
+        for call in mock_publish.mock_calls:
+            name, args, kwargs = call
+            metric = args[0]
+            self.assertEquals(metric.dimensions, c.dimensions[metric.name])
+        """
+        pass

--- a/src/diamond/tests/testconvertor.py
+++ b/src/diamond/tests/testconvertor.py
@@ -1,0 +1,24 @@
+from diamond.convertor import time
+
+import unittest
+
+
+class TestConvertor(unittest.TestCase):
+    def test_basic(self):
+        self.assertEquals(time.convert(60, 's', 's'), 60.0)
+        self.assertEquals(time.convert(60, 's', 'm'), 1.0)
+        self.assertEquals(time.convert(60000, 'ms', 'm'), 1.0)
+        self.assertEquals(time.convert(60000, 'MS', 'minutes'), 1.0)
+
+        self.assertEquals(time.convert(3600 * 1000 * 1.4, 'ms', 'h'), 1.4)
+        self.assertEquals(time.convert(86400 * 1000 * 2.5, 'ms', 'd'), 2.5)
+        self.assertEquals(time.convert(86400 * 1000 * 365 * 0.7, 'ms', 'y'),
+                          0.7)
+        self.assertEquals(time.convert(1000, 'ms', 'us'), 1000000)
+        self.assertEquals(time.convert(1000, 'ms', 'ns'), 1000000000)
+
+        self.assertEquals(time.convert(1.5, 'y', 'ns'),
+                          1.5 * 365 * 24 * 3600 * 1000 * 1000 * 1000)
+
+    def test_unrecognised_unit(self):
+        self.assertRaises(NotImplementedError, time.convert, 60, 's', 'months')

--- a/src/diamond/tests/testmetric.py
+++ b/src/diamond/tests/testmetric.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import unittest
+
+from diamond.metric import Metric
+
+
+class TestMetric(unittest.TestCase):
+
+    def testgetPathPrefix(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0,
+                        host='com.example.www')
+
+        actual_value = metric.getPathPrefix()
+        expected_value = 'prefix'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    def testgetCollectorPath(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0,
+                        host='com.example.www')
+
+        actual_value = metric.getCollectorPath()
+        expected_value = 'cpu'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    def testgetMetricPath(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0,
+                        host='com.example.www')
+
+        actual_value = metric.getMetricPath()
+        expected_value = 'TotalIdle'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    # Test hostname of none
+    def testgetPathPrefixHostNone(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0)
+
+        actual_value = metric.getPathPrefix()
+        expected_value = 'prefix'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    def testgetCollectorPathHostNone(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0)
+
+        actual_value = metric.getCollectorPath()
+        expected_value = 'cpu'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    def testgetMetricPathHostNone(self):
+        metric = Metric('prefix.cpu.TotalIdle',
+                        0)
+
+        actual_value = metric.getMetricPath()
+        expected_value = 'TotalIdle'
+
+        message = 'Actual %s, expected %s' % (actual_value, expected_value)
+        self.assertEqual(actual_value, expected_value, message)
+
+    def test_issue_723(self):
+        metrics = [
+            9.97143369909e-05,
+            '9.97143369909e-05',
+            0.0000997143369909,
+            '0.0000997143369909',
+        ]
+
+        for precision in xrange(0, 100):
+            for m in metrics:
+                metric = Metric('test.723', m, timestamp=0)
+
+                actual_value = str(metric).strip()
+                expected_value = 'test.723 0 0'
+
+                message = 'Actual %s, expected %s' % (actual_value,
+                                                      expected_value)
+                self.assertEqual(actual_value, expected_value, message)


### PR DESCRIPTION
As per the standards we hold ourselves to of testing our software, now
we can run tests on the core diamond code for collectors and metrics.
Running the tests for these modules is done with the command:-

`python test.py -d`

This runs the tests for the diamond core *NOT* the collectors. The
collectors are handles in pull/87.