### PR TITLE
Prefixing collectors and dimensioanlising them

### DIFF
--- a/src/diamond/collectors/conntrack/conntrack.py
+++ b/src/diamond/collectors/conntrack/conntrack.py
@@ -88,4 +88,5 @@ class ConnTrackCollector(diamond.collector.Collector):
             if collected.get('nf_conntrack_max', None) and collected.get('nf_conntrack_buckets', None):
                 collected['nf_hash_ratio'] = collected['nf_conntrack_max'] / collected['nf_conntrack_buckets']
             for key in collected.keys():
-                self.publish(key, collected[key])
+                metric_name = '.'.join(['conntrack', key])
+                self.publish(metric_name, collected[key])

--- a/src/diamond/collectors/diskusage/diskusage.py
+++ b/src/diamond/collectors/diskusage/diskusage.py
@@ -280,6 +280,9 @@ class DiskUsageCollector(diamond.collector.Collector):
             # Only publish when we have io figures
             if (metrics['io'] > 0 or self.config['send_zero']):
                 for key in metrics:
-                    metric_name = '.'.join([info['device'], key]).replace(
+                    self.dimensions = {
+                        'device': info['device']
+                    }
+                    metric_name = '.'.join(['iostat', key]).replace(
                         '/', '_')
                     self.publish(metric_name, metrics[key])

--- a/src/diamond/collectors/entropy/entropy.py
+++ b/src/diamond/collectors/entropy/entropy.py
@@ -44,4 +44,4 @@ class EntropyStatCollector(diamond.collector.Collector):
         entropy_file.close()
 
         # Publish value
-        self.publish_gauge("available", entropy)
+        self.publish_gauge("entropy.available", entropy)

--- a/src/diamond/collectors/gearman_stats/gearman_stats.py
+++ b/src/diamond/collectors/gearman_stats/gearman_stats.py
@@ -63,14 +63,14 @@ class GearmanCollector(diamond.collector.Collector):
         try:
             if gearman is None:
                 self.log.error("Unable to import python gearman client")
-                return 
-                
+                return
+
             # Collect and Publish Metrics
             self.log.debug("Using pid file: %s & gearman endpoint : %s",
                     self.config['gearman_pid_path'], self.config['url'])
             gm_admin_client = gearman.GearmanAdminClient([self.config['url']])
-            self.publish('gearman_ping', gearman_ping(gm_admin_client))
-            self.publish('gearman_queued', gearman_queued(gm_admin_client))
-            self.publish('gearman_fds', get_fds(self.config['gearman_pid_path']))
+            self.publish('gearman.ping', gearman_ping(gm_admin_client))
+            self.publish('gearman.queued', gearman_queued(gm_admin_client))
+            self.publish('gearman.fds', get_fds(self.config['gearman_pid_path']))
         except Exception, e:
             self.log.error("GearmanCollector Error: %s", e)

--- a/src/diamond/collectors/haproxy/haproxy.py
+++ b/src/diamond/collectors/haproxy/haproxy.py
@@ -185,7 +185,7 @@ class HAProxyCollector(diamond.collector.Collector):
         csv_data = self.get_csv_data(section)
         data = list(csv.reader(csv_data))
         headings = self._generate_headings(data[0])
-        section_name = section and self._sanitize(section.lower()) + '.' or ''
+        section_name = section and self._sanitize(section.lower()) or ''
 
         for row in data:
             if (self._get_config_value(section, 'ignore_servers')
@@ -206,7 +206,7 @@ class HAProxyCollector(diamond.collector.Collector):
                 }
                 metric_name = '.'.join(['haproxy', headings[index]])
                 if section_name:
-                    metric_name = '.'.join([section_name, metric_name])
+                    self.dimensions['section_server'] = section_name
                 self.publish(metric_name, metric_value, metric_type='GAUGE')
 
     def collect(self):

--- a/src/diamond/collectors/memcached/memcached.py
+++ b/src/diamond/collectors/memcached/memcached.py
@@ -156,12 +156,15 @@ class MemcachedCollector(diamond.collector.Collector):
             # for everything we want
             for stat in desired:
                 if stat in stats:
-
+                    self.dimensions = {
+                        'memcache_host': alias,
+                    }
+                    metric_name = '.'.join(['memcache', stat])
                     # we have it
                     if stat in self.GAUGES:
-                        self.publish_gauge(alias + "." + stat, stats[stat])
+                        self.publish_gauge(metric_name, stats[stat])
                     else:
-                        self.publish_counter(alias + "." + stat, stats[stat])
+                        self.publish_counter(metric_name, stats[stat])
 
                 else:
 

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -109,7 +109,7 @@ class NetworkCollector(diamond.collector.Collector):
             stats = results[device]
             for s, v in stats.items():
                 # Get Metric Name
-                metric_name = '.'.join(['network', s])
+                metric_name = '.'.join(['net', s])
                 # Get Metric Value
                 metric_value = self.derivative(metric_name,
                                                long(v),

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -57,39 +57,42 @@ class NetworkCollector(diamond.collector.Collector):
         if os.access(self.PROC, os.R_OK):
 
             # Open File
-            file = open(self.PROC)
-            # Build Regular Expression
-            greed = ''
-            if self.config['greedy'].lower() == 'true':
-                greed = '\S*'
+            with open(self.PROC) as file:
+                # Build Regular Expression
+                greed = ''
+                if self.config['greedy'].lower() == 'true':
+                    greed = '\S*'
 
-            exp = ('^(?:\s*)((?:%s)%s):(?:\s*)'
-                   + '(?P<rx_bytes>\d+)(?:\s*)'
-                   + '(?P<rx_packets>\w+)(?:\s*)'
-                   + '(?P<rx_errors>\d+)(?:\s*)'
-                   + '(?P<rx_drop>\d+)(?:\s*)'
-                   + '(?P<rx_fifo>\d+)(?:\s*)'
-                   + '(?P<rx_frame>\d+)(?:\s*)'
-                   + '(?P<rx_compressed>\d+)(?:\s*)'
-                   + '(?P<rx_multicast>\d+)(?:\s*)'
-                   + '(?P<tx_bytes>\d+)(?:\s*)'
-                   + '(?P<tx_packets>\w+)(?:\s*)'
-                   + '(?P<tx_errors>\d+)(?:\s*)'
-                   + '(?P<tx_drop>\d+)(?:\s*)'
-                   + '(?P<tx_fifo>\d+)(?:\s*)'
-                   + '(?P<tx_colls>\d+)(?:\s*)'
-                   + '(?P<tx_carrier>\d+)(?:\s*)'
-                   + '(?P<tx_compressed>\d+)(?:.*)$') % (
-                ('|'.join(self.config['interfaces'])), greed)
-            reg = re.compile(exp)
-            # Match Interfaces
-            for line in file:
-                match = reg.match(line)
-                if match:
-                    device = match.group(1)
-                    results[device] = match.groupdict()
-            # Close File
-            file.close()
+                exp = ('^(?:\s*)((?:%s)%s):(?:\s*)'
+                       + '(?P<rx_bytes>\d+)(?:\s*)'
+                       + '(?P<rx_packets>\w+)(?:\s*)'
+                       + '(?P<rx_errors>\d+)(?:\s*)'
+                       + '(?P<rx_drop>\d+)(?:\s*)'
+                       + '(?P<rx_fifo>\d+)(?:\s*)'
+                       + '(?P<rx_frame>\d+)(?:\s*)'
+                       + '(?P<rx_compressed>\d+)(?:\s*)'
+                       + '(?P<rx_multicast>\d+)(?:\s*)'
+                       + '(?P<tx_bytes>\d+)(?:\s*)'
+                       + '(?P<tx_packets>\w+)(?:\s*)'
+                       + '(?P<tx_errors>\d+)(?:\s*)'
+                       + '(?P<tx_drop>\d+)(?:\s*)'
+                       + '(?P<tx_fifo>\d+)(?:\s*)'
+                       + '(?P<tx_colls>\d+)(?:\s*)'
+                       + '(?P<tx_carrier>\d+)(?:\s*)'
+                       + '(?P<tx_compressed>\d+)(?:.*)$') % (
+                    ('|'.join(self.config['interfaces'])), greed)
+                try:
+                    reg = re.compile(exp)
+                    # Match Interfaces
+                    for line in file:
+                        match = reg.match(line)
+                        if match:
+                            device = match.group(1)
+                            results[device] = match.groupdict()
+                except Exception as e:
+                    self.log.error(
+                        "Failed to parse file: {0!s}".format(e)
+                    )
         else:
             if not psutil:
                 self.log.error('Unable to import psutil')

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -41,7 +41,7 @@ class NetworkCollector(diamond.collector.Collector):
         config.update({
             'path':         'network',
             'interfaces':   ['eth', 'bond', 'em', 'p1p', 'tun'],
-            'byte_unit':    ['byte'],
+            'byte_unit':    ['bit', 'byte'],
             'greedy':       'true',
         })
         return config

--- a/src/diamond/collectors/network/network.py
+++ b/src/diamond/collectors/network/network.py
@@ -41,7 +41,7 @@ class NetworkCollector(diamond.collector.Collector):
         config.update({
             'path':         'network',
             'interfaces':   ['eth', 'bond', 'em', 'p1p', 'tun'],
-            'byte_unit':    ['bit', 'byte'],
+            'byte_unit':    ['byte'],
             'greedy':       'true',
         })
         return config
@@ -109,7 +109,7 @@ class NetworkCollector(diamond.collector.Collector):
             stats = results[device]
             for s, v in stats.items():
                 # Get Metric Name
-                metric_name = '.'.join([device, s])
+                metric_name = '.'.join(['network', s])
                 # Get Metric Value
                 metric_value = self.derivative(metric_name,
                                                long(v),
@@ -122,10 +122,16 @@ class NetworkCollector(diamond.collector.Collector):
 
                     for u in self.config['byte_unit']:
                         # Public Converted Metric
+                        self.dimensions = {
+                            'iface': device
+                        }
                         self.publish(metric_name.replace('bytes', u),
                                      convertor.get(unit=u), precision=2)
                 else:
                     # Publish Metric Derivative
+                    self.dimensions = {
+                        'iface': device
+                    }
                     self.publish(metric_name, metric_value)
 
         return None

--- a/src/diamond/collectors/numazoneinfo/numazoneinfo.py
+++ b/src/diamond/collectors/numazoneinfo/numazoneinfo.py
@@ -36,7 +36,8 @@ class NUMAZoneInfoCollector(diamond.collector.Collector):
             filepath = self.config['proc_path']
 
             with open(filepath, 'r') as file_handle:
-                metric = ''
+                node = ''
+                zone = ''
                 numlines_to_process = 0
 
                 for line in file_handle:
@@ -45,7 +46,13 @@ class NUMAZoneInfoCollector(diamond.collector.Collector):
                     if numlines_to_process > 0:
                         numlines_to_process -= 1
                         statname, metric_value = line.split('pages')[-1].split()
-                        metric_name = ''.join([metric, statname])
+                        metric_name = '.'.join(['numastats', statname])
+
+                        self.dimensions = {}
+                        if node:
+                            self.dimensions['node'] = node
+                        if zone:
+                            self.dimensions['zone'] = zone
 
                         self.publish(metric_name, metric_value)
 
@@ -55,7 +62,6 @@ class NUMAZoneInfoCollector(diamond.collector.Collector):
 
                         node = match.group('node') or ''
                         zone = match.group('zone') or ''
-                        metric = "node{0!s}-zone-{1!s}-".format(node, zone)
 
                         # We get 4 lines afterwards for free, min, low, and high
                         # page thresholds

--- a/src/diamond/collectors/numazoneinfo/numazoneinfo.py
+++ b/src/diamond/collectors/numazoneinfo/numazoneinfo.py
@@ -46,7 +46,7 @@ class NUMAZoneInfoCollector(diamond.collector.Collector):
                     if numlines_to_process > 0:
                         numlines_to_process -= 1
                         statname, metric_value = line.split('pages')[-1].split()
-                        metric_name = '.'.join(['numastats', statname])
+                        metric_name = '.'.join(['numa', statname])
 
                         self.dimensions = {}
                         if node:

--- a/src/diamond/collectors/scribe/scribe.py
+++ b/src/diamond/collectors/scribe/scribe.py
@@ -104,11 +104,12 @@ class ScribeCollector(diamond.collector.Collector):
 
     def collect(self):
         for stat, val in self.get_scribe_stats():
+            metric_name = '.'.join(['scribe', stat])
             self.log.debug(
                 "Publishing: {0} {1}".format(stat, val)
             )
             if str_to_bool(self.config['scribe_leaf']):
-                metric_name = '.'.join(['scribe_leaf', stat])
+                self.dimensions = { 'node_type': 'leaf' }
             else:
-                metric_name = '.'.join(['scribe', stat])
+                self.dimensions = { 'node_type': 'aggregator' }
             self.publish(metric_name, val)

--- a/src/diamond/collectors/scribe/scribe.py
+++ b/src/diamond/collectors/scribe/scribe.py
@@ -21,7 +21,7 @@ class ScribeCollector(diamond.collector.Collector):
         config_help = super(ScribeCollector, self).get_default_config_help()
         config_help.update({
             'exclude_pattern': 'Exclude items from scribe buffer that match this pattern',
-            'path': 'Path to scribe buffer',
+            'buffer_path': 'Path to scribe buffer',
             'scribe_ctrl_bin': 'Path to scribe_ctrl binary',
             'scribe_port': 'Scribe port',
         })
@@ -31,6 +31,7 @@ class ScribeCollector(diamond.collector.Collector):
         config = super(ScribeCollector, self).get_default_config()
         config.update({
             'exclude_pattern': None,
+            'buffer_path': None,
             'path': 'scribe',
             'scribe_ctrl_bin': self.find_binary('/usr/sbin/scribe_ctrl'),
             'scribe_port': None,
@@ -74,8 +75,8 @@ class ScribeCollector(diamond.collector.Collector):
             metric = self.key_to_metric(key)
             data[metric] = int(val)
 
-        if self.config['path']:
-            cmd = ['du', '-sb', '--apparent-size', self.config['path']]
+        if self.config['buffer_path']:
+            cmd = ['du', '-sb', '--apparent-size', self.config['buffer_path']]
             if self.config['exclude_pattern']:
                 cmd.append(
                     "--exclude={0!s}".format(self.config['exclude_pattern'])
@@ -102,4 +103,5 @@ class ScribeCollector(diamond.collector.Collector):
             self.log.debug(
                 "Publishing: {0} {1}".format(stat, val)
             )
-            self.publish(stat, val)
+            metric_name = '.'.join(['scribe', stat])
+            self.publish(metric_name, val)

--- a/src/diamond/collectors/tcp/tcp.py
+++ b/src/diamond/collectors/tcp/tcp.py
@@ -273,6 +273,8 @@ class TCPCollector(diamond.collector.Collector):
 
             # Publish the metric
             if metric_name in self.GAUGES:
+                metric_name = '.'.join(['tcp', metric_name])
                 self.publish_gauge(metric_name, value, 0)
             else:
+                metric_name = '.'.join(['tcp', metric_name])
                 self.publish_counter(metric_name, value, 0)

--- a/src/diamond/collectors/vmstat/vmstat.py
+++ b/src/diamond/collectors/vmstat/vmstat.py
@@ -64,5 +64,5 @@ class VMStatCollector(diamond.collector.Collector):
         file.close()
 
         for key, value in results.items():
-            metric_name = '.'.join(['virtual_memory', key])
+            metric_name = '.'.join(['vm', key])
             self.publish(metric_name, value, precision=2)

--- a/src/diamond/collectors/vmstat/vmstat.py
+++ b/src/diamond/collectors/vmstat/vmstat.py
@@ -64,4 +64,5 @@ class VMStatCollector(diamond.collector.Collector):
         file.close()
 
         for key, value in results.items():
-            self.publish(key, value, precision=2)
+            metric_name = '.'.join(['virtual_memory', key])
+            self.publish(metric_name, value, precision=2)

--- a/src/diamond/collectors/zookeeper/zookeeper.py
+++ b/src/diamond/collectors/zookeeper/zookeeper.py
@@ -125,6 +125,9 @@ class ZookeeperCollector(diamond.collector.Collector):
             hostname = matches.group(3)
             port = matches.group(5)
 
+            if alias is None:
+                alias = hostname
+
             stats = self.get_stats(hostname, port)
 
             # figure out what we're configured to get, defaulting to everything
@@ -133,12 +136,10 @@ class ZookeeperCollector(diamond.collector.Collector):
             # for everything we want
             for stat in desired:
                 if stat in stats:
-
-                    # we have it
-                    if alias is not None:
-                        self.publish(alias + "." + stat, stats[stat])
-                    else:
-                        self.publish(stat, stats[stat])
+                    self.dimensions = {
+                        'zookeeper_host': alias,
+                    }
+                    self.publish(stat, stats[stat])
                 else:
 
                     # we don't, must be somehting configured in publish so we


### PR DESCRIPTION
Adding some of the metric names to the main namespace is a very bad idea
for example the EntropyCollector had the metric => 'available' in the
main name space that is really frustrating.

Also since we now have support for dimensions, I have incorporated
dimensionalising the collectors that have been recently newly migrated from
Ganglia and those that existed but have been touched due to the
migraiton.