### PR TITLE
Disable log message propagation in test env

### DIFF
--- a/src/diamond/tests/testcollector.py
+++ b/src/diamond/tests/testcollector.py
@@ -17,6 +17,8 @@ class BaseCollectorTest(unittest.TestCase):
     def tearDown(self):
         log = logging.getLogger("diamond.Collector")
         log.removeHandler(log.handlers[0])
+        # Ensure that we aren't printing log messages to stdout in unit tests
+        log.propagate = False
 
     def config_object(self):
         config = configobj.ConfigObj()


### PR DESCRIPTION
This disables printing of undesirable log messages in test
environment.