### PR TITLE
Emit docker network usage as cumulative counter

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -121,11 +121,11 @@ func (d DockerStats) getDockerContainerInfo(container *docker.Container) {
 // buildMetrics creates the actual metrics for the given container.
 func (d DockerStats) buildMetrics(container *docker.Container, containerStats *docker.Stats, cpuPercentage float64) []metric.Metric {
 	ret := []metric.Metric{
-		buildDockerMetric("DockerRxBytes", float64(containerStats.Network.RxBytes)),
-		buildDockerMetric("DockerTxBytes", float64(containerStats.Network.TxBytes)),
-		buildDockerMetric("DockerMemoryUsed", float64(containerStats.MemoryStats.Usage)),
-		buildDockerMetric("DockerMemoryLimit", float64(containerStats.MemoryStats.Limit)),
-		buildDockerMetric("DockerCpuPercentage", cpuPercentage),
+		buildDockerMetric("DockerRxBytes", metric.CumulativeCounter, float64(containerStats.Network.RxBytes)),
+		buildDockerMetric("DockerTxBytes", metric.CumulativeCounter, float64(containerStats.Network.TxBytes)),
+		buildDockerMetric("DockerMemoryUsed", metric.Gauge, float64(containerStats.MemoryStats.Usage)),
+		buildDockerMetric("DockerMemoryLimit", metric.Gauge, float64(containerStats.MemoryStats.Limit)),
+		buildDockerMetric("DockerCpuPercentage", metric.Gauge, cpuPercentage),
 	}
 	additionalDimensions := map[string]string{
 		"container_id":   container.ID,
@@ -167,8 +167,9 @@ func getInfoFromMesosTaskID(taskID string) (serviceName, instance string) {
 	return strings.Replace(varArray[0], "--", "_", -1), strings.Replace(varArray[1], "--", "_", -1)
 }
 
-func buildDockerMetric(name string, value float64) (m metric.Metric) {
+func buildDockerMetric(name string, metricType string, value float64) (m metric.Metric) {
 	m = metric.New(name)
+	m.MetricType = metricType
 	m.Value = value
 	m.AddDimension("collector", "DockerStats")
 	return m

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -83,8 +83,8 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 		"collector":      "DockerStats",
 	}
 	expectedMetrics := []metric.Metric{
-		metric.Metric{"DockerRxBytes", "gauge", 10, expectedDims},
-		metric.Metric{"DockerTxBytes", "gauge", 20, expectedDims},
+		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
+		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},


### PR DESCRIPTION
The network usage reported by docker stats is the number of bytes sent
or received since the container was started. This would be better
represented in SignalFx by a cumulative counter than a gauge.