### PR TITLE
Add the *mesos.* namespace to all mesos slave + master metrics.

### DIFF
--- a/src/fullerite/collector/mesos.go
+++ b/src/fullerite/collector/mesos.go
@@ -164,7 +164,7 @@ func (m *MesosStats) getMetrics(ip string) map[string]float64 {
 
 // buildMetric Build a fullerite metric.
 func buildMetric(k string, v float64) metric.Metric {
-	m := metric.New(k)
+	m := metric.New("mesos." + k)
 	m.Value = v
 
 	if _, exists := mesosMasterCumulativeCountersList[k]; exists {

--- a/src/fullerite/collector/mesos_slave.go
+++ b/src/fullerite/collector/mesos_slave.go
@@ -135,7 +135,7 @@ func (m *MesosSlaveStats) getSlaveMetrics(ip string) map[string]float64 {
 
 // buildMetric creates the metric and set the correct metricType
 func (m *MesosSlaveStats) buildMetric(name string, value float64) metric.Metric {
-	s := metric.New(name)
+	s := metric.New("mesos." + name)
 	s.Value = value
 	if _, exists := mesosSlaveCumulativeCountersList[name]; exists {
 		s.MetricType = metric.CumulativeCounter

--- a/src/fullerite/collector/mesos_slave_test.go
+++ b/src/fullerite/collector/mesos_slave_test.go
@@ -69,7 +69,7 @@ func TestMesosSlaveStatsSendMetrics(t *testing.T) {
 	oldGetMetrics := getSlaveMetrics
 	defer func() { getSlaveMetrics = oldGetMetrics }()
 
-	expected := metric.Metric{"test", "gauge", 0.1, map[string]string{}}
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
 	getSlaveMetrics = func(m *MesosSlaveStats, ip string) map[string]float64 {
 		return map[string]float64{
 			"test": 0.1,

--- a/src/fullerite/collector/mesos_test.go
+++ b/src/fullerite/collector/mesos_test.go
@@ -141,7 +141,7 @@ func TestMesosStatsSendMetrics(t *testing.T) {
 	oldGetMetrics := getMetrics
 	defer func() { getMetrics = oldGetMetrics }()
 
-	expected := metric.Metric{"test", "gauge", 0.1, map[string]string{}}
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
 	getMetrics = func(m *MesosStats, ip string) map[string]float64 {
 		return map[string]float64{
 			"test": 0.1,
@@ -224,7 +224,7 @@ func TestMesosStatsGetMetricsHandleNon200s(t *testing.T) {
 }
 
 func TestMesosStatsBuildMetric(t *testing.T) {
-	expected := metric.Metric{"test", "gauge", 0.1, map[string]string{}}
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
 
 	actual := buildMetric("test", 0.1)
 
@@ -232,7 +232,7 @@ func TestMesosStatsBuildMetric(t *testing.T) {
 }
 
 func TestMesosStatsBuildMetricCumCounter(t *testing.T) {
-	expected := metric.Metric{"master.slave_reregistrations", metric.CumulativeCounter, 0.1, map[string]string{}}
+	expected := metric.Metric{"mesos.master.slave_reregistrations", metric.CumulativeCounter, 0.1, map[string]string{}}
 
 	actual := buildMetric("master.slave_reregistrations", 0.1)
 


### PR DESCRIPTION
Without this, all mesos metrics are named either `master.*` or `slave.*`. This will soon hamper discoverability in signalfx/kairos. Therefore, this change to add the `mesos.` namespace to all mesos master and slave metrics.