### PR TITLE
Monitor collectors taking too long to run

### DIFF
--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -81,6 +81,10 @@ def collector_process(collector, log):
 
             max_time = int(max(interval - stagger_offset, 1))
             log.debug('Max collection time: %s seconds', max_time)
+            collector.dimensions = {
+                'interval': interval,
+            }
+            collector.publish_cumulative_counter('fullerite.collection_time_exceeded', 1)
 
         except SIGHUPException:
             # Reload the config if requested

--- a/src/diamond/utils/scheduler.py
+++ b/src/diamond/utils/scheduler.py
@@ -84,7 +84,7 @@ def collector_process(collector, log):
             collector.dimensions = {
                 'interval': interval,
             }
-            collector.publish_cumulative_counter('fullerite.collection_time_exceeded', 1)
+            collector.publish('fullerite.collection_time_exceeded', 1)
 
         except SIGHUPException:
             # Reload the config if requested


### PR DESCRIPTION
We need to be able to monitor collectors taking a longer time to run
than their set run interval.
This is important so we can set a detector for this in SignalFx for
example if a collector takes too long for X colletion rounds and get
paged about this so we can jump on the host and see where this is happening and why.

Since we are adding a lot! of new collectors this is crucial so we
can easily tweak the collection interval on collector level.