### PR TITLE
Make the batch size configurable

### DIFF
--- a/fullerite.conf.example
+++ b/fullerite.conf.example
@@ -10,7 +10,7 @@
 
     "diamondCollectorsPath": "src/diamond/collectors",
     "diamondCollectors": {
-        "CPUCollector": {"interval": 10},
+        "CPUCollector": {"interval": 10, "max_buffer_size": 50},
         "PingCollector": {"target_google": "google.com", "interval": 10, "bin": "/sbin/ping"}
     },
 

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -448,6 +448,8 @@ class Collector(object):
             start_time = time.time()
 
             # Collect Data
+            self.payload = []
+            self.default_dimensions = None
             self.collect()
 
             end_time = time.time()

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -232,6 +232,9 @@ class Collector(object):
 
             # Blacklist of metrics to let through
             'metrics_blacklist': None,
+
+            # Max buffer size before flushing to fullerite core
+            'max_buffer_size': 300,
         }
 
     def get_metric_path(self, name, instance=None):
@@ -348,9 +351,14 @@ class Collector(object):
             metric.dimensions or {}
         )
         self.payload.append(payload)
+        if len(self.payload) >= self.config.get('max_buffer_size', 300):
+            self.flush()
+            self.payload = []
 
     def flush(self):
         payloadStr = "%s\n" % json.dumps(self.payload)
+        self.log.info("Flushing {0} {1} ".format(self.name, len(self.payload)))
+        return
         success = False
 
         for i in range(FULLERITE_RETRY_COUNT):

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -168,6 +168,9 @@ class Collector(object):
             self.config['metrics_blacklist'] = re.compile(
                 self.config['metrics_blacklist'])
 
+        if 'max_buffer_size' in self.config:
+            self.config['max_buffer_size'] = int(self.config['max_buffer_size'])
+
     def get_default_config_help(self):
         """
         Returns the help text for the configuration options for this collector

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -357,8 +357,6 @@ class Collector(object):
 
     def flush(self):
         payloadStr = "%s\n" % json.dumps(self.payload)
-        self.log.info("Flushing {0} {1} ".format(self.name, len(self.payload)))
-        return
         success = False
 
         for i in range(FULLERITE_RETRY_COUNT):

--- a/src/diamond/tests/testcollector.py
+++ b/src/diamond/tests/testcollector.py
@@ -75,3 +75,18 @@ class BaseCollectorTest(unittest.TestCase):
 
         c._socket = "socket"
         self.assertTrue(c.can_publish_metric())
+
+    @patch('diamond.collector.Collector.flush', autoSpec=True)
+    def test_batch_size_flush(self, mock_flush):
+        c = Collector(self.config_object(), [])
+        mock_socket = Mock()
+        c._socket = mock_socket
+        c.config['max_buffer_size'] = 2
+        with patch.object(c, 'log'):
+            try:
+                c.publish('metric1', 1)
+                c.publish('metric2', 2)
+                c.publish('metric3', 3)
+            except DiamondException:
+                pass
+        self.assertEquals(len(mock_flush.mock_calls), 1)


### PR DESCRIPTION
We have seen some collectors that are capable of sending hige messages
to the fullerite core, which causes lots of errors and also causes the
collector process to hold a lot in memory at a time. For such collectors
we can tweak the max_buffer_size config variable 'defaulted to 300'
to a value we see fit.