### PR TITLE
Notify on long running fullerite collectors

### DIFF
--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -26,8 +26,8 @@ type Collector interface {
 	Channel() chan metric.Metric
 	Interval() int
 	SetInterval(int)
-	LongRunning() bool
-	SetLongRunning(bool)
+	CollectorType() string
+	SetCollectorType(string)
 }
 
 // New creates a new Collector based on the requested collector name.
@@ -42,14 +42,14 @@ func New(name string) Collector {
 		collector = NewTest(channel, DefaultCollectionInterval, collectorLog)
 	case "Diamond":
 		collector = NewDiamond(channel, DefaultCollectionInterval, collectorLog)
-		collector.SetLongRunning(true)
+		collector.SetCollectorType("listener")
 	case "Fullerite":
 		collector = NewFullerite(channel, DefaultCollectionInterval, collectorLog)
 	case "ProcStatus":
 		collector = NewProcStatus(channel, DefaultCollectionInterval, collectorLog)
 	case "FulleriteHTTP":
 		collector = newFulleriteHTTPCollector(channel, DefaultCollectionInterval, collectorLog)
-		collector.SetLongRunning(true)
+		collector.SetCollectorType("listener")
 	case "NerveUWSGI":
 		collector = newNerveUWSGICollector(channel, DefaultCollectionInterval, collectorLog)
 	case "DockerStats":
@@ -66,15 +66,18 @@ func New(name string) Collector {
 		defaultLog.Error("Cannot create collector: ", name)
 		return nil
 	}
+	if collector.CollectorType() == "" {
+		collector.SetCollectorType("collector")
+	}
 	return collector
 }
 
 type baseCollector struct {
 	// fulfill most of the rote parts of the collector interface
-	channel     chan metric.Metric
-	name        string
-	interval    int
-	longRunning bool
+	channel       chan metric.Metric
+	name          string
+	interval      int
+	collectorType string
 
 	// intentionally exported
 	log *l.Entry
@@ -91,14 +94,14 @@ func (col *baseCollector) SetInterval(interval int) {
 	col.interval = interval
 }
 
-// SetLongRunning : don't kill this collector if runs for too long
-func (col *baseCollector) SetLongRunning(keep bool) {
-	col.longRunning = keep
+// SetCollectorType : collector type
+func (col *baseCollector) SetCollectorType(collectorType string) {
+	col.collectorType = collectorType
 }
 
-// LongRunning : don't kill this collector if runs for too long
-func (col *baseCollector) LongRunning() bool {
-	return col.longRunning
+// CollectorType : collector type
+func (col *baseCollector) CollectorType() string {
+	return col.collectorType
 }
 
 // Channel : the channel on which the collector should send metrics

--- a/src/fullerite/collector/test.go
+++ b/src/fullerite/collector/test.go
@@ -4,6 +4,7 @@ import (
 	"fullerite/metric"
 
 	"math/rand"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 )
@@ -50,4 +51,5 @@ func (t Test) Collect() {
 	metric.AddDimension("testing", "yes")
 	t.Channel() <- metric
 	t.log.Debug(metric)
+	time.Sleep(2 * time.Second)
 }

--- a/src/fullerite/collector/test.go
+++ b/src/fullerite/collector/test.go
@@ -49,7 +49,7 @@ func (t Test) Collect() {
 	metric := metric.New(t.metricName)
 	metric.Value = t.generator()
 	metric.AddDimension("testing", "yes")
+	time.Sleep(3 * time.Second)
 	t.Channel() <- metric
 	t.log.Debug(metric)
-	time.Sleep(2 * time.Second)
 }

--- a/src/fullerite/collector/test_test.go
+++ b/src/fullerite/collector/test_test.go
@@ -53,7 +53,7 @@ func TestTestConfigureMetricName(t *testing.T) {
 	case m := <-test.Channel():
 		// don't test for the value - only metric name
 		assert.Equal(t, m.Name, "lala")
-	case <-time.After(1 * time.Second):
+	case <-time.After(4 * time.Second):
 		t.Fail()
 	}
 }
@@ -79,7 +79,7 @@ func TestTestCollect(t *testing.T) {
 	case m := <-test.Channel():
 		assert.Equal(t, 4.0, m.Value)
 		return
-	case <-time.After(2 * time.Second):
+	case <-time.After(4 * time.Second):
 		t.Fail()
 	}
 }

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -86,7 +86,7 @@ func TestStartCollectorTooLong(t *testing.T) {
 		assert.Equal(t, "fullerite.collection_time_exceeded", m.Name)
 		assert.Equal(t, "1", m.Dimensions["interval"])
 		return
-	case <-time.After(3 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fail()
 	}
 }


### PR DESCRIPTION
If a collector runs longer than it's collection interval, we risk memory
and cpu resource abuse since w can not keep track of their running
interval. Having a specified collection interval will also help users
notice if their collectors are slower than usual since we monitor this.

There is no sane way to kill a g routine or stop execution of a function
in go that I was able to find. Hence I will suffice with the defer,
panic, recover technique using bool channels to be able to report when such
misbehaviour happens with a collector. This will not kill the collection
however will report this incident.

As per go 1.2 https://golang.org/doc/go1.2#preemption any go routine taking *too much* cpu time as determined by
the runtime scheduler will be yielded and will stop processing so that
should take care of itself.

I have also ensured that only one collection takes places at a time by
blocking in the collect ticker channel.

**Termination of a long running collection is not possible, we can only notify through sending metrics**
The reason is, unlike other languages go uses it's own scheduler and does not expose OS threads to the user, it only exposes go routines which unlike OS threads do not have a handle, so you can not perform an action on a go routine. You can communicate with it using channels, but that is useless if the go routine has the ability to block in itself. Hence this is as much as I can go with this without editing the go source to give us a handle on go routines, which is something that is **NOT** aligned with the go design principles.