### PR TITLE
Make http persistent connections data race safe

### DIFF
--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -7,9 +7,9 @@ import (
 	"os"
 	"testing"
 
+	"encoding/json"
 	"github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"encoding/json"
 )
 
 var testBadConfiguration = `{

--- a/src/fullerite/handler/signalfx.go
+++ b/src/fullerite/handler/signalfx.go
@@ -142,12 +142,16 @@ func (s *SignalFx) emitMetrics(metrics []metric.Metric) bool {
 		return false
 	}
 
-	s.httpClient.SetHeader(map[string]string{
+	customHeader := map[string]string{
 		"X-SF-TOKEN":   s.authToken,
 		"Content-Type": "application/x-protobuf",
-	})
+	}
 
-	rsp, err := s.httpClient.MakeRequest("POST", s.endpoint, bytes.NewBuffer(serialized))
+	rsp, err := s.httpClient.MakeRequest(
+		"POST",
+		s.endpoint,
+		bytes.NewBuffer(serialized),
+		customHeader)
 
 	if err != nil {
 		s.log.Error("Failed to make request ", err,

--- a/src/fullerite/util/http_alive.go
+++ b/src/fullerite/util/http_alive.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -13,7 +12,6 @@ import (
 type HTTPAlive struct {
 	client    *http.Client
 	transport *http.Transport
-	mu        sync.Mutex
 }
 
 // HTTPAliveResponse returns a response
@@ -47,8 +45,6 @@ func (connection *HTTPAlive) Configure(timeout time.Duration,
 // MakeRequest make a new http request
 func (connection *HTTPAlive) MakeRequest(method string,
 	uri string, body io.Reader, header map[string]string) (*HTTPAliveResponse, error) {
-	connection.mu.Lock()
-	defer connection.mu.Unlock()
 	req, err := http.NewRequest(method, uri, body)
 
 	if err != nil {

--- a/src/fullerite/util/http_alive.go
+++ b/src/fullerite/util/http_alive.go
@@ -5,14 +5,15 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // HTTPAlive implements a simple way of reusing http connections
 type HTTPAlive struct {
-	client       *http.Client
-	transport    *http.Transport
-	customHeader map[string]string
+	client    *http.Client
+	transport *http.Transport
+	mu        sync.Mutex
 }
 
 // HTTPAliveResponse returns a response
@@ -43,16 +44,11 @@ func (connection *HTTPAlive) Configure(timeout time.Duration,
 	}
 }
 
-// SetHeader for setting some custom headers
-func (connection *HTTPAlive) SetHeader(header map[string]string) {
-	connection.customHeader = header
-}
-
 // MakeRequest make a new http request
 func (connection *HTTPAlive) MakeRequest(method string,
-	uri string, body io.Reader) (*HTTPAliveResponse, error) {
-
-	defer connection.resetCustomHeader()
+	uri string, body io.Reader, header map[string]string) (*HTTPAliveResponse, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
 	req, err := http.NewRequest(method, uri, body)
 
 	if err != nil {
@@ -60,7 +56,7 @@ func (connection *HTTPAlive) MakeRequest(method string,
 	}
 
 	// Apply user provided headers
-	for key, value := range connection.customHeader {
+	for key, value := range header {
 		req.Header.Set(key, value)
 	}
 
@@ -88,10 +84,6 @@ func (connection *HTTPAlive) submitRequest(req *http.Request) (*HTTPAliveRespons
 	httpAliveResponse.StatusCode = rsp.StatusCode
 	httpAliveResponse.Header = rsp.Header
 	return httpAliveResponse, nil
-}
-
-func (connection *HTTPAlive) resetCustomHeader() {
-	connection.customHeader = make(map[string]string)
 }
 
 func discardResponseBody(body io.ReadCloser) {

--- a/src/fullerite/util/http_alive_test.go
+++ b/src/fullerite/util/http_alive_test.go
@@ -21,15 +21,16 @@ func TestMakeRequest(t *testing.T) {
 	httpClient.Configure(time.Duration(10)*time.Second, time.Minute, 10)
 	assert.Equal(t, 10, httpClient.transport.MaxIdleConnsPerHost)
 
-	httpClient.SetHeader(map[string]string{
+	customHeader := map[string]string{
 		"foo": "bar",
-	})
+	}
 
-	assert.Equal(t, httpClient.customHeader["foo"], "bar")
-
-	resp, err := httpClient.MakeRequest("GET", ts.URL, bytes.NewBufferString("fullerite"))
+	resp, err := httpClient.MakeRequest(
+		"GET",
+		ts.URL,
+		bytes.NewBufferString("fullerite"),
+		customHeader)
 
 	assert.Nil(t, err)
 	assert.Equal(t, string(resp.Body), "done\n")
-	assert.Empty(t, httpClient.customHeader)
 }


### PR DESCRIPTION
Using keepalive connections has a downside that,
these connections can not be shared between goroutines
without using some sort of synchronization mechanism.

We are calling `go base.emitAndTime(metrics, emitFunc, emissionResults)` 
which means each emit happens in its own goroutine. This was not a problem
as long as we made new http connection for each POST, but it becomes a problem if we
are going to reuse the http connection.

My plan is to - further test this in dev/stage environments and revert keepalive change altogether
if lock/unlock becomes a problem.