### PR TITLE
Fixed metric type for mesos metrics

### DIFF
--- a/src/fullerite/collector/mesos.go
+++ b/src/fullerite/collector/mesos.go
@@ -25,6 +25,45 @@ var (
 	getMetricsURL = func(ip string) string { return fmt.Sprintf("http://%s:5050/metrics/snapshot", ip) }
 )
 
+// All mesos metrics are gauges except the ones in this list
+var mesosMasterCumulativeCountersList = map[string]int{
+	"master.slave_registrations":                    0,
+	"master.slave_removals":                         0,
+	"master.slave_reregistrations":                  0,
+	"master.slave_shutdowns_scheduled":              0,
+	"master.slave_shutdowns_cancelled":              0,
+	"master.slave_shutdowns_completed":              0,
+	"master.tasks_error":                            0,
+	"master.tasks_failed":                           0,
+	"master.tasks_finished":                         0,
+	"master.tasks_killed":                           0,
+	"master.tasks_lost":                             0,
+	"master.invalid_framework_to_executor_messages": 0,
+	"master.invalid_status_update_acknowledgements": 0,
+	"master.invalid_status_updates":                 0,
+	"master.dropped_messages":                       0,
+	"master.messages_authenticate":                  0,
+	"master.messages_deactivate_framework":          0,
+	"master.messages_exited_executor":               0,
+	"master.messages_framework_to_executor":         0,
+	"master.messages_kill_task":                     0,
+	"master.messages_launch_tasks":                  0,
+	"master.messages_reconcile_tasks":               0,
+	"master.messages_register_framework":            0,
+	"master.messages_register_slave":                0,
+	"master.messages_reregister_framework":          0,
+	"master.messages_reregister_slave":              0,
+	"master.messages_resource_request":              0,
+	"master.messages_revive_offers":                 0,
+	"master.messages_status_udpate":                 0,
+	"master.messages_status_update_acknowledgement": 0,
+	"master.messages_unregister_framework":          0,
+	"master.messages_unregister_slave":              0,
+	"master.valid_framework_to_executor_messages":   0,
+	"master.valid_status_update_acknowledgements":   0,
+	"master.valid_status_updates":                   0,
+}
+
 const (
 	cacheTimeout = 5 * time.Minute
 	getTimeout   = 10 * time.Second
@@ -127,6 +166,10 @@ func (m *MesosStats) getMetrics(ip string) map[string]float64 {
 func buildMetric(k string, v float64) metric.Metric {
 	m := metric.New(k)
 	m.Value = v
+
+	if _, exists := mesosMasterCumulativeCountersList[k]; exists {
+		m.MetricType = metric.CumulativeCounter
+	}
 
 	return m
 }

--- a/src/fullerite/collector/mesos_slave.go
+++ b/src/fullerite/collector/mesos_slave.go
@@ -31,15 +31,15 @@ var (
 
 // All mesos metrics are gauges except the ones in this list
 var mesosSlaveCumulativeCountersList = map[string]int{
-	"slave/executors_terminated":       0,
-	"slave/tasks_failed":               0,
-	"slave/tasks_finished":             0,
-	"slave/tasks_killed":               0,
-	"slave/tasks_lost":                 0,
-	"slave/invalid_framework_messages": 0,
-	"slave/invalid_status_udpates":     0,
-	"slave/valid_framework_messages":   0,
-	"slave/valid_status_udpates":       0,
+	"slave.executors_terminated":       0,
+	"slave.tasks_failed":               0,
+	"slave.tasks_finished":             0,
+	"slave.tasks_killed":               0,
+	"slave.tasks_lost":                 0,
+	"slave.invalid_framework_messages": 0,
+	"slave.invalid_status_udpates":     0,
+	"slave.valid_framework_messages":   0,
+	"slave.valid_status_udpates":       0,
 }
 
 // MesosSlaveStats Collector for mesos leader stats.

--- a/src/fullerite/collector/mesos_slave_test.go
+++ b/src/fullerite/collector/mesos_slave_test.go
@@ -158,8 +158,8 @@ func TestMesosSlaveStatsBuildMetric(t *testing.T) {
 		name       string
 		MetricType string
 	}{
-		{"slave/mem_used", metric.Gauge},
-		{"slave/tasks_killed", metric.CumulativeCounter},
+		{"slave.mem_used", metric.Gauge},
+		{"slave.tasks_killed", metric.CumulativeCounter},
 	}
 
 	for _, test := range tests {

--- a/src/fullerite/collector/mesos_test.go
+++ b/src/fullerite/collector/mesos_test.go
@@ -230,3 +230,11 @@ func TestMesosStatsBuildMetric(t *testing.T) {
 
 	assert.Equal(t, expected, actual)
 }
+
+func TestMesosStatsBuildMetricCumCounter(t *testing.T) {
+	expected := metric.Metric{"master.slave_reregistrations", metric.CumulativeCounter, 0.1, map[string]string{}}
+
+	actual := buildMetric("master.slave_reregistrations", 0.1)
+
+	assert.Equal(t, expected, actual)
+}


### PR DESCRIPTION
A bunch of mesos master metrics are emitted as counters but they're
actually counters, which are best represented in SignalFx as cumulative
counters.

The mesos slave metrics map was also updated since the '/' in the metric
name is replaced with '.'.