### PR TITLE
Create a handler channel per collector

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
+  - 1.4
   - 1.4.1
   - 1.4.2
   - 1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4
   - 1.4.1
   - 1.4.2
   - 1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
+  - 1.4
   - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.5
+  - 1.4.2
   - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
+  - 1.4
+  - 1.4.1
   - 1.4.2
+  - 1.5
+  - 1.5.1
   - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4
+  - 1.4.2
   - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-
+sudo: true
 install: "pip install --user -r requirements-dev.txt"
 go:
   - 1.4.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: go
 sudo: true
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4.3
+  - 1.5
   - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4
+  - 1.5.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: go
-sudo: true
+
 install: "pip install --user -r requirements-dev.txt"
 go:
   - 1.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4.2
+  - 1.4.3
   - 1.5.2

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ please fix them before opening a pull request.
 
 Running `make` should build the fullerite go binary and place it in the `bin` directory.
 
+#### IMPORTANT
+Due to a compiler bug in `go1.4` we advise to use `go1.4.2` and later. Otherwise you risk
+running into infinite loops when you run many go routines with many channels. Which is what we use
+for connecitng collectors to handlers.
+
 ## Building package fails or gom install fails
 
 If you have vendored external dependencies in `src/` directory or `pkg` directory from old build configuration, you should

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ please fix them before opening a pull request.
 Running `make` should build the fullerite go binary and place it in the `bin` directory.
 
 #### IMPORTANT
-Due to a compiler bug in `go1.4` we advise to use `go1.4.3` and later. Otherwise you risk
+Due to a compiler bug in `go1.4.x` we advise to use `go1.5` and later. Otherwise you risk
 running into infinite loops when you run many go routines with many channels. Which is what we use
 for connecitng collectors to handlers.
 

--- a/README.md
+++ b/README.md
@@ -71,11 +71,6 @@ please fix them before opening a pull request.
 
 Running `make` should build the fullerite go binary and place it in the `bin` directory.
 
-#### IMPORTANT
-Due to a compiler bug in `go1.4.x` we advise to use `go1.5` and later. Otherwise you risk
-running into infinite loops when you run many go routines with many channels. Which is what we use
-for connecitng collectors to handlers.
-
 ## Building package fails or gom install fails
 
 If you have vendored external dependencies in `src/` directory or `pkg` directory from old build configuration, you should

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ please fix them before opening a pull request.
 Running `make` should build the fullerite go binary and place it in the `bin` directory.
 
 #### IMPORTANT
-Due to a compiler bug in `go1.4` we advise to use `go1.4.2` and later. Otherwise you risk
+Due to a compiler bug in `go1.4` we advise to use `go1.4.3` and later. Otherwise you risk
 running into infinite loops when you run many go routines with many channels. Which is what we use
 for connecitng collectors to handlers.
 

--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -353,6 +353,7 @@ class Collector(object):
             'dimensions': {
                 'prefix': metric.getPathPrefix(),
                 'collector': metric.getCollectorPath(),
+                'collectorCanonicalName': self.name,
             }
         }
 

--- a/src/fullerite/collector/collector_test.go
+++ b/src/fullerite/collector/collector_test.go
@@ -2,15 +2,17 @@ package collector
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNew(t *testing.T) {
-	names := []string{"Test", "Diamond", "Fullerite", "ProcStatus"}
+	names := []string{"Test", "Diamond", "Fullerite", "ProcStatus", "ProcStatus Instance2"}
 	for _, name := range names {
 		c := New(name)
+		name = strings.Split(name, " ")[0]
 		assert.NotNil(t, c, "should create a Collector for "+name)
 		assert.Equal(t, name, c.Name())
 		assert.Equal(

--- a/src/fullerite/collector_hook_test.go
+++ b/src/fullerite/collector_hook_test.go
@@ -23,7 +23,7 @@ func TestCollectorLogsErrors(t *testing.T) {
 	testCol.Configure(config)
 
 	timeout := time.Duration(5 * time.Second)
-	h := handler.NewSignalFx(channel, 10, 10, timeout, testLogger)
+	h := handler.NewTest(channel, 10, 10, timeout, testLogger)
 
 	hook := NewLogErrorHook([]handler.Handler{h})
 	testLogger.Logger.Hooks.Add(hook)

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -79,7 +79,7 @@ func runCollector(collector collector.Collector) {
 }
 
 func readFromCollectors(collectors []collector.Collector, handlers []handler.Handler) {
-	for i, _ := range collectors {
+	for i := range collectors {
 		go readFromCollector(collectors[i], handlers)
 	}
 }
@@ -99,7 +99,7 @@ func readFromCollector(collector collector.Collector, handlers []handler.Handler
 			metric.RemoveDimension("collectorCanonicalName")
 		}
 
-		for i, _ := range handlers {
+		for i := range handlers {
 			if _, exists := handlers[i].CollectorChannels()[c]; exists {
 				handlers[i].CollectorChannels()[c] <- metric
 			}

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -79,7 +79,7 @@ func runCollector(collector collector.Collector) {
 }
 
 func readFromCollectors(collectors []collector.Collector, handlers []handler.Handler) {
-	for i := range collectors {
+	for i, _ := range collectors {
 		go readFromCollector(collectors[i], handlers)
 	}
 }
@@ -99,9 +99,9 @@ func readFromCollector(collector collector.Collector, handlers []handler.Handler
 			metric.RemoveDimension("collectorCanonicalName")
 		}
 
-		for i := range handlers {
-			if ch, exists := handlers[i].CollectorChannels()[c]; exists {
-				ch <- metric
+		for i, _ := range handlers {
+			if _, exists := handlers[i].CollectorChannels()[c]; exists {
+				handlers[i].CollectorChannels()[c] <- metric
 			}
 		}
 	}

--- a/src/fullerite/handler/datadog.go
+++ b/src/fullerite/handler/datadog.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("Datadog", NewDatadog)
+	RegisterHandler("Datadog", newDatadog)
 }
 
 // Datadog handler
@@ -39,8 +39,8 @@ type datadogMetric struct {
 
 type datadogPoint [2]float64
 
-// NewDatadog returns a new Datadog handler
-func NewDatadog(
+// newDatadog returns a new Datadog handler
+func newDatadog(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/datadog.go
+++ b/src/fullerite/handler/datadog.go
@@ -14,6 +14,10 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
+func init() {
+	RegisterHandler("Datadog", NewDatadog)
+}
+
 // Datadog handler
 type Datadog struct {
 	BaseHandler
@@ -41,7 +45,7 @@ func NewDatadog(
 	initialInterval int,
 	initialBufferSize int,
 	initialTimeout time.Duration,
-	log *l.Entry) *Datadog {
+	log *l.Entry) Handler {
 
 	inst := new(Datadog)
 	inst.name = "Datadog"
@@ -70,7 +74,7 @@ func (d *Datadog) Configure(configMap map[string]interface{}) {
 }
 
 // Endpoint returns the Datadog API endpoint
-func (d *Datadog) Endpoint() string {
+func (d Datadog) Endpoint() string {
 	return d.endpoint
 }
 
@@ -153,11 +157,11 @@ func (d *Datadog) emitMetrics(metrics []metric.Metric) bool {
 	return false
 }
 
-func (d *Datadog) dialTimeout(network, addr string) (net.Conn, error) {
+func (d Datadog) dialTimeout(network, addr string) (net.Conn, error) {
 	return net.DialTimeout(network, addr, d.timeout)
 }
 
-func (d *Datadog) serializedDimensions(m metric.Metric) (dimensions []string) {
+func (d Datadog) serializedDimensions(m metric.Metric) (dimensions []string) {
 	for name, value := range m.GetDimensions(d.DefaultDimensions()) {
 		dimensions = append(dimensions, name+":"+value)
 	}

--- a/src/fullerite/handler/datadog_test.go
+++ b/src/fullerite/handler/datadog_test.go
@@ -15,7 +15,7 @@ func getTestDataDogHandler(interval, buffsize, timeoutsec int) *Datadog {
 	testLog := l.WithField("testing", "datadog_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewDatadog(testChannel, interval, buffsize, timeout, testLog).(*Datadog)
+	return newDatadog(testChannel, interval, buffsize, timeout, testLog).(*Datadog)
 }
 
 func TestDatadogConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/datadog_test.go
+++ b/src/fullerite/handler/datadog_test.go
@@ -15,7 +15,7 @@ func getTestDataDogHandler(interval, buffsize, timeoutsec int) *Datadog {
 	testLog := l.WithField("testing", "datadog_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewDatadog(testChannel, interval, buffsize, timeout, testLog)
+	return NewDatadog(testChannel, interval, buffsize, timeout, testLog).(*Datadog)
 }
 
 func TestDatadogConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/graphite.go
+++ b/src/fullerite/handler/graphite.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("Graphite", NewGraphite)
+	RegisterHandler("Graphite", newGraphite)
 }
 
 // Graphite type
@@ -21,8 +21,8 @@ type Graphite struct {
 	port   string
 }
 
-// NewGraphite returns a new Graphite handler.
-func NewGraphite(
+// newGraphite returns a new Graphite handler.
+func newGraphite(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/graphite.go
+++ b/src/fullerite/handler/graphite.go
@@ -10,6 +10,10 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
+func init() {
+	RegisterHandler("Graphite", NewGraphite)
+}
+
 // Graphite type
 type Graphite struct {
 	BaseHandler
@@ -23,7 +27,7 @@ func NewGraphite(
 	initialInterval int,
 	initialBufferSize int,
 	initialTimeout time.Duration,
-	log *l.Entry) *Graphite {
+	log *l.Entry) Handler {
 
 	inst := new(Graphite)
 	inst.name = "Graphite"
@@ -38,12 +42,12 @@ func NewGraphite(
 }
 
 // Server returns the Graphite server's name or IP
-func (g *Graphite) Server() string {
+func (g Graphite) Server() string {
 	return g.server
 }
 
 // Port returns the Graphite server's port number
-func (g *Graphite) Port() string {
+func (g Graphite) Port() string {
 	return g.port
 }
 
@@ -68,7 +72,7 @@ func (g *Graphite) Run() {
 	g.run(g.emitMetrics)
 }
 
-func (g *Graphite) convertToGraphite(incomingMetric metric.Metric) (datapoint string) {
+func (g Graphite) convertToGraphite(incomingMetric metric.Metric) (datapoint string) {
 	//orders dimensions so datapoint keeps consistent name
 	var keys []string
 	dimensions := incomingMetric.GetDimensions(g.DefaultDimensions())

--- a/src/fullerite/handler/graphite_test.go
+++ b/src/fullerite/handler/graphite_test.go
@@ -15,7 +15,7 @@ func getTestGraphiteHandler(interval, buffsize, timeoutsec int) *Graphite {
 	testLog := l.WithField("testing", "graphite_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewGraphite(testChannel, interval, buffsize, timeout, testLog).(*Graphite)
+	return newGraphite(testChannel, interval, buffsize, timeout, testLog).(*Graphite)
 }
 
 func TestGraphiteConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/graphite_test.go
+++ b/src/fullerite/handler/graphite_test.go
@@ -15,7 +15,7 @@ func getTestGraphiteHandler(interval, buffsize, timeoutsec int) *Graphite {
 	testLog := l.WithField("testing", "graphite_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewGraphite(testChannel, interval, buffsize, timeout, testLog)
+	return NewGraphite(testChannel, interval, buffsize, timeout, testLog).(*Graphite)
 }
 
 func TestGraphiteConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -393,10 +393,10 @@ func (base *BaseHandler) run(emitFunc func([]metric.Metric) bool) {
 	emissionResults := make(chan emissionTiming)
 	go base.recordEmissions(emissionResults)
 
+	go base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
 	for _, v := range base.CollectorChannels() {
 		go base.listenForMetrics(emitFunc, v, emissionResults)
 	}
-	go base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
 }
 
 func (base *BaseHandler) listenForMetrics(
@@ -442,7 +442,7 @@ func (base *BaseHandler) recordEmissions(timingsChannel chan emissionTiming) {
 
 		base.emissionTimes.PushBack(timing)
 
-		// now kull the list of old times, iterate through the list until we find
+		// now kill the list of old times, iterate through the list until we find
 		// a timestamp that is within the interval
 		minTime := now.Add(time.Duration(-1*base.interval) * time.Second)
 		toRemove := []*list.Element{}

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -395,10 +395,10 @@ func (base *BaseHandler) run(emitFunc func([]metric.Metric) bool) {
 	emissionResults := make(chan emissionTiming)
 	go base.recordEmissions(emissionResults)
 
+	go base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
 	for k := range base.CollectorChannels() {
 		go base.listenForMetrics(emitFunc, base.CollectorChannels()[k], emissionResults)
 	}
-	base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
 }
 
 func (base *BaseHandler) listenForMetrics(

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -188,7 +188,10 @@ func (base BaseHandler) CollectorChannels() map[string]chan metric.Metric {
 
 // SetCollectorChannels : the channels to handler listens for metrics on
 func (base *BaseHandler) SetCollectorChannels(c map[string]chan metric.Metric) {
-	base.collectorChannels = c
+	base.collectorChannels = make(map[string]chan metric.Metric)
+	for name, channel := range c {
+		base.collectorChannels[name] = channel
+	}
 }
 
 // Name : the name of the handler
@@ -292,7 +295,7 @@ func (base *BaseHandler) InitListeners(globalConfig config.Config) {
 				continue
 			}
 		}
-		collectorChannels[c] = make(chan metric.Metric)
+		collectorChannels[c] = make(chan metric.Metric, 1)
 	}
 	base.SetCollectorChannels(collectorChannels)
 }

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -396,7 +396,7 @@ func (base *BaseHandler) run(emitFunc func([]metric.Metric) bool) {
 	go base.recordEmissions(emissionResults)
 
 	go base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
-	for k, _ := range base.CollectorChannels() {
+	for k := range base.CollectorChannels() {
 		go base.listenForMetrics(emitFunc, base.CollectorChannels()[k], emissionResults)
 	}
 }

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -417,7 +417,7 @@ func (base *BaseHandler) listenForMetrics(
 		case incomingMetric := <-c:
 			base.log.Debug(base.Name(), " metric: ", incomingMetric)
 			metrics = append(metrics, incomingMetric)
-			currentBufferSize += 1
+			currentBufferSize++
 
 			if int(currentBufferSize) >= base.MaxBufferSize() {
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
@@ -455,8 +455,8 @@ func (base *BaseHandler) recordEmissions(timingsChannel <-chan emissionTiming) {
 			toRemove = append(toRemove, e)
 		}
 
-		for _, entry := range toRemove {
-			base.emissionTimes.Remove(entry)
+		for i := range toRemove {
+			base.emissionTimes.Remove(toRemove[i])
 		}
 		base.log.Debug("We removed ", len(toRemove), " entries and now have ", base.emissionTimes.Len())
 	}

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"container/list"
 	"fmt"
+	"strings"
 	"time"
 
 	l "github.com/Sirupsen/logrus"
@@ -39,11 +40,16 @@ func New(name string) Handler {
 	handlerLog := defaultLog.WithFields(l.Fields{"handler": name})
 	timeout := time.Duration(DefaultTimeoutSec * time.Second)
 
-	if f, exists := handlerConstructs[name]; exists {
+	// This allows for initiating multiple handlers of the same type
+	// but with a different canonical name so they can receive different
+	// configs
+	realName := strings.Split(name, " ")[0]
+
+	if f, exists := handlerConstructs[realName]; exists {
 		return f(channel, DefaultInterval, DefaultBufferSize, timeout, handlerLog)
 	}
 
-	defaultLog.Error("Cannot create handler ", name)
+	defaultLog.Error("Cannot create handler ", realName)
 	return nil
 }
 

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -396,8 +396,8 @@ func (base *BaseHandler) run(emitFunc func([]metric.Metric) bool) {
 	go base.recordEmissions(emissionResults)
 
 	go base.listenForMetrics(emitFunc, base.Channel(), emissionResults)
-	for _, v := range base.CollectorChannels() {
-		go base.listenForMetrics(emitFunc, v, emissionResults)
+	for k, _ := range base.CollectorChannels() {
+		go base.listenForMetrics(emitFunc, base.CollectorChannels()[k], emissionResults)
 	}
 }
 

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -393,7 +393,7 @@ func (base *BaseHandler) run(emitFunc func([]metric.Metric) bool) {
 	for _, v := range base.CollectorChannels() {
 		go base.listenForMetrics(emitFunc, v)
 	}
-	base.listenForMetrics(emitFunc, base.Channel())
+	go base.listenForMetrics(emitFunc, base.Channel())
 }
 
 func (base *BaseHandler) listenForMetrics(emitFunc func([]metric.Metric) bool, c chan metric.Metric) {

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -102,7 +102,7 @@ func TestEmissionAndRecord(t *testing.T) {
 	metrics := []metric.Metric{metric.New("example")}
 
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler")
+	base.log = l.WithField("testing", "basehandler_emit")
 	go base.emitAndTime(metrics, emitFunc, callbackChannel)
 
 	select {
@@ -121,7 +121,7 @@ func TestEmissionAndRecord(t *testing.T) {
 
 func TestRecordTimings(t *testing.T) {
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler")
+	base.log = l.WithField("testing", "basehandler_record")
 	base.interval = 2
 
 	minusFiveSec := -1 * 5 * time.Second
@@ -184,7 +184,7 @@ func TestHandlerRunFlushInterval(t *testing.T) {
 
 func TestHandlerRun(t *testing.T) {
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler")
+	base.log = l.WithField("testing", "basehandler_run")
 	base.interval = 1
 	base.maxBufferSize = 1
 	base.channel = make(chan metric.Metric)

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -143,7 +143,7 @@ func TestRecordTimings(t *testing.T) {
 
 func TestHandlerRunFlushInterval(t *testing.T) {
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler")
+	base.log = l.WithField("testing", "basehandler_flush")
 	base.interval = 1
 	base.maxBufferSize = 2
 	base.channel = make(chan metric.Metric)
@@ -152,6 +152,10 @@ func TestHandlerRunFlushInterval(t *testing.T) {
 	emitCalledTwice := false
 	emitCalledThrice := false
 	emitFunc := func(metrics []metric.Metric) bool {
+		if emitCalledOnce && emitCalledTwice {
+			emitCalledThrice = true
+			close(base.channel)
+		}
 		if emitCalledOnce && !emitCalledTwice {
 			assert.Equal(t, 1, len(metrics))
 			emitCalledTwice = true
@@ -176,8 +180,6 @@ func TestHandlerRunFlushInterval(t *testing.T) {
 	assert.Equal(t, uint64(3), base.metricsSent)
 	assert.Equal(t, uint64(0), base.metricsDropped)
 	assert.Equal(t, uint64(2), base.totalEmissions)
-	assertEmpty(t, base.channel)
-	base.channel = nil
 }
 
 func TestHandlerRun(t *testing.T) {

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -143,7 +143,7 @@ func TestRecordTimings(t *testing.T) {
 
 func TestHandlerRunFlushInterval(t *testing.T) {
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler")
+	base.log = l.WithField("testing", "basehandler_flush")
 	base.interval = 1
 	base.maxBufferSize = 2
 	base.channel = make(chan metric.Metric)

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -143,7 +143,7 @@ func TestRecordTimings(t *testing.T) {
 
 func TestHandlerRunFlushInterval(t *testing.T) {
 	base := BaseHandler{}
-	base.log = l.WithField("testing", "basehandler_flush")
+	base.log = l.WithField("testing", "basehandler")
 	base.interval = 1
 	base.maxBufferSize = 2
 	base.channel = make(chan metric.Metric)

--- a/src/fullerite/handler/kairos.go
+++ b/src/fullerite/handler/kairos.go
@@ -17,7 +17,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("Kairos", NewKairos)
+	RegisterHandler("Kairos", newKairos)
 }
 
 // Kairos handler
@@ -36,8 +36,8 @@ type KairosMetric struct {
 	Tags       map[string]string `json:"tags"`
 }
 
-// NewKairos returns a new Kairos handler
-func NewKairos(
+// newKairos returns a new Kairos handler
+func newKairos(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/kairos.go
+++ b/src/fullerite/handler/kairos.go
@@ -16,6 +16,10 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
+func init() {
+	RegisterHandler("Kairos", NewKairos)
+}
+
 // Kairos handler
 type Kairos struct {
 	BaseHandler
@@ -38,7 +42,7 @@ func NewKairos(
 	initialInterval int,
 	initialBufferSize int,
 	initialTimeout time.Duration,
-	log *l.Entry) *Kairos {
+	log *l.Entry) Handler {
 
 	inst := new(Kairos)
 	inst.name = "Kairos"
@@ -69,12 +73,12 @@ func (k *Kairos) Configure(configMap map[string]interface{}) {
 }
 
 // Server returns the Kairos server's hostname or IP address
-func (k *Kairos) Server() string {
+func (k Kairos) Server() string {
 	return k.server
 }
 
 // Port returns the Kairos server's port number
-func (k *Kairos) Port() string {
+func (k Kairos) Port() string {
 	return k.port
 }
 
@@ -83,7 +87,7 @@ func (k *Kairos) Run() {
 	k.run(k.emitMetrics)
 }
 
-func (k *Kairos) convertToKairos(incomingMetric metric.Metric) (datapoint KairosMetric) {
+func (k Kairos) convertToKairos(incomingMetric metric.Metric) (datapoint KairosMetric) {
 	km := new(KairosMetric)
 	km.Name = k.Prefix() + incomingMetric.Name
 	km.Value = incomingMetric.Value
@@ -154,11 +158,11 @@ func (k *Kairos) emitMetrics(metrics []metric.Metric) bool {
 	return false
 }
 
-func (k *Kairos) dialTimeout(network, addr string) (net.Conn, error) {
+func (k Kairos) dialTimeout(network, addr string) (net.Conn, error) {
 	return net.DialTimeout(network, addr, k.timeout)
 }
 
-func (k *Kairos) parseServerError(errMsg string, metrics []KairosMetric) string {
+func (k Kairos) parseServerError(errMsg string, metrics []KairosMetric) string {
 	re, err := regexp.Compile(`metric\[([0-9]+)\]`)
 	if err != nil {
 		return ""

--- a/src/fullerite/handler/kairos_test.go
+++ b/src/fullerite/handler/kairos_test.go
@@ -21,7 +21,7 @@ func getTestKairosHandler(interval, buffsize, timeoutsec int) *Kairos {
 	testLog := l.WithField("testing", "kairos_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewKairos(testChannel, interval, buffsize, timeout, testLog).(*Kairos)
+	return newKairos(testChannel, interval, buffsize, timeout, testLog).(*Kairos)
 }
 
 func TestKairosConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/kairos_test.go
+++ b/src/fullerite/handler/kairos_test.go
@@ -21,7 +21,7 @@ func getTestKairosHandler(interval, buffsize, timeoutsec int) *Kairos {
 	testLog := l.WithField("testing", "kairos_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewKairos(testChannel, interval, buffsize, timeout, testLog)
+	return NewKairos(testChannel, interval, buffsize, timeout, testLog).(*Kairos)
 }
 
 func TestKairosConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/log.go
+++ b/src/fullerite/handler/log.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("Log", NewLog)
+	RegisterHandler("Log", newLog)
 }
 
 // Log type
@@ -19,8 +19,8 @@ type Log struct {
 	BaseHandler
 }
 
-// NewLog returns a new Debug handler.
-func NewLog(
+// newLog returns a new Debug handler.
+func newLog(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/log.go
+++ b/src/fullerite/handler/log.go
@@ -5,9 +5,14 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 )
+
+func init() {
+	RegisterHandler("Log", NewLog)
+}
 
 // Log type
 type Log struct {
@@ -19,7 +24,8 @@ func NewLog(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,
-	log *l.Entry) *Log {
+	initialTimeout time.Duration,
+	log *l.Entry) Handler {
 
 	inst := new(Log)
 	inst.name = "Log"
@@ -42,7 +48,7 @@ func (h *Log) Run() {
 	h.run(h.emitMetrics)
 }
 
-func (h *Log) convertToLog(incomingMetric metric.Metric) (string, error) {
+func (h Log) convertToLog(incomingMetric metric.Metric) (string, error) {
 	jsonOut, err := json.Marshal(incomingMetric)
 	return string(jsonOut), err
 }

--- a/src/fullerite/handler/log_test.go
+++ b/src/fullerite/handler/log_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fullerite/metric"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -12,7 +13,7 @@ func getTestLogHandler(interval int, buffsize int) *Log {
 	testChannel := make(chan metric.Metric)
 	testLog := l.WithField("testing", "log_handler")
 
-	return NewLog(testChannel, interval, buffsize, testLog)
+	return NewLog(testChannel, interval, buffsize, time.Duration(1)*time.Second, testLog).(*Log)
 }
 
 func TestLogConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/log_test.go
+++ b/src/fullerite/handler/log_test.go
@@ -13,7 +13,7 @@ func getTestLogHandler(interval int, buffsize int) *Log {
 	testChannel := make(chan metric.Metric)
 	testLog := l.WithField("testing", "log_handler")
 
-	return NewLog(testChannel, interval, buffsize, time.Duration(1)*time.Second, testLog).(*Log)
+	return newLog(testChannel, interval, buffsize, time.Duration(1)*time.Second, testLog).(*Log)
 }
 
 func TestLogConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/scribe.go
+++ b/src/fullerite/handler/scribe.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("Scribe", NewScribe)
+	RegisterHandler("Scribe", newScribe)
 }
 
 type fulleriteScribeClient interface {
@@ -45,8 +45,8 @@ const (
 	defaultScribeStreamName = "fullerite_to_scribe"
 )
 
-// NewScribe returns a new Scribe handler.
-func NewScribe(
+// newScribe returns a new Scribe handler.
+func newScribe(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/scribe.go
+++ b/src/fullerite/handler/scribe.go
@@ -14,6 +14,10 @@ import (
 	"github.com/samuel/go-thrift/thrift"
 )
 
+func init() {
+	RegisterHandler("Scribe", NewScribe)
+}
+
 type fulleriteScribeClient interface {
 	Log(Messages []*scribe.LogEntry) (scribe.ResultCode, error)
 }
@@ -47,7 +51,7 @@ func NewScribe(
 	initialInterval int,
 	initialBufferSize int,
 	initialTimeout time.Duration,
-	log *l.Entry) *Scribe {
+	log *l.Entry) Handler {
 
 	inst := new(Scribe)
 	inst.name = "Scribe"
@@ -135,7 +139,7 @@ func (s *Scribe) emitMetrics(metrics []metric.Metric) bool {
 	return true
 }
 
-func (s *Scribe) createScribeMetric(m metric.Metric) scribeMetric {
+func (s Scribe) createScribeMetric(m metric.Metric) scribeMetric {
 	return scribeMetric{
 		Name:       m.Name,
 		Value:      m.Value,

--- a/src/fullerite/handler/scribe_test.go
+++ b/src/fullerite/handler/scribe_test.go
@@ -17,7 +17,7 @@ func getTestScribeHandler(interval, buffsize, timeoutsec int) *Scribe {
 	testLog := l.WithField("testing", "scribe_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewScribe(testChannel, interval, buffsize, timeout, testLog).(*Scribe)
+	return newScribe(testChannel, interval, buffsize, timeout, testLog).(*Scribe)
 }
 
 type MockScribeClient struct {

--- a/src/fullerite/handler/scribe_test.go
+++ b/src/fullerite/handler/scribe_test.go
@@ -17,7 +17,7 @@ func getTestScribeHandler(interval, buffsize, timeoutsec int) *Scribe {
 	testLog := l.WithField("testing", "scribe_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewScribe(testChannel, interval, buffsize, timeout, testLog)
+	return NewScribe(testChannel, interval, buffsize, timeout, testLog).(*Scribe)
 }
 
 type MockScribeClient struct {

--- a/src/fullerite/handler/signalfx.go
+++ b/src/fullerite/handler/signalfx.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	RegisterHandler("SignalFx", NewSignalFx)
+	RegisterHandler("SignalFx", newSignalFx)
 }
 
 // SignalFx Handler
@@ -23,8 +23,8 @@ type SignalFx struct {
 	httpClient *util.HTTPAlive
 }
 
-// NewSignalFx returns a new SignalFx handler.
-func NewSignalFx(
+// newSignalFx returns a new SignalFx handler.
+func newSignalFx(
 	channel chan metric.Metric,
 	initialInterval int,
 	initialBufferSize int,

--- a/src/fullerite/handler/signalfx.go
+++ b/src/fullerite/handler/signalfx.go
@@ -11,6 +11,10 @@ import (
 	"github.com/golang/protobuf/proto"
 )
 
+func init() {
+	RegisterHandler("SignalFx", NewSignalFx)
+}
+
 // SignalFx Handler
 type SignalFx struct {
 	BaseHandler
@@ -25,7 +29,7 @@ func NewSignalFx(
 	initialInterval int,
 	initialBufferSize int,
 	initialTimeout time.Duration,
-	log *l.Entry) *SignalFx {
+	log *l.Entry) Handler {
 
 	inst := new(SignalFx)
 	inst.name = "SignalFx"
@@ -58,7 +62,7 @@ func (s *SignalFx) Configure(configMap map[string]interface{}) {
 }
 
 // Endpoint returns SignalFx' API endpoint
-func (s *SignalFx) Endpoint() string {
+func (s SignalFx) Endpoint() string {
 	return s.endpoint
 }
 
@@ -73,7 +77,7 @@ func (s *SignalFx) Run() {
 	s.run(s.emitMetrics)
 }
 
-func (s *SignalFx) convertToProto(incomingMetric metric.Metric) *DataPoint {
+func (s SignalFx) convertToProto(incomingMetric metric.Metric) *DataPoint {
 	// Create a new values for the Datapoint that requires pointers.
 	outname := s.Prefix() + incomingMetric.Name
 	value := incomingMetric.Value

--- a/src/fullerite/handler/signalfx_test.go
+++ b/src/fullerite/handler/signalfx_test.go
@@ -19,7 +19,7 @@ func getTestSignalfxHandler(interval, buffsize, timeoutsec int) *SignalFx {
 	testLog := l.WithField("testing", "signalfx_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewSignalFx(testChannel, interval, buffsize, timeout, testLog)
+	return NewSignalFx(testChannel, interval, buffsize, timeout, testLog).(*SignalFx)
 }
 
 func TestSignalfxConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/signalfx_test.go
+++ b/src/fullerite/handler/signalfx_test.go
@@ -19,7 +19,7 @@ func getTestSignalfxHandler(interval, buffsize, timeoutsec int) *SignalFx {
 	testLog := l.WithField("testing", "signalfx_handler")
 	timeout := time.Duration(timeoutsec) * time.Second
 
-	return NewSignalFx(testChannel, interval, buffsize, timeout, testLog).(*SignalFx)
+	return newSignalFx(testChannel, interval, buffsize, timeout, testLog).(*SignalFx)
 }
 
 func TestSignalfxConfigureEmptyConfig(t *testing.T) {

--- a/src/fullerite/handler/test.go
+++ b/src/fullerite/handler/test.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"fullerite/metric"
+
+	"time"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+// Test type
+type Test struct {
+	BaseHandler
+}
+
+// NewTest returns a new Test handler.
+func NewTest(
+	channel chan metric.Metric,
+	initialInterval int,
+	initialBufferSize int,
+	initialTimeout time.Duration,
+	log *l.Entry) Handler {
+
+	inst := new(Test)
+	inst.name = "Test"
+
+	inst.interval = initialInterval
+	inst.maxBufferSize = initialBufferSize
+	inst.log = log
+	inst.channel = channel
+
+	return inst
+}
+
+// Configure accepts the different configuration options for the Test handler
+func (h *Test) Configure(configMap map[string]interface{}) {
+	h.configureCommonParams(configMap)
+}
+
+// Run runs the handler main loop
+func (h *Test) Run() {
+	h.run(h.emitMetrics)
+}
+
+func (h *Test) emitMetrics(metrics []metric.Metric) bool {
+	h.log.Info("Starting to emit ", len(metrics), " metrics")
+
+	if len(metrics) == 0 {
+		h.log.Warn("Skipping send because of an empty payload")
+		return false
+	}
+
+	return true
+}

--- a/src/fullerite/handlers.go
+++ b/src/fullerite/handlers.go
@@ -37,7 +37,7 @@ func startHandler(name string, globalConfig config.Config, instanceConfig map[st
 }
 
 func writeToHandlers(handlers []handler.Handler, metric metric.Metric) {
-	for _, handler := range handlers {
-		handler.Channel() <- metric
+	for i, _ := range handlers {
+		handlers[i].Channel() <- metric
 	}
 }

--- a/src/fullerite/handlers.go
+++ b/src/fullerite/handlers.go
@@ -37,7 +37,7 @@ func startHandler(name string, globalConfig config.Config, instanceConfig map[st
 }
 
 func writeToHandlers(handlers []handler.Handler, metric metric.Metric) {
-	for i, _ := range handlers {
+	for i := range handlers {
 		handlers[i].Channel() <- metric
 	}
 }

--- a/src/fullerite/handlers.go
+++ b/src/fullerite/handlers.go
@@ -29,38 +29,15 @@ func startHandler(name string, globalConfig config.Config, instanceConfig map[st
 	// now apply the handler level configs
 	handlerInst.Configure(instanceConfig)
 
+	// now run a listener channel for each collector
+	handlerInst.InitListeners(globalConfig)
+
 	go handlerInst.Run()
 	return handlerInst
 }
 
 func writeToHandlers(handlers []handler.Handler, metric metric.Metric) {
 	for _, handler := range handlers {
-		if canSendMetric(handler, metric) {
-			handler.Channel() <- metric
-		}
+		handler.Channel() <- metric
 	}
-}
-
-func canSendMetric(handler handler.Handler, metric metric.Metric) bool {
-	// If the handler's whitelist is set, then only metrics from collectors in it will be emitted. If the same
-	// collector is also in the blacklist, it will be skipped.
-	// If the handler's whitelist is not set and its blacklist is not empty, only metrics from collectors not in
-	// the blacklist will be emitted.
-	value, _ := metric.GetDimensionValue("collector")
-	isWhiteListed, _ := handler.IsCollectorWhiteListed(value)
-	isBlackListed, _ := handler.IsCollectorBlackListed(value)
-
-	// If the handler's whitelist is not nil and not empty, only the whitelisted collectors should be considered
-	if handler.CollectorWhiteList() != nil && len(handler.CollectorWhiteList()) > 0 {
-		if isWhiteListed && !isBlackListed {
-			return true
-		}
-		return false
-	}
-
-	// If the handler's whitelist is nil, all collector except the ones in the blacklist are enabled
-	if !isBlackListed {
-		return true
-	}
-	return false
 }

--- a/src/fullerite/handlers_test.go
+++ b/src/fullerite/handlers_test.go
@@ -36,16 +36,13 @@ func checkEmission(t *testing.T, coll string, h handler.Handler, expected bool) 
 		Dimensions: map[string]string{"collector": coll},
 	}
 	writeToHandlers([]handler.Handler{h}, m)
-
-	select {
-	case res := <-h.Channel():
-		if !expected {
-			assert.Fail(t, fmt.Sprintf("Did not expect metric %s", res.Name))
-		}
-	default:
-		if expected {
-			assert.Fail(t, "Was expecting the metric to go through")
-		}
+	ch, _ := h.CollectorChannels()[coll]
+	fmt.Println(h.CollectorChannels(), ch)
+	if !expected && ch != nil {
+		assert.Fail(t, fmt.Sprintf("Was not expecting a collector channel for %s", coll))
+	}
+	if expected && ch == nil {
+		assert.Fail(t, fmt.Sprintf("Was expecting a collector channel for %s", coll))
 	}
 }
 
@@ -56,9 +53,12 @@ func TestCanSendMetricsWhiteList(t *testing.T) {
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
 	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
-
+	c := config.Config{
+		Collectors: []string{"coll1", "coll2", "coll3"},
+	}
 	h.SetCollectorWhiteList([]string{"coll1", "coll2"})
 	h.SetCollectorBlackList([]string{"coll2"})
+	h.InitListeners(c)
 
 	checkEmission(t, "coll1", h, true)
 	checkEmission(t, "coll2", h, false)
@@ -72,8 +72,11 @@ func TestCanSendMetricsOnlyBlackList(t *testing.T) {
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
 	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
-
+	c := config.Config{
+		Collectors: []string{"coll1", "coll2", "coll3"},
+	}
 	h.SetCollectorBlackList([]string{"coll2"})
+	h.InitListeners(c)
 
 	checkEmission(t, "coll1", h, true)
 	checkEmission(t, "coll2", h, false)
@@ -87,6 +90,10 @@ func TestCanSendMetrics(t *testing.T) {
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
 	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
+	c := config.Config{
+		Collectors: []string{"coll1", "coll2", "coll3"},
+	}
+	h.InitListeners(c)
 
 	checkEmission(t, "coll1", h, true)
 	checkEmission(t, "coll2", h, true)

--- a/src/fullerite/handlers_test.go
+++ b/src/fullerite/handlers_test.go
@@ -37,7 +37,6 @@ func checkEmission(t *testing.T, coll string, h handler.Handler, expected bool) 
 	}
 	writeToHandlers([]handler.Handler{h}, m)
 	ch, _ := h.CollectorChannels()[coll]
-	fmt.Println(h.CollectorChannels(), ch)
 	if !expected && ch != nil {
 		assert.Fail(t, fmt.Sprintf("Was not expecting a collector channel for %s", coll))
 	}

--- a/src/fullerite/handlers_test.go
+++ b/src/fullerite/handlers_test.go
@@ -52,7 +52,7 @@ func TestCanSendMetricsWhiteList(t *testing.T) {
 	channel := make(chan metric.Metric, 5)
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
-	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
+	h := handler.NewTest(channel, 10, 10, timeout, log)
 	c := config.Config{
 		Collectors: []string{"coll1", "coll2", "coll3"},
 	}
@@ -71,7 +71,7 @@ func TestCanSendMetricsOnlyBlackList(t *testing.T) {
 	channel := make(chan metric.Metric, 5)
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
-	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
+	h := handler.NewTest(channel, 10, 10, timeout, log)
 	c := config.Config{
 		Collectors: []string{"coll1", "coll2", "coll3"},
 	}
@@ -89,7 +89,7 @@ func TestCanSendMetrics(t *testing.T) {
 	channel := make(chan metric.Metric, 5)
 	timeout := time.Duration(5 * time.Second)
 	log := logrus.WithFields(logrus.Fields{"app": "fullerite", "pkg": "handler"})
-	h := handler.NewSignalFx(channel, 10, 10, timeout, log)
+	h := handler.NewTest(channel, 10, 10, timeout, log)
 	c := config.Config{
 		Collectors: []string{"coll1", "coll2", "coll3"},
 	}

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -109,6 +109,7 @@ func start(ctx *cli.Context) {
 		p := profile.Start(&pcfg)
 		defer p.Stop()
 	}
+	quit := make(chan bool)
 	initLogrus(ctx)
 	log.Info("Starting fullerite...")
 
@@ -122,13 +123,12 @@ func start(ctx *cli.Context) {
 	internalServer := internalserver.New(c, &handlers)
 	go internalServer.Run()
 
-	metrics := make(chan metric.Metric)
-	readFromCollectors(collectors, metrics)
+	readFromCollectors(collectors, handlers)
 
-	hook := NewLogErrorHook(metrics)
+	hook := NewLogErrorHook(handlers)
 	log.Logger.Hooks.Add(hook)
 
-	relayMetricsToHandlers(handlers, metrics)
+	<-quit
 }
 
 func visualize(ctx *cli.Context) {
@@ -153,15 +153,17 @@ func visualize(ctx *cli.Context) {
 
 	// Start collector and handlers
 	collector := startCollector("AdHoc", c, configMap)
+	c.Collectors = []string{}
+	c.DiamondCollectors = []string{}
 	handlers := startHandlers(c)
 
 	// Create channel for incoming metrics
-	metrics := make(chan metric.Metric)
-	defer close(metrics)
+	var metrics []chan metric.Metric
+	metrics = append(metrics, make(chan metric.Metric))
 
 	// Read the metrics from the AdHoc collector
 	go readFromCollector(collector, metrics)
-	go relayMetricsToHandlers(handlers, metrics)
+	go relayMetricsToHandlers(handlers, metrics[0])
 
 	// Stop collecting after `die-after` duration expires
 	quitChannel := make(chan bool, 1)
@@ -173,12 +175,7 @@ func visualize(ctx *cli.Context) {
 		quitChannel <- true
 	})
 	// Wait to quit
-	for {
-		select {
-		case <-quitChannel:
-			return
-		}
-	}
+	<-quitChannel
 }
 
 func relayMetricsToHandlers(handlers []handler.Handler, metrics chan metric.Metric) {

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -34,6 +34,11 @@ func (m *Metric) AddDimension(name, value string) {
 	m.Dimensions[sanitizeString(name)] = sanitizeString(value)
 }
 
+// RemoveDimension removes a dimension from the Metric.
+func (m *Metric) RemoveDimension(name string) {
+	delete(m.Dimensions, name)
+}
+
 // AddDimensions adds multiple new dimensions to the Metric.
 func (m *Metric) AddDimensions(dimensions map[string]string) {
 	for k, v := range dimensions {

--- a/src/fullerite/metric/metric_test.go
+++ b/src/fullerite/metric/metric_test.go
@@ -27,6 +27,18 @@ func TestAddDimension(t *testing.T) {
 	assert.Equal(m.Dimensions["TestDimension"], "test value")
 }
 
+func TestRemoveDimension(t *testing.T) {
+	m := metric.New("TestMetric")
+	m.AddDimension("TestDimension", "test value")
+	m.AddDimension("TestDimension1", "test value")
+
+	assert := assert.New(t)
+	assert.Equal(len(m.Dimensions), 2, "should have 2 dimensions")
+	m.RemoveDimension("TestDimension1")
+	assert.Equal(len(m.Dimensions), 1, "should have 1 dimension")
+	assert.Equal(m.Dimensions["TestDimension"], "test value")
+}
+
 func TestGetDimensionsWithNoDimensions(t *testing.T) {
 	defaultDimensions := make(map[string]string)
 	m := metric.New("TestMetric")


### PR DESCRIPTION
We have seen a lot of contention between different collectors over the
single metrics channel provided to write to handlers. Also given that
handlers were only reading on one channel we made a parallel colleciton
system eventually single threaded which killed performance and also
caused a lot of strange behaviours relating to emissions to the
different storage backends, like missing aggregation buckets which for
cumulative counters leads to saw toothed charts

This commit makes sure that each collector has a dedicated channel to
it's handlers and each handler spins off a go routine for responding to
that channel. What that eventually means is that we can tolerate any
contention raising from an aggressive collector on one channel since it
can only affect itself and its own emissions.