### PR TITLE
Add MySQL BinLog Growth collector

### DIFF
--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -53,6 +53,8 @@ func New(name string) Collector {
 		collector = NewCpuInfo(channel, CpuInfoCollectionInterval, collectorLog)
 	case "MesosStats":
 		collector = NewMesosStats(channel, DefaultCollectionInterval, collectorLog)
+	case "MySQLBinlogGrowth":
+		collector = NewMySQLBinlogGrowth(channel, DefaultCollectionInterval, collectorLog)
 	default:
 		defaultLog.Error("Cannot create collector", name)
 		return nil

--- a/src/fullerite/collector/mysql_binary_growth.go
+++ b/src/fullerite/collector/mysql_binary_growth.go
@@ -1,0 +1,159 @@
+package collector
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+
+	"fullerite/metric"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/alyu/configparser"
+)
+
+const (
+	defaultCnfPath   = "/etc/my.cnf"
+	binLogFileSuffix = ".index"
+)
+
+// MySQLBinlogGrowth collector
+type MySQLBinlogGrowth struct {
+	baseCollector
+	myCnfPath string
+}
+
+// Dependency injection: Makes writing unit tests much easier, by being able to override these values in the *_test.go files.
+var (
+	getBinlogPath = (*MySQLBinlogGrowth).getBinlogPath
+	getBinlogSize = (*MySQLBinlogGrowth).getBinlogSize
+	getFileSize   = (*MySQLBinlogGrowth).getFileSize
+)
+
+// The MySQLBinlogGrowth collector emits the current size of all the binlog files as cumulative counter. This will show
+// up in SignalFx as the rate of growth.
+//
+// The my.cnf config file contains the path to the binlog files (if it's not absolute, then it's relative to the
+// datadir directory). The <binlog>.index file contains the list of the log files and their path.
+//
+// Example my.cnf format:
+// [mysqld]
+// log-bin = ../dir
+// datadir = /var/srv/dir
+
+// NewMySQLBinlogGrowth creates a new MySQLBinlogGrowth collector.
+func NewMySQLBinlogGrowth(channel chan metric.Metric, initialInterval int, log *l.Entry) *MySQLBinlogGrowth {
+	d := &MySQLBinlogGrowth{
+		baseCollector: baseCollector{
+			name:     "MySQLBinlogGrowth",
+			log:      log,
+			channel:  channel,
+			interval: initialInterval,
+		},
+		myCnfPath: defaultCnfPath,
+	}
+
+	return d
+}
+
+// Configure takes a dictionary of values with which the handler can configure itself.
+func (m *MySQLBinlogGrowth) Configure(configMap map[string]interface{}) {
+	m.configureCommonParams(configMap)
+	if myCnfPath, exists := configMap["mycnf"]; exists {
+		m.myCnfPath = myCnfPath.(string)
+	}
+}
+
+// Collect computes the difference between the current bin-log size and the one at the previous run and
+// emits the rate of change per second
+func (m *MySQLBinlogGrowth) Collect() {
+	// read the bin-log and datadir values from my.cnf
+	binLog, dataDir := getBinlogPath(m)
+	if binLog == "" || dataDir == "" {
+		return
+	}
+
+	size, err := getBinlogSize(m, binLog+binLogFileSuffix, dataDir)
+
+	if err == nil {
+		metric := metric.Metric{
+			Name:       "mysql.binlog_growth_rate",
+			MetricType: metric.CumulativeCounter,
+			Value:      float64(size),
+			Dimensions: map[string]string{},
+		}
+
+		m.Channel() <- metric
+	}
+}
+
+// getBinlogPath read and parse the my.cnf config file and returns the path to the binlog file and datadir.
+func (m *MySQLBinlogGrowth) getBinlogPath() (binLog string, dataDir string) {
+	// read my.cnf config file
+	config, err := configparser.Read(m.myCnfPath)
+	if err != nil {
+		m.log.Error(err)
+		return "", ""
+	}
+
+	section, err := config.Section("mysqld")
+	if err != nil {
+		m.log.Error("mysqld section missing in ", m.myCnfPath)
+		return "", ""
+	}
+
+	binLog = section.ValueOf("log-bin")
+	dataDir = section.ValueOf("datadir")
+	// If the log-bin value is a relative path then it's based on datadir
+	if !path.IsAbs(binLog) {
+		binLog = path.Join(dataDir, binLog)
+	}
+	return
+}
+
+// getFileSize returns the size in bytes of the specified file
+func (m *MySQLBinlogGrowth) getFileSize(filePath string) int64 {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0
+	}
+	fi, err := file.Stat()
+	if err != nil {
+		return 0
+	}
+	return fi.Size()
+}
+
+// getBinlogSize returns the total size of the binlog files
+func (m *MySQLBinlogGrowth) getBinlogSize(binLog string, dataDir string) (size int64, err error) {
+	size = 0
+	err = nil
+
+	// Read the binlog.index file
+	// It contains a list of log files, one per line
+	file, err := os.Open(binLog)
+	if err != nil {
+		m.log.Warn("Cannot open index file ", binLog)
+		return 0, fmt.Errorf("Cannot open index file %s", binLog)
+	}
+	defer file.Close()
+
+	// Read the file line by line
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fileName := scanner.Text()
+		// If the fileName is not an absolute path, then it's relative to the datadir directory
+		if !path.IsAbs(fileName) {
+			fileName = path.Join(dataDir, fileName)
+		}
+
+		size += getFileSize(m, fileName)
+	}
+
+	if err := scanner.Err(); err != nil {
+		m.log.Warn("There was an error reading the index file")
+		return 0, errors.New("There was an error reading the index file")
+	}
+	return
+}

--- a/src/fullerite/collector/mysql_binary_growth_test.go
+++ b/src/fullerite/collector/mysql_binary_growth_test.go
@@ -3,6 +3,7 @@ package collector
 import (
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"fullerite/metric"
@@ -170,7 +171,7 @@ func TestgetBinlogSize(t *testing.T) {
 	defer func() { getFileSize = oldGetFileSize }()
 	getFileSize = func(m *MySQLBinlogGrowth, filePath string) int64 { return int64(123) }
 
-	file, _ := ioutil.TempFile("", "binlog"+binLogFileSuffix)
+	file, _ := ioutil.TempFile("", strings.Join([]string{"binlog", binLogFileSuffix}, "."))
 	file.WriteString("../log1")
 	file.WriteString("../log2")
 	defer os.Remove(file.Name())

--- a/src/fullerite/collector/mysql_binary_growth_test.go
+++ b/src/fullerite/collector/mysql_binary_growth_test.go
@@ -1,0 +1,188 @@
+package collector
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"fullerite/metric"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMockMySQLBinlogGrowth() *MySQLBinlogGrowth {
+	c := make(chan metric.Metric, 2)
+	i := 10
+	l := defaultLog.WithFields(l.Fields{"collector": "MySQLBinlog"})
+	return NewMySQLBinlogGrowth(c, i, l)
+}
+
+func TestNewMySQLBinlogGrowth(t *testing.T) {
+	c := make(chan metric.Metric)
+	i := 10
+	l := defaultLog.WithFields(l.Fields{"collector": "MySQLBinlog"})
+	m := NewMySQLBinlogGrowth(c, i, l)
+
+	assert.Equal(t, m.Channel(), c)
+	assert.Equal(t, m.Interval(), i)
+	assert.Equal(t, m.log, l)
+	assert.Equal(t, m.myCnfPath, defaultCnfPath)
+}
+
+func TestMySQLBinlogGrowthConfigure(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+	config := map[string]interface{}{"mycnf": "my/cnf/path"}
+
+	m.Configure(config)
+
+	assert.Equal(t, m.myCnfPath, "my/cnf/path")
+}
+
+func TestMySQLBinlogGrowthConfigureEmpty(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+	config := map[string]interface{}{}
+
+	m.Configure(config)
+
+	assert.Equal(t, m.myCnfPath, defaultCnfPath)
+}
+
+func mockGetBinlogGrowth(m *MySQLBinlogGrowth, binLog string, dataDir string, previousLog string, previousSize int64) (string, int64, int64) {
+	return "log1", 1234, 30
+}
+
+func TestMySQLBinlogGrowthCollect(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	oldGetBinlogSize := getBinlogSize
+	defer func() { getBinlogSize = oldGetBinlogSize }()
+	getBinlogSize = func(m *MySQLBinlogGrowth, bilLog string, datadir string) (int64, error) { return int64(123456), nil }
+
+	oldGetBinlogPath := getBinlogPath
+	defer func() { getBinlogPath = oldGetBinlogPath }()
+	getBinlogPath = func(m *MySQLBinlogGrowth) (string, string) { return "path/to/binlog", "/datadir" }
+
+	m.Collect()
+
+	select {
+	case res := <-m.Channel():
+		assert.Equal(t, res.Value, float64(123456))
+	default:
+		t.Fatal("The collect method did not emit anything")
+	}
+}
+
+func TestMySQLBinlogGrowthCollectNoMyCnf(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+	m.Configure(map[string]interface{}{"mycnf": "/non/existing/path"})
+
+	m.Collect()
+
+	select {
+	case _ = <-m.Channel():
+		t.Fatal("The collect method shoudln't emit anything")
+	default:
+	}
+}
+
+func TestGetBinlogPathNoConfig(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+	config := map[string]interface{}{"mycnf": "my/cnf/path"}
+	m.Configure(config)
+
+	binLog, dataDir := m.getBinlogPath()
+	assert.Equal(t, binLog, "")
+	assert.Equal(t, dataDir, "")
+}
+
+func TestGetBinlogPathNoSection(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	file, _ := ioutil.TempFile(os.TempDir(), "my.cnf")
+	defer os.Remove(file.Name())
+
+	config := map[string]interface{}{"mycnf": file.Name()}
+	m.Configure(config)
+
+	binLog, dataDir := m.getBinlogPath()
+	assert.Equal(t, binLog, "")
+	assert.Equal(t, dataDir, "")
+}
+
+func TestGetBinlogPath(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	file, _ := ioutil.TempFile("", "my.cnf")
+	file.WriteString("[mysqld]\n")
+	file.WriteString("log-bin = ../binlog\n")
+	file.WriteString("datadir = /usr/local/data\n")
+	defer os.Remove(file.Name())
+
+	config := map[string]interface{}{"mycnf": file.Name()}
+	m.Configure(config)
+
+	binLog, dataDir := m.getBinlogPath()
+	assert.Equal(t, "/usr/local/binlog", binLog)
+	assert.Equal(t, "/usr/local/data", dataDir)
+}
+
+func TestGetBinlogPathAbsolute(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	file, _ := ioutil.TempFile("", "my.cnf")
+	file.WriteString("[mysqld]\n")
+	file.WriteString("log-bin = /usr/local/binlog\n")
+	file.WriteString("datadir = /usr/local/data\n")
+	defer os.Remove(file.Name())
+
+	config := map[string]interface{}{"mycnf": file.Name()}
+	m.Configure(config)
+
+	binLog, dataDir := m.getBinlogPath()
+	assert.Equal(t, "/usr/local/binlog", binLog)
+	assert.Equal(t, "/usr/local/data", dataDir)
+}
+
+func TestGetFileSizeMissing(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	size := m.getFileSize("/random/file")
+	assert.Equal(t, int64(0), size)
+}
+
+func TestGetFileSize(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	file, _ := ioutil.TempFile("", "my.cnf")
+	defer os.Remove(file.Name())
+
+	file.Write([]byte("abcdef"))
+
+	size := m.getFileSize(file.Name())
+	assert.Equal(t, int64(6), size)
+}
+
+func TestgetBinlogSize(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	oldGetFileSize := getFileSize
+	defer func() { getFileSize = oldGetFileSize }()
+	getFileSize = func(m *MySQLBinlogGrowth, filePath string) int64 { return int64(123) }
+
+	file, _ := ioutil.TempFile("", "binlog"+binLogFileSuffix)
+	file.WriteString("../log1")
+	file.WriteString("../log2")
+	defer os.Remove(file.Name())
+
+	size, err := m.getBinlogSize(file.Name(), "/datadir")
+	assert.Equal(t, size, int64(246))
+	assert.Nil(t, err)
+}
+
+func TestgetBinlogSizeNoIndex(t *testing.T) {
+	m := newMockMySQLBinlogGrowth()
+
+	_, err := m.getBinlogSize("/random/file", "/datadir")
+	assert.NotNil(t, err)
+}

--- a/src/fullerite/util/file.go
+++ b/src/fullerite/util/file.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"os"
+)
+
+// getFileSize returns the size in bytes of the specified file
+func GetFileSize(filePath string) (int64, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return 0, err
+	}
+	return fi.Size(), nil
+}

--- a/src/fullerite/util/file_test.go
+++ b/src/fullerite/util/file_test.go
@@ -1,0 +1,26 @@
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetFileSizeMissing(t *testing.T) {
+	size, err := GetFileSize("/random/file")
+	assert.Equal(t, int64(0), size)
+	assert.NotNil(t, err)
+}
+
+func TestGetFileSize(t *testing.T) {
+	file, _ := ioutil.TempFile("", "my.cnf")
+	defer os.Remove(file.Name())
+
+	file.Write([]byte("abcdef"))
+
+	size, err := GetFileSize(file.Name())
+	assert.Equal(t, int64(6), size)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
This collector emits the current size of the mysql binary logs as
cumulative counter. This will show up in SignalFx as rate per second.