### PR TITLE
Fullerite should fail gracefully with unknown collector name

### DIFF
--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -55,7 +55,7 @@ func New(name string) Collector {
 	case "MesosStats":
 		collector = NewMesosStats(channel, DefaultCollectionInterval, collectorLog)
 	default:
-		defaultLog.Error("Cannot create collector", name)
+		defaultLog.Error("Cannot create collector: ", name)
 		return nil
 	}
 	return collector

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -10,7 +10,10 @@ import (
 func startCollectors(c config.Config) (collectors []collector.Collector) {
 	log.Info("Starting collectors...")
 	for name, config := range c.Collectors {
-		collectors = append(collectors, startCollector(name, c, config))
+		collectorInst := startCollector(name, c, config)
+		if collectorInst != nil {
+			collectors = append(collectors, collectorInst)
+		}
 	}
 	return collectors
 }


### PR DESCRIPTION
When the conf file has a collector that is unknown by fullerite, we
should not panic, instead we should log an error and gracefully fail.