### PR TITLE
Only remove files/user on purge for deb package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ ifeq ($(OS),Ubuntu)
 		--deb-upstart "deb/etc/init/fullerite_diamond_server" \
 		--before-install "deb/before_install.sh" \
 		--before-remove "deb/before_rm.sh" \
-		--before-upgrade "deb/before_upgrade.sh" \
+		--after-remove "deb/post_rm.sh" \
 		-C build .
 # CentOS 7 Only
 else ifeq ($(OS),CentOS)

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,7 @@ ifeq ($(OS),Ubuntu)
 		--deb-upstart "deb/etc/init/fullerite_diamond_server" \
 		--before-install "deb/before_install.sh" \
 		--before-remove "deb/before_rm.sh" \
+		--before-upgrade "deb/before_upgrade.sh" \
 		-C build .
 # CentOS 7 Only
 else ifeq ($(OS),CentOS)

--- a/deb/before_rm.sh
+++ b/deb/before_rm.sh
@@ -2,9 +2,4 @@
 
 service 'fullerite' stop
 service 'fullerite_diamond_server' stop
-
-if [ "$(id 'fuller')" ]; then
-  userdel 'fuller'
-fi
-
-rm -rf /var/log/fullerite
+exit 0

--- a/deb/before_upgrade.sh
+++ b/deb/before_upgrade.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+service 'fullerite' stop || exit 0
+service 'fullerite_diamond_server' stop || exit 0

--- a/deb/before_upgrade.sh
+++ b/deb/before_upgrade.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-service 'fullerite' stop || exit 0
-service 'fullerite_diamond_server' stop || exit 0

--- a/deb/post_rm.sh
+++ b/deb/post_rm.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+case "$1" in
+    purge)
+        if [ "$(id 'fuller')" ]; then
+            userdel 'fuller'
+        fi
+        rm -rf /var/log/fullerite
+        ;;
+    remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+            ;;
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+        ;;
+esac
+
+exit 0


### PR DESCRIPTION
This PR adds `postrm` for debian package and ensures that `fuller` user and some of the owned files by the user are deleted when package gets uninstalled by `purge` (something like apt-get purge)

This will bring it very close to debian packaging guidelines. Redis package for example does similar thing - http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/trusty/redis/trusty/view/head:/debian/redis-server.postrm 