### PR TITLE
Add service name info for docker outside paasta

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -13,8 +13,9 @@ import (
 )
 
 const (
-	mesosTaskID = "MESOS_TASK_ID"
-	endpoint    = "unix:///var/run/docker.sock"
+	mesosTaskID      = "MESOS_TASK_ID"
+	endpoint         = "unix:///var/run/docker.sock"
+	serviceNameLabel = "SERVICE_NAME"
 )
 
 // DockerStats collector type.
@@ -157,6 +158,8 @@ func getServiceDimensions(container *docker.Container) map[string]string {
 			tmp["service_name"] = serviceName
 			tmp["instance_name"] = instance
 			break
+		} else if envArray[0] == serviceNameLabel {
+			tmp["service_name"] = envArray[1]
 		}
 	}
 	return tmp

--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -159,7 +159,7 @@ func getServiceDimensions(container *docker.Container) map[string]string {
 			tmp["instance_name"] = instance
 			break
 		} else if envArray[0] == serviceNameLabel {
-			tmp["service_name"] = envArray[1]
+			tmp["service_name"] = strings.Replace(envArray[1], "\n", "", -1)
 		}
 	}
 	return tmp

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -124,8 +124,8 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 		"collector":      "DockerStats",
 	}
 	expectedMetrics := []metric.Metric{
-		metric.Metric{"DockerRxBytes", "gauge", 10, expectedDims},
-		metric.Metric{"DockerTxBytes", "gauge", 20, expectedDims},
+		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
+		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -96,6 +96,47 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	assert.Equal(t, ret, expectedMetrics)
 }
 
+func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
+	stats := new(docker.Stats)
+	stats.Network.RxBytes = 10
+	stats.Network.TxBytes = 20
+	stats.MemoryStats.Usage = 50
+	stats.MemoryStats.Limit = 70
+
+	containerJSON := []byte(`
+	{
+		"ID": "test-id",
+		"Name": "test-container",
+		"Config": {
+			"Env": [
+				"SERVICE_NAME=my_service"
+			]
+		}
+	}`)
+	var container *docker.Container
+	err := json.Unmarshal(containerJSON, &container)
+	assert.Equal(t, err, nil)
+
+	expectedDims := map[string]string{
+		"container_id":   "test-id",
+		"container_name": "test-container",
+		"service_name":   "my_service",
+		"collector":      "DockerStats",
+	}
+	expectedMetrics := []metric.Metric{
+		metric.Metric{"DockerRxBytes", "gauge", 10, expectedDims},
+		metric.Metric{"DockerTxBytes", "gauge", 20, expectedDims},
+		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
+		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
+		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
+	}
+
+	d := getSUT()
+	ret := d.buildMetrics(container, stats, 0.5)
+
+	assert.Equal(t, ret, expectedMetrics)
+}
+
 func TestDockerStatsCalculateCPUPercent(t *testing.T) {
 	var previousTotalUsage = uint64(0)
 	var previousSystem = uint64(0)


### PR DESCRIPTION
If a docker container is outside paasta the MESOS_TASK_ID env variable is not available.  So to have the service name in our metrics we can add a new env variable in the Docker file called SERVICE_NAME and set the name we prefer.

Inside the Dockerfile you need to add this line:
`ENV SERVICE_NAME my_service_name`