### PR TITLE
Allow collectors to have their individual config files

### DIFF
--- a/examples/config/another_collector.conf.example
+++ b/examples/config/another_collector.conf.example
@@ -1,0 +1,1 @@
+{"target_google": "google.com", "interval": 10, "bin": "/sbin/ping"}

--- a/examples/config/collector.conf.example
+++ b/examples/config/collector.conf.example
@@ -1,0 +1,1 @@
+{"interval": 10, "max_buffer_size": 50}

--- a/examples/config/fullerite.conf.example
+++ b/examples/config/fullerite.conf.example
@@ -1,6 +1,9 @@
 {
     "prefix": "test.",
     "interval": 10,
+    "defaultConfig": {
+        "prefix":"fullerite"
+    },
     "defaultDimensions": {
         "application": "fullerite",
         "host": "dev33-devc"

--- a/examples/config/fullerite.conf.example
+++ b/examples/config/fullerite.conf.example
@@ -7,32 +7,12 @@
     },
     "fulleritePort": 19191,
     "internalServer": {"port":"29090","path":"/metrics"},
-
+    "collectorsConfigPath": "/etc/fullerite/conf.d",
     "diamondCollectorsPath": "src/diamond/collectors",
-    "diamondCollectors": {
-        "CPUCollector": {"interval": 10, "max_buffer_size": 50},
-        "PingCollector": {"target_google": "google.com", "interval": 10, "bin": "/sbin/ping"}
+    "diamondCollectors": [ "CPUCollector", "PingCollector" ]
     },
 
-    "collectors": {
-        "Test": {
-            "metricName": "TestMetric",
-            "interval": 10
-        },
-        "Diamond":{
-            "port": "19191",
-            "interval": 10
-        },
-        "Fullerite":{
-        },
-        "DockerStats":{
-            "generatedDimensions":{
-                "service_name":{
-                    "MESOS_TASK_ID": "[^\\.]*"
-                }
-            }
-        }
-    },
+    "collectors": ["Test", "Diamond", "Fullerite", "DockerStats"],
 
     "handlers": {
         "Graphite": {

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -127,12 +127,10 @@ class Collector(object):
         if self.get_default_config() is not None:
             self.config.update(self.get_default_config())
 
-            if 'diamondCollectors' in config:
-                if 'default' in config['collectors']:
-                    self.config.update(config['diamondCollectors']['default'])
+        if 'default' in config:
+            self.config.update(config['default'])
 
-                if self.name in config['diamondCollectors']:
-                    self.config.update(config['diamondCollectors'][self.name])
+        self.config.update(config)
         self.process_config()
 
     def can_publish_metric(self):

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -100,6 +100,7 @@ class Collector(object):
         self.payload = []
 
         self.config = {}
+        self.configfile = configfile or {}
         self.load_config(config if config else {})
 
     def _connect(self):
@@ -127,10 +128,20 @@ class Collector(object):
         if self.get_default_config() is not None:
             self.config.update(self.get_default_config())
 
-        if 'default' in config:
-            self.config.update(config['default'])
+        # Inject keys to collector's configuration.
+        #
+        # "enabled" is requied to be compatible with
+        # diamond configuration. There are collectors that
+        # check if they are enabled.
+        #
+        # We use "fulleritePort" in collectors to connect
+        # to the running fullerite instance.
+        self.config['enabled'] = True
+        self.config['fulleritePort'] = config['fulleritePort']
+        self.config['interval'] = self.configfile.get('interval', config['interval'])
 
-        self.config.update(config)
+        self.config.update(config.get('defaultConfig', {}))
+        self.config.update(self.configfile)
         self.process_config()
 
     def can_publish_metric(self):

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -75,6 +75,7 @@ class Server(object):
         self.config = load_config(self.configfile)
 
         collectors = load_collectors(self.config['diamondCollectorsPath'])
+        collectors_config_dir = self.config['collectorsConfigPath']
 
         ########################################################################
         # Signals
@@ -113,7 +114,8 @@ class Server(object):
                     # instances of the same collector, we want their files
                     # will not have that space and needs to have it replaced with an underscore
                     # instead
-                    config_file = '/'.join([self.config['collectorsConfigPath'], collector]).replace(' ', '_')
+                    config_file = '/'.join([
+                        collectors_config_dir, collector]).replace(' ', '_') + '.conf'
                     config = load_config(config_file)
 
                     config['enabled'] = True

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -121,6 +121,7 @@ class Server(object):
                     config['enabled'] = True
                     config['fulleritePort'] = self.config['fulleritePort']
                     config['interval'] = config.get('interval', self.config['interval'])
+                    config['default'] = self.config.get('defaultConfig', {})
                     self.collector_config[collector] = config
 
                     running_collectors.append(collector)

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -52,6 +52,7 @@ class Server(object):
         # Initialize Members
         self.configfile = configfile
         self.config = None
+        self.collector_config = {}
         self.modules = {}
 
         # We do this weird process title swap around to get the sync manager
@@ -118,6 +119,7 @@ class Server(object):
                     config['enabled'] = True
                     config['fulleritePort'] = self.config['fulleritePort']
                     config['interval'] = config.get('interval', self.config['interval'])
+                    self.collector_config[collector] = config
 
                     running_collectors.append(collector)
                 running_collectors = set(running_collectors)
@@ -153,7 +155,7 @@ class Server(object):
                     collector = initialize_collector(
                         collector_classes[collector_name],
                         name=process_name,
-                        config=self.config,
+                        config=self.collector_config[process_name],
                         handlers=[])
 
                     if collector is None:

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -107,6 +107,11 @@ class Server(object):
                     # to the running fullerite instance.
 
                     # Each collector has it's own config file
+
+                    # Since collector naems can be defined with a space in order to instantiate multiple
+                    # instances of the same collector, we want their files
+                    # will not have that space and needs to have it replaced with an underscore
+                    # instead
                     config_file = '/'.join([self.config['collectorsConfigPath'], collector]).replace(' ', '_')
                     config = load_config(config_file)
 

--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -96,7 +96,7 @@ class Server(object):
                 ##############################################################
 
                 running_collectors = []
-                for collector, config in self.config['diamondCollectors'].iteritems():
+                for collector in self.config['diamondCollectors']:
                     # Inject keys to collector's configuration.
                     #
                     # "enabled" is requied to be compatible with
@@ -105,6 +105,11 @@ class Server(object):
                     #
                     # We use "fulleritePort" in collectors to connect
                     # to the running fullerite instance.
+
+                    # Each collector has it's own config file
+                    config_file = '/'.join([self.config['collectorsConfigPath'], collector]).replace(' ', '_')
+                    config = load_config(config_file)
+
                     config['enabled'] = True
                     config['fulleritePort'] = self.config['fulleritePort']
                     config['interval'] = config.get('interval', self.config['interval'])

--- a/src/diamond/tests/testcollector.py
+++ b/src/diamond/tests/testcollector.py
@@ -25,7 +25,16 @@ class BaseCollectorTest(unittest.TestCase):
         config['server'] = {}
         config['server']['collectors_config_path'] = ''
         config['collectors'] = {}
+        config['defaultConfig'] = { "conf": "val" }
+        config['interval'] = 10
+        config['fulleritePort'] = 0
         return config
+
+    def configfile(self):
+        return {
+            'interval': 5,
+            'alice': 'bob',
+        }
 
     @patch('diamond.collector.Collector.publish_metric', autoSpec=True)
     def test_SetDimensions(self, mock_publish):
@@ -91,3 +100,24 @@ class BaseCollectorTest(unittest.TestCase):
                 pass
         self.assertEquals(mock_socket.sendall.call_count, 1)
         self.assertEquals(len(c.payload), 1)
+
+    def test_configure_collector(self):
+        c = Collector(self.config_object(), [], configfile=self.configfile())
+        self.assertEquals(c.config, {
+            'ttl_multiplier':2,
+            'path_suffix':'',
+            'measure_collector_time':False,
+            'metrics_blacklist':None,
+            'byte_unit':[
+                'byte'
+            ],
+            'instance_prefix':'instances',
+            'conf':'val',
+            'fulleritePort':0,
+            'interval':5,
+            'enabled':True,
+            'alice':'bob',
+            'metrics_whitelist':None,
+            'max_buffer_size':300,
+            'path_prefix':'servers'
+    })

--- a/src/diamond/utils/classes.py
+++ b/src/diamond/utils/classes.py
@@ -140,7 +140,7 @@ def load_collectors(paths=None, filter=None):
     return collectors
 
 
-def initialize_collector(cls, name=None, config=None, handlers=[]):
+def initialize_collector(cls, name=None, config=None, handlers=[], configfile=None):
     """
     Initialize collector
     """
@@ -149,7 +149,7 @@ def initialize_collector(cls, name=None, config=None, handlers=[]):
 
     try:
         # Initialize Collector
-        collector = cls(name=name, config=config, handlers=handlers)
+        collector = cls(name=name, config=config, handlers=handlers, configfile=configfile)
     except Exception:
         # Log error
         log.error("Failed to initialize Collector: %s. %s",

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -6,12 +6,22 @@ import (
 	"fullerite/metric"
 
 	"fmt"
+	"strings"
 	"time"
 )
 
 func startCollectors(c config.Config) (collectors []collector.Collector) {
 	log.Info("Starting collectors...")
-	for name, config := range c.Collectors {
+
+	for _, name := range c.Collectors {
+		configFile := strings.Join([]string{c.CollectorsConfigPath, name}, "/")
+		configFile = strings.Replace(configFile, " ", "_", -1)
+		config, err := config.ReadCollectorConfig(configFile)
+		if err != nil {
+			log.Error("Collector config failed to load for: ", name)
+			continue
+		}
+
 		collectorInst := startCollector(name, c, config)
 		if collectorInst != nil {
 			collectors = append(collectors, collectorInst)

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -14,7 +14,7 @@ func startCollectors(c config.Config) (collectors []collector.Collector) {
 	log.Info("Starting collectors...")
 
 	for _, name := range c.Collectors {
-		configFile := strings.Join([]string{c.CollectorsConfigPath, name}, "/")
+		configFile := strings.Join([]string{c.CollectorsConfigPath, name}, "/") + ".conf"
 		// Since collector naems can be defined with a space in order to instantiate multiple
 		// instances of the same collector, we want their files
 		// will not have that space and needs to have it replaced with an underscore

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -15,6 +15,10 @@ func startCollectors(c config.Config) (collectors []collector.Collector) {
 
 	for _, name := range c.Collectors {
 		configFile := strings.Join([]string{c.CollectorsConfigPath, name}, "/")
+		// Since collector naems can be defined with a space in order to instantiate multiple
+		// instances of the same collector, we want their files
+		// will not have that space and needs to have it replaced with an underscore
+		// instead
 		configFile = strings.Replace(configFile, " ", "_", -1)
 		config, err := config.ReadCollectorConfig(configFile)
 		if err != nil {

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	}
 	if f, err := ioutil.TempFile("/tmp", "fullerite"); err == nil {
 		f.WriteString(testCollectorConfiguration)
-		tempTestCollectorConfig = f.Name()
+		tempTestCollectorConfig = f.Name() + ".conf"
 		f.Close()
 		defer os.Remove(tempTestCollectorConfig)
 	}

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -18,24 +18,25 @@ var testFakeConfiguration = `{
     "defaultDimensions": {
     },
 
+	"collectorsConfigPath": "/tmp",
     "diamondCollectorsPath": "src/diamond/collectors",
-    "diamondCollectors": {
-    },
+    "diamondCollectors": [],
 
-    "collectors": {
-        "FakeCollector": {
-        },
-        "Test":{
-        }
-    },
+    "collectors": ["FakeCollector","Test"],
 
     "handlers": {
     }
 }
 `
 
+var testCollectorConfiguration = `{
+	"metricName": "TestMetric",
+	"interval": 10
+}
+`
+
 var (
-	tmpTestFakeFile string
+	tmpTestFakeFile, tempTestCollectorConfig string
 )
 
 func TestMain(m *testing.M) {
@@ -45,6 +46,12 @@ func TestMain(m *testing.M) {
 		tmpTestFakeFile = f.Name()
 		f.Close()
 		defer os.Remove(tmpTestFakeFile)
+	}
+	if f, err := ioutil.TempFile("/tmp", "fullerite"); err == nil {
+		f.WriteString(testCollectorConfiguration)
+		tempTestCollectorConfig = f.Name()
+		f.Close()
+		defer os.Remove(tempTestCollectorConfig)
 	}
 	os.Exit(m.Run())
 }

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -15,10 +15,11 @@ var log = logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "config"})
 type Config struct {
 	Prefix                string                            `json:"prefix"`
 	Interval              interface{}                       `json:"interval"`
+	CollectorsConfigPath  string                            `json:"collectorsConfigPath"`
 	DiamondCollectorsPath string                            `json:"diamondCollectorsPath"`
-	DiamondCollectors     map[string]map[string]interface{} `json:"diamondCollectors"`
+	DiamondCollectors     []string                          `json:"diamondCollectors"`
 	Handlers              map[string]map[string]interface{} `json:"handlers"`
-	Collectors            map[string]map[string]interface{} `json:"collectors"`
+	Collectors            []string                          `json:"collectors"`
 	DefaultDimensions     map[string]string                 `json:"defaultDimensions"`
 	InternalServerConfig  map[string]interface{}            `json:"internalServer"`
 }
@@ -26,6 +27,22 @@ type Config struct {
 // ReadConfig reads a fullerite configuration file
 func ReadConfig(configFile string) (c Config, e error) {
 	log.Info("Reading configuration file at ", configFile)
+	contents, e := ioutil.ReadFile(configFile)
+	if e != nil {
+		log.Error("Config file error: ", e)
+		return c, e
+	}
+	err := json.Unmarshal(contents, &c)
+	if err != nil {
+		log.Error("Invalid JSON in config: ", err)
+		return c, err
+	}
+	return c, nil
+}
+
+// ReadCollectorConfig reads a fullerite collector configuration file
+func ReadCollectorConfig(configFile string) (c map[string]interface{}, e error) {
+	log.Info("Reading collector configuration file at ", configFile)
 	contents, e := ioutil.ReadFile(configFile)
 	if e != nil {
 		log.Error("Config file error: ", e)

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -26,7 +26,7 @@ var testGoodConfiguration = `{
         "host": "dev33-devc"
     },
 
-	"collectorsConfigPath": "/tmp",
+    "collectorsConfigPath": "/tmp",
     "diamondCollectorsPath": "src/diamond/collectors",
     "diamondCollectors": ["CPUCollector","PingCollector"],
     "collectors": ["Test"],

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -26,22 +26,10 @@ var testGoodConfiguration = `{
         "host": "dev33-devc"
     },
 
+	"collectorsConfigPath": "/tmp",
     "diamondCollectorsPath": "src/diamond/collectors",
-    "diamondCollectors": {
-        "CPUCollector": {"enabled": true, "interval": 10},
-        "PingCollector": {"enabled": true, "target_google": "google.com", "interval": 10, "bin": "/bin/ping"}
-    },
-
-    "collectors": {
-        "Test": {
-            "metricName": "TestMetric",
-            "interval": 10
-        },
-        "Diamond":{
-            "port": "19191",
-            "interval": 10
-        }
-    },
+    "diamondCollectors": ["CPUCollector","PingCollector"],
+    "collectors": ["Test"],
 
     "handlers": {
         "Graphite": {
@@ -59,8 +47,15 @@ var testGoodConfiguration = `{
     }
 }
 `
+
+var testCollectorConfiguration = `{
+	"metricName": "TestMetric",
+	"interval": 10
+}
+`
+
 var (
-	tmpTestGoodFile, tmpTestBadFile string
+	tmpTestGoodFile, tmpTestBadFile, tempTestCollectorConfig string
 )
 
 func TestMain(m *testing.M) {
@@ -76,6 +71,12 @@ func TestMain(m *testing.M) {
 		tmpTestBadFile = f.Name()
 		f.Close()
 		defer os.Remove(tmpTestBadFile)
+	}
+	if f, err := ioutil.TempFile("/tmp", "fullerite"); err == nil {
+		f.WriteString(testCollectorConfiguration)
+		tempTestCollectorConfig = f.Name()
+		f.Close()
+		defer os.Remove(tempTestCollectorConfig)
 	}
 	os.Exit(m.Run())
 }
@@ -155,6 +156,11 @@ func TestGetAsSliceFromJson(t *testing.T) {
 		res := config.GetAsSlice(temp["listOfStrings"])
 		assert.Equal(t, []string{"a", "b", "c"}, res)
 	}
+}
+
+func TestParseCollectorConfig(t *testing.T) {
+	_, err := config.ReadCollectorConfig(tempTestCollectorConfig)
+	assert.Nil(t, err, "should succeed")
 }
 
 func TestParseGoodConfig(t *testing.T) {

--- a/src/fullerite/handlers.go
+++ b/src/fullerite/handlers.go
@@ -56,11 +56,11 @@ func canSendMetric(handler handler.Handler, metric metric.Metric) bool {
 			return true
 		}
 		return false
-	} else {
-		// If the handler's whitelist is nil, all collector except the ones in the blacklist are enabled
-		if !isBlackListed {
-			return true
-		}
+	}
+
+	// If the handler's whitelist is nil, all collector except the ones in the blacklist are enabled
+	if !isBlackListed {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
Now each collector will have it's own config file that will live in a
config directory. This means each collector will have to be instantiated
and it's config file read into memory. If one collector's config is
corrupt, *ONLY* that collector will be skipped and other non corrupt
ones will start