### PR TITLE
Add a Log handler, to emit metrics via logger; Vagrant setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ src/golang.org/*
 *.pyc
 *.DS_Store
 .project
+.vagrant
 src/fullerite/collector/collector.test

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,54 @@
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+# -*- ruby -*-
+VAGRANTFILE_API_VERSION = "2"
+
+stub_name = "fullerite"
+
+boxes = {
+  :trusty  => 'ubuntu/trusty64',
+  :precise => 'puppetlabs/ubuntu-12.04-64-nocm',
+  :lucid   => 'chef/ubuntu-10.04',
+}
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # 192.168.33.210-229
+  nodes = [
+    { name: 'test', memory: '512', box: 'trusty',  master: true, },
+  ]
+
+  if Vagrant.has_plugin?("vagrant-cachier")
+    config.cache.scope = :box
+  end
+
+  nodes.each do |node|
+    config.vm.define "#{node[:name]}.#{stub_name}" do |vm_config|
+
+      vm_config.vm.box = boxes[node[:box].to_sym]
+      vm_config.vm.hostname = "#{node[:name]}.#{stub_name}"
+
+      if ! node.fetch(:ip, nil).nil?
+        vm_config.vm.network :private_network, ip: node[:ip]
+      end
+
+      vm_config.vm.provider "virtualbox" do |v|
+        v.customize ["modifyvm", :id, "--memory", node[:memory]]
+        v.name = node[:name]
+      end
+
+      node.fetch(:sync_dirs, []).each do |sync_dir|
+        puts sync_dir.fetch(:source)
+        puts sync_dir.fetch(:dest)
+        vm_config.vm.synced_folder sync_dir.fetch(:source), sync_dir.fetch(:dest)
+      end
+
+      vm_config.vm.provision "shell", inline: "apt-get update && apt-get -y dist-upgrade && apt-get install -y git"
+      vm_config.vm.provision "shell", privileged: true, inline: "[ ! -f go1.5.2.linux-amd64.tar.gz ] && wget -q https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.5.2.linux-amd64.tar.gz"
+      vm_config.vm.provision "shell", inline: "echo 'PATH=/usr/local/go/bin:$PATH' >> .profile"
+      vm_config.vm.provision "shell", privileged: true, inline: "cp /vagrant/vagrant/fullerite.conf /etc/fullerite.conf"
+
+    end
+
+  end
+
+end

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -37,6 +37,8 @@ func New(name string) Handler {
 		base = NewDatadog(channel, DefaultInterval, DefaultBufferSize, timeout, handlerLog)
 	case "Kairos":
 		base = NewKairos(channel, DefaultInterval, DefaultBufferSize, timeout, handlerLog)
+	case "Log":
+		base = NewLog(channel, DefaultInterval, DefaultBufferSize, handlerLog)
 	default:
 		defaultLog.Error("Cannot create handler ", name)
 		return nil

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -19,7 +19,7 @@ func assertEmpty(t *testing.T, channel chan metric.Metric) {
 }
 
 func TestNewHandler(t *testing.T) {
-	names := []string{"Graphite", "Kairos", "SignalFx", "Datadog"}
+	names := []string{"Graphite", "Kairos", "SignalFx", "Datadog", "Log"}
 	for _, name := range names {
 		h := New(name)
 		assert.NotNil(t, h, "should create a Handler for "+name)

--- a/src/fullerite/handler/log.go
+++ b/src/fullerite/handler/log.go
@@ -41,9 +41,9 @@ func (h *Log) Run() {
 	h.run(h.emitMetrics)
 }
 
-func (h *Log) convertToLog(incomingMetric metric.Metric) string {
-	jsonOut, _ := json.Marshal(incomingMetric)
-	return string(jsonOut)
+func (h *Log) convertToLog(incomingMetric metric.Metric) (string, error) {
+	jsonOut, err := json.Marshal(incomingMetric)
+	return string(jsonOut), err
 }
 
 func (h *Log) emitMetrics(metrics []metric.Metric) bool {
@@ -55,7 +55,12 @@ func (h *Log) emitMetrics(metrics []metric.Metric) bool {
 	}
 
 	for _, m := range metrics {
-		h.log.Info(fmt.Sprintf(h.convertToLog(m)))
+		if dpString, err := h.convertToLog(m); err == nil {
+			h.log.Error(fmt.Sprintf("Cannot convert metric %q to JSON: %s", m, err))
+			continue
+		} else {
+			h.log.Info(dpString)
+		}
 	}
 	return true
 }

--- a/src/fullerite/handler/log.go
+++ b/src/fullerite/handler/log.go
@@ -55,7 +55,7 @@ func (h *Log) emitMetrics(metrics []metric.Metric) bool {
 	}
 
 	for _, m := range metrics {
-		if dpString, err := h.convertToLog(m); err == nil {
+		if dpString, err := h.convertToLog(m); err != nil {
 			h.log.Error(fmt.Sprintf("Cannot convert metric %q to JSON: %s", m, err))
 			continue
 		} else {

--- a/src/fullerite/handler/log_test.go
+++ b/src/fullerite/handler/log_test.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"fullerite/metric"
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func getTestLogHandler(interval int, buffsize int) *Log {
+	testChannel := make(chan metric.Metric)
+	testLog := l.WithField("testing", "log_handler")
+
+	return NewLog(testChannel, interval, buffsize, testLog)
+}
+
+func TestLogConfigureEmptyConfig(t *testing.T) {
+	config := make(map[string]interface{})
+	h := getTestLogHandler(12, 13)
+	h.Configure(config)
+
+	assert.Equal(t, 12, h.Interval())
+	assert.Equal(t, 13, h.MaxBufferSize())
+}
+
+func TestLogConfigure(t *testing.T) {
+	config := map[string]interface{}{
+		"interval":        "10",
+		"max_buffer_size": "100",
+	}
+
+	h := getTestLogHandler(12, 13)
+	h.Configure(config)
+
+	assert.Equal(t, 10, h.Interval())
+	assert.Equal(t, 100, h.MaxBufferSize())
+}

--- a/src/fullerite/handler/log_test.go
+++ b/src/fullerite/handler/log_test.go
@@ -35,3 +35,16 @@ func TestLogConfigure(t *testing.T) {
 	assert.Equal(t, 10, h.Interval())
 	assert.Equal(t, 100, h.MaxBufferSize())
 }
+
+func TestConvertToLog(t *testing.T) {
+
+	h := getTestLogHandler(12, 13)
+	m := metric.New("TestMetric")
+
+	dpString, err := h.convertToLog(m)
+	if err != nil {
+		t.Errorf("convertToLog failed to convert %q: err", m, err)
+	}
+
+	assert.Equal(t, "{\"name\":\"TestMetric\",\"type\":\"gauge\",\"value\":0,\"dimensions\":{}}", dpString)
+}

--- a/vagrant/fullerite.conf
+++ b/vagrant/fullerite.conf
@@ -1,0 +1,24 @@
+{
+    "prefix": "test.",
+    "interval": 10,
+    "defaultDimensions": {
+        "application": "fullerite",
+        "host": "vagrant"
+    },
+    "fulleritePort": 19191,
+
+    "collectors": {
+        "Test": {
+            "metricName": "TestMetric",
+            "interval": 10
+        }
+    },
+
+    "handlers": {
+        "Log": {
+            "interval": "10",
+            "max_buffer_size": 300
+        }
+    }
+}
+


### PR DESCRIPTION
This adds a Log handler that can be used to test metrics collection
without actually sending to a remote service: metrics are outputted as
JSON via the logrus logger. 

This also adds a Vagrant config, for local development and testing.
