### PR TITLE
Relay mode dimensionalised postfix collector

### DIFF
--- a/src/diamond/collectors/postfix/postfix.py
+++ b/src/diamond/collectors/postfix/postfix.py
@@ -84,7 +84,7 @@ class PostfixCollector(diamond.collector.Collector):
 
         try:
             data = json.loads(json_string)
-        except (ValueError, TypeError) as e:
+        except (ValueError, TypeError):
             self.log.exception("Error parsing json from postfix-stats")
             return None
 

--- a/src/diamond/collectors/postfix/postfix.py
+++ b/src/diamond/collectors/postfix/postfix.py
@@ -84,7 +84,7 @@ class PostfixCollector(diamond.collector.Collector):
 
         try:
             data = json.loads(json_string)
-        except (ValueError, TypeError):
+        except (ValueError, TypeError) as e:
             self.log.exception("Error parsing json from postfix-stats")
             return None
 
@@ -96,24 +96,24 @@ class PostfixCollector(diamond.collector.Collector):
         if not data:
             return
 
-        if str_to_bool(self.config['include_clients']) and u'clients' in data:
+        if str_to_bool(self.config['include_clients']):
 
             metric_name = 'postfix.incoming'
             if not str_to_bool(self.config['relay_mode']):
-                for client, value in data['clients'].iteritems():
+                for client, value in data.get('clients', {}).iteritems():
                     self.dimensions = {
                         'client': str(client),
                     }
 
                     self.publish_cumulative_counter(metric_name, value)
             else:
-                for component, clients in data['relay_clients'].iteritems():
+
+                for component, clients in data.get('relay_clients', {}).iteritems():
                     for client, value in clients.iteritems():
                         self.dimensions = {
                             'client': str(client),
                             'queue':str(component),
                         }
-
                         self.publish_cumulative_counter(metric_name, value)
 
         for action in (u'in', u'recv', u'send'):

--- a/src/diamond/collectors/postfix/test/fixtures/postfix-queue.json
+++ b/src/diamond/collectors/postfix/test/fixtures/postfix-queue.json
@@ -1,0 +1,39 @@
+{
+  "local": {},
+  "relay_clients": {
+    "sendgrid": {
+      "192.168.0.1": 38,
+      "192.168.0.2": 77
+    },
+    "sendgrid-high": {
+      "192.168.1.1": 10,
+      "192.168.1.2": 20
+    }
+  },
+  "recv": {
+    "status": {},
+    "all": 1042,
+    "resp_codes": {}
+  },
+  "send": {
+    "status": {
+      "sent": 1041
+    },
+    "relay_status": {
+      "sendgrid": {
+        "sent": 542
+      },
+      "sendgrid-high": {
+        "sent": 499
+      }
+    },
+    "resp_codes": {
+      "2.0.0": 1041
+    }
+  },
+  "in": {
+    "status": {},
+    "queue": {},
+    "resp_codes": {}
+  }
+}

--- a/src/diamond/collectors/postfix/test/testpostfix.py
+++ b/src/diamond/collectors/postfix/test/testpostfix.py
@@ -13,13 +13,14 @@ from postfix import PostfixCollector
 
 ################################################################################
 
-
-class TestPostfixCollector(CollectorTestCase):
+class TestYelpPostfixCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('PostfixCollector', {
             'host':     'localhost',
             'port':     7777,
             'interval': '1',
+            'include_clients': True,
+            'relay_mode': True,
         })
 
         self.collector = PostfixCollector(config, None)
@@ -27,7 +28,7 @@ class TestPostfixCollector(CollectorTestCase):
     def test_import(self):
         self.assertTrue(PostfixCollector)
 
-    @patch.object(Collector, 'publish')
+    @patch.object(Collector, 'publish_cumulative_counter')
     def test_should_work_with_synthetic_data(self, publish_mock):
         first_resp = self.getFixture('postfix-stats.1.json').getvalue()
         patch_collector = patch.object(
@@ -51,16 +52,49 @@ class TestPostfixCollector(CollectorTestCase):
         patch_collector.stop()
 
         metrics = {
-            'send.status.sent': 4,
-            'send.resp_codes.2_0_0': 5,
-            'clients.127_0_0_1': 1,
+            'postfix.incoming': 2,
         }
-
         self.assertPublishedMany(publish_mock, metrics)
 
         self.setDocExample(collector=self.collector.__class__.__name__,
                            metrics=metrics,
                            defaultpath=self.collector.config['path'])
+
+    @patch.object(Collector, 'publish_cumulative_counter')
+    def test_should_export_queue_metrics(self, publish_mock):
+        first_resp = self.getFixture('postfix-queue.json').getvalue()
+        patch_collector = patch.object(
+            PostfixCollector,
+            'get_json',
+            Mock(return_value=first_resp))
+
+        with patch_collector:
+            self.collector.config['relay_mode'] = True
+            self.collector.collect()
+            self.collector.config['relay_mode'] = False
+
+        metrics = [
+            ('postfix.incoming', 38),
+            ('postfix.incoming', 77),
+            ('postfix.incoming', 10),
+            ('postfix.incoming', 20),
+            ('postfix.send', 542),
+            ('postfix.send', 499)
+        ]
+
+        for expected_metric in metrics:
+            k, v = expected_metric
+            message = "metric : {0} is not equal to {1}".format(k, v)
+            self.assertTrue(self.check_for_call(publish_mock, k, v), message)
+
+    # Check in entire call_arg_list for given key and value
+    def check_for_call(self, mock, key, value):
+        call_found = False
+        for call in mock.call_args_list:
+            if call[0][0] == key and call[0][1] == value:
+                call_found = True
+        return call_found
+
 
 ################################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
Since we were able to get https://github.com/disqus/postfix-stats/pull/4
successfully merged into the upstream postfix-stats project, we can now
allow the postfix diamond collector to work in relay mode as well as non
relay mode.