### PR TITLE
Add metric for total container count

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -154,6 +154,7 @@ func (d DockerStats) buildMetrics(container *docker.Container, containerStats *d
 		"container_name": strings.TrimPrefix(container.Name, "/"),
 	}
 	metric.AddToAll(&ret, additionalDimensions)
+	ret = append(ret, buildDockerMetric("DockerContainerCount", metric.Counter, 1))
 	metric.AddToAll(&ret, d.extractDimensions(container))
 
 	return ret

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -96,12 +96,18 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 		"service_name":   "my_service",
 		"instance_name":  "main",
 	}
+
+	expectedDimsGen := map[string]string{
+		"service_name":  "my_service",
+		"instance_name": "main",
+	}
 	expectedMetrics := []metric.Metric{
 		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
 		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
+		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
 	}
 
 	d := getSUT()
@@ -150,12 +156,16 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 		"container_name": "test-container",
 		"service_name":   "my_service",
 	}
+	expectedDimsGen := map[string]string{
+		"service_name": "my_service",
+	}
 	expectedMetrics := []metric.Metric{
 		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
 		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
+		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
 	}
 
 	d := getSUT()


### PR DESCRIPTION
this metric will not use the dimensions for container id and container
name since the transient nature of these fields cause itme series to
explode