### PR TITLE
Fixed get slice of strings from config

### DIFF
--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -124,8 +124,13 @@ func GetAsSlice(value interface{}) []string {
 		}
 	case []string:
 		result = realValue
+	case []interface{}:
+		result = make([]string, len(realValue))
+		for i, value := range realValue {
+			result[i] = value.(string)
+		}
 	default:
-		log.Warn("Expected a string array but got", reflect.TypeOf(realValue), ".Returning empty slice!")
+		log.Warn("Expected a string array but got", reflect.TypeOf(realValue), ". Returning empty slice!")
 	}
 
 	return result

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"encoding/json"
 )
 
 var testBadConfiguration = `{
@@ -139,6 +140,21 @@ func TestGetAsSlice(t *testing.T) {
 
 	sliceToParse := []string{"TestCollector1", "TestCollector2"}
 	assert.Equal(config.GetAsSlice(sliceToParse), expectedValue)
+}
+
+func TestGetAsSliceFromJson(t *testing.T) {
+	var data interface{}
+	jsonString := []byte(`{"listOfStrings": ["a", "b", "c"]}`)
+
+	err := json.Unmarshal(jsonString, &data)
+	assert.Nil(t, err)
+
+	if err == nil {
+		temp := data.(map[string]interface{})
+
+		res := config.GetAsSlice(temp["listOfStrings"])
+		assert.Equal(t, []string{"a", "b", "c"}, res)
+	}
 }
 
 func TestParseGoodConfig(t *testing.T) {


### PR DESCRIPTION
When unmarshaling a json string you'll get a slice of interface{}. We
need to consider also that case and convert it to []string.