### PR TITLE
We can flush immediately after making josn string

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -356,10 +356,13 @@ class Collector(object):
         self.payload.append(payload)
         if len(self.payload) >= self.config.get('max_buffer_size', 300):
             self.flush()
-            self.payload = []
 
     def flush(self):
-        payloadStr = "%s\n" % json.dumps(self.payload)
+        try:
+            payloadStr = "%s\n" % json.dumps(self.payload)
+        finally:
+            self.payload = []
+
         success = False
 
         for i in range(FULLERITE_RETRY_COUNT):
@@ -448,7 +451,6 @@ class Collector(object):
             start_time = time.time()
 
             # Collect Data
-            self.payload = []
             self.default_dimensions = None
             self.collect()
 
@@ -469,7 +471,6 @@ class Collector(object):
             # After collector run, invoke a flush
             # method on each handler.
             self.flush()
-            self.payload = []
             self.default_dimensions = None
             for handler in self.handlers:
                 handler._flush()

--- a/src/diamond/tests/testcollector.py
+++ b/src/diamond/tests/testcollector.py
@@ -76,11 +76,11 @@ class BaseCollectorTest(unittest.TestCase):
         c._socket = "socket"
         self.assertTrue(c.can_publish_metric())
 
-    @patch('diamond.collector.Collector.flush', autoSpec=True)
-    def test_batch_size_flush(self, mock_flush):
+    def test_batch_size_flush(self):
         c = Collector(self.config_object(), [])
         mock_socket = Mock()
         c._socket = mock_socket
+        c._reconnect = False
         c.config['max_buffer_size'] = 2
         with patch.object(c, 'log'):
             try:
@@ -89,4 +89,5 @@ class BaseCollectorTest(unittest.TestCase):
                 c.publish('metric3', 3)
             except DiamondException:
                 pass
-        self.assertEquals(len(mock_flush.mock_calls), 1)
+        self.assertEquals(mock_socket.sendall.call_count, 1)
+        self.assertEquals(len(c.payload), 1)


### PR DESCRIPTION
This centralizes all flush() calls