### PR TITLE
Add more stats to the MySQLCollector

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -317,6 +317,7 @@ class Collector(object):
             metric.dimensions or {}
         )
         payloadStr = "%s\n" % json.dumps(payload)
+        return
         success = False
 
         for i in range(FULLERITE_RETRY_COUNT):

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -317,7 +317,6 @@ class Collector(object):
             metric.dimensions or {}
         )
         payloadStr = "%s\n" % json.dumps(payload)
-        return
         success = False
 
         for i in range(FULLERITE_RETRY_COUNT):

--- a/src/diamond/collectors/mysqlstat/mysqlstat.py
+++ b/src/diamond/collectors/mysqlstat/mysqlstat.py
@@ -414,7 +414,7 @@ class MySQLCollector(diamond.collector.Collector):
                                 'metric_name': 'MySQL_idle_threads',
                                 'metric_value': time,
                                 'dimensions': {
-                                    'user': user,
+                                    'user': str(user),
                                 }
                             }
                     elif user not in self.config['ignore_users'] and time > self.config['query_threshold']:
@@ -422,8 +422,8 @@ class MySQLCollector(diamond.collector.Collector):
                             'metric_name': 'MySQL_long_queries',
                             'metric_value': time,
                             'dimensions': {
-                                'user': user,
-                                'query': query,
+                                'user': str(user),
+                                'query': str(query),
                             }
                         }
             except:

--- a/src/diamond/collectors/mysqlstat/mysqlstat.py
+++ b/src/diamond/collectors/mysqlstat/mysqlstat.py
@@ -300,11 +300,10 @@ class MySQLCollector(diamond.collector.Collector):
         return config
 
     def get_db_stats(self, query):
-        cursor = self.db.cursor(cursorclass=MySQLdb.cursors.DictCursor)
-
         try:
-            cursor.execute(query)
-            return cursor.fetchall()
+            with self.db.cursor(cursorclass=MySQLdb.cursors.DictCursor) as cursor:
+                cursor.execute(query)
+                return cursor.fetchall()
         except MySQLError, e:
             self.log.error('MySQLCollector could not get db stats', e)
             return ()

--- a/src/diamond/collectors/mysqlstat/mysqlstat.py
+++ b/src/diamond/collectors/mysqlstat/mysqlstat.py
@@ -300,10 +300,11 @@ class MySQLCollector(diamond.collector.Collector):
         return config
 
     def get_db_stats(self, query):
+        cursor = self.db.cursor(cursorclass=MySQLdb.cursors.DictCursor)
+
         try:
-            with self.db.cursor(cursorclass=MySQLdb.cursors.DictCursor) as cursor:
-                cursor.execute(query)
-                return cursor.fetchall()
+            cursor.execute(query)
+            return cursor.fetchall()
         except MySQLError, e:
             self.log.error('MySQLCollector could not get db stats', e)
             return ()

--- a/src/diamond/collectors/mysqlstat/mysqlstat.py
+++ b/src/diamond/collectors/mysqlstat/mysqlstat.py
@@ -507,7 +507,7 @@ class MySQLCollector(diamond.collector.Collector):
 
                 if type(metric_value) is dict:
                     self.dimensions = metric_value.get('dimensions', {})
-                    self.log.info("{0} {1}".format(nickname + metric_value['metric_name'], metric_value['metric_value']))
+
                     self.publish(nickname + metric_value['metric_name'], metric_value['metric_value'])
                     continue
 
@@ -520,10 +520,8 @@ class MySQLCollector(diamond.collector.Collector):
                 if key == 'status':
                     if ('publish' not in self.config
                             or metric_name in self.config['publish']):
-                        self.log.info("{0} {1}".format(nickname + metric_name, metric_value))
                         self.publish(nickname + metric_name, metric_value)
                 else:
-                    self.log.info("{0} {1}".format(nickname + metric_name, metric_value))
                     self.publish(nickname + metric_name, metric_value)
 
     def collect(self):

--- a/src/diamond/collectors/mysqlstat/mysqlstat.py
+++ b/src/diamond/collectors/mysqlstat/mysqlstat.py
@@ -305,12 +305,12 @@ class MySQLCollector(diamond.collector.Collector):
         try:
             cursor.execute(query)
             result = cursor.fetchall()
-            cursor.close()
             return result
         except MySQLError, e:
             self.log.error('MySQLCollector could not get db stats', e)
-            cursor.close()
             return ()
+        finally:
+            cursor.close()
 
     def connect(self, params):
         try:


### PR DESCRIPTION
Now the collector produces on demand stats about:
    * Innodb rollback segments
    * Processlist idle threads and long queries
    * Temp table sizes on disk