### PR TITLE
Make collectors anonymous to Fullerite core

### DIFF
--- a/src/fullerite/collector/adhoc.go
+++ b/src/fullerite/collector/adhoc.go
@@ -19,8 +19,12 @@ type AdHoc struct {
 	collectorFile string
 }
 
+func init() {
+	RegisterCollector("AdHoc", newAdHoc)
+}
+
 // newAdHoc Simple constructor for an AdHoc collector
-func newAdHoc(channel chan metric.Metric, initialInterval int, log *l.Entry) *AdHoc {
+func newAdHoc(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	a := new(AdHoc)
 	a.channel = channel
 	a.interval = initialInterval
@@ -29,6 +33,7 @@ func newAdHoc(channel chan metric.Metric, initialInterval int, log *l.Entry) *Ad
 	a.name = "AdHoc"
 	currentUser, _ := user.Current()
 	a.metricPrefix = "adhoc." + currentUser.Username + "."
+	a.SetCollectorType("listener")
 	return a
 }
 

--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -28,6 +28,15 @@ type Collector interface {
 	SetCollectorType(string)
 }
 
+var collectorConstructs map[string]func(chan metric.Metric, int, *l.Entry) Collector
+
+func RegisterCollector(name string, f func(chan metric.Metric, int, *l.Entry) Collector) {
+	if collectorConstructs == nil {
+		collectorConstructs = make(map[string]func(chan metric.Metric, int, *l.Entry) Collector)
+	}
+	collectorConstructs[name] = f
+}
+
 // New creates a new Collector based on the requested collector name.
 func New(name string) Collector {
 	var collector Collector
@@ -35,38 +44,13 @@ func New(name string) Collector {
 	channel := make(chan metric.Metric)
 	collectorLog := defaultLog.WithFields(l.Fields{"collector": name})
 
-	switch name {
-	case "Test":
-		collector = NewTest(channel, DefaultCollectionInterval, collectorLog)
-	case "Diamond":
-		collector = newDiamond(channel, DefaultCollectionInterval, collectorLog)
-		collector.SetCollectorType("listener")
-	case "Fullerite":
-		collector = newFullerite(channel, DefaultCollectionInterval, collectorLog)
-	case "ProcStatus":
-		collector = newProcStatus(channel, DefaultCollectionInterval, collectorLog)
-	case "FulleriteHTTP":
-		collector = newFulleriteHTTP(channel, DefaultCollectionInterval, collectorLog)
-		collector.SetCollectorType("listener")
-	case "NerveUWSGI":
-		collector = newNerveUWSGI(channel, DefaultCollectionInterval, collectorLog)
-	case "DockerStats":
-		collector = newDockerStats(channel, DefaultCollectionInterval, collectorLog)
-	case "CPUInfo":
-		collector = newCPUInfo(channel, DefaultCollectionInterval, collectorLog)
-	case "MesosStats":
-		collector = newMesosStats(channel, DefaultCollectionInterval, collectorLog)
-	case "MesosSlaveStats":
-		collector = newMesosSlaveStats(channel, DefaultCollectionInterval, collectorLog)
-	case "MySQLBinlogGrowth":
-		collector = newMySQLBinlogGrowth(channel, DefaultCollectionInterval, collectorLog)
-	case "AdHoc":
-		collector = newAdHoc(channel, DefaultCollectionInterval, collectorLog)
-		collector.SetCollectorType("listener")
-	default:
+	if f, exists := collectorConstructs[name]; exists {
+		collector = f(channel, DefaultCollectionInterval, collectorLog)
+	} else {
 		defaultLog.Error("Cannot create collector: ", name)
 		return nil
 	}
+
 	if collector.CollectorType() == "" {
 		collector.SetCollectorType("collector")
 	}

--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -30,6 +30,7 @@ type Collector interface {
 
 var collectorConstructs map[string]func(chan metric.Metric, int, *l.Entry) Collector
 
+// Compose a map of collector names -> factor functions
 func RegisterCollector(name string, f func(chan metric.Metric, int, *l.Entry) Collector) {
 	if collectorConstructs == nil {
 		collectorConstructs = make(map[string]func(chan metric.Metric, int, *l.Entry) Collector)

--- a/src/fullerite/collector/collector.go
+++ b/src/fullerite/collector/collector.go
@@ -30,7 +30,7 @@ type Collector interface {
 
 var collectorConstructs map[string]func(chan metric.Metric, int, *l.Entry) Collector
 
-// Compose a map of collector names -> factor functions
+// RegisterCollector composes a map of collector names -> factor functions
 func RegisterCollector(name string, f func(chan metric.Metric, int, *l.Entry) Collector) {
 	if collectorConstructs == nil {
 		collectorConstructs = make(map[string]func(chan metric.Metric, int, *l.Entry) Collector)

--- a/src/fullerite/collector/cpu_info.go
+++ b/src/fullerite/collector/cpu_info.go
@@ -26,8 +26,12 @@ type CPUInfo struct {
 	procPath   string
 }
 
+func init() {
+	RegisterCollector("CPUInfo", newCPUInfo)
+}
+
 // newCPUInfo Simple constructor for CPUInfo collector
-func newCPUInfo(channel chan metric.Metric, initialInterval int, log *l.Entry) *CPUInfo {
+func newCPUInfo(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	c := new(CPUInfo)
 	c.channel = channel
 	c.interval = initialInterval

--- a/src/fullerite/collector/diamond.go
+++ b/src/fullerite/collector/diamond.go
@@ -26,8 +26,12 @@ type Diamond struct {
 	incoming      chan []byte
 }
 
+func init() {
+	RegisterCollector("Diamond", newDiamond)
+}
+
 // newDiamond creates a new Diamond collector.
-func newDiamond(channel chan metric.Metric, initialInterval int, log *l.Entry) *Diamond {
+func newDiamond(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	d := new(Diamond)
 
 	d.log = log
@@ -38,6 +42,7 @@ func newDiamond(channel chan metric.Metric, initialInterval int, log *l.Entry) *
 	d.incoming = make(chan []byte)
 	d.port = DefaultDiamondCollectorPort
 	d.serverStarted = false
+	d.SetCollectorType("listener")
 	return d
 }
 

--- a/src/fullerite/collector/diamond_test.go
+++ b/src/fullerite/collector/diamond_test.go
@@ -18,7 +18,7 @@ import (
 func TestDiamondConfigureEmptyConfig(t *testing.T) {
 	config := make(map[string]interface{})
 
-	d := newDiamond(nil, 12, nil)
+	d := newDiamond(nil, 12, nil).(*Diamond)
 	d.Configure(config)
 
 	assert.Equal(t,
@@ -32,7 +32,7 @@ func TestDiamondConfigure(t *testing.T) {
 	config := make(map[string]interface{})
 	config["interval"] = 9999
 	config["port"] = "0"
-	d := newDiamond(nil, 12, nil)
+	d := newDiamond(nil, 12, nil).(*Diamond)
 	d.Configure(config)
 
 	assert := assert.New(t)
@@ -47,7 +47,7 @@ func TestDiamondCollect(t *testing.T) {
 	testChannel := make(chan metric.Metric)
 	testLog := test_utils.BuildLogger()
 
-	d := newDiamond(testChannel, 123, testLog)
+	d := newDiamond(testChannel, 123, testLog).(*Diamond)
 	d.Configure(config)
 
 	// start collecting Diamond metrics
@@ -78,7 +78,7 @@ func TestParseJsonToMetric(t *testing.T) {
    }
 }]
         `)
-	d := newDiamond(nil, 12, nil)
+	d := newDiamond(nil, 12, nil).(*Diamond)
 	metrics, ok := d.parseMetrics(rawData)
 	assert.True(t, ok)
 	for _, metric := range metrics {
@@ -97,7 +97,7 @@ func TestInvalidJsonToMetric(t *testing.T) {
 }]
         `)
 	l := defaultLog.WithFields(l.Fields{"collector": "diamond"})
-	d := newDiamond(nil, 12, l)
+	d := newDiamond(nil, 12, l).(*Diamond)
 	_, ok := d.parseMetrics(rawData)
 	assert.False(t, ok)
 }

--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -42,8 +42,12 @@ type Regex struct {
 	regex *regexp.Regexp
 }
 
+func init() {
+	RegisterCollector("DockerStats", newDockerStats)
+}
+
 // newDockerStats creates a new DockerStats collector.
-func newDockerStats(channel chan metric.Metric, initialInterval int, log *l.Entry) *DockerStats {
+func newDockerStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	d := new(DockerStats)
 
 	d.log = log

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -16,7 +16,7 @@ func getSUT() *DockerStats {
 	expectedChan := make(chan metric.Metric)
 	var expectedLogger = defaultLog.WithFields(l.Fields{"collector": "fullerite"})
 
-	return newDockerStats(expectedChan, 10, expectedLogger)
+	return newDockerStats(expectedChan, 10, expectedLogger).(*DockerStats)
 }
 
 func TestDockerStatsNewDockerStats(t *testing.T) {
@@ -24,7 +24,7 @@ func TestDockerStatsNewDockerStats(t *testing.T) {
 	var expectedLogger = defaultLog.WithFields(l.Fields{"collector": "fullerite"})
 	expectedType := make(map[string]*CPUValues)
 
-	d := newDockerStats(expectedChan, 10, expectedLogger)
+	d := newDockerStats(expectedChan, 10, expectedLogger).(*DockerStats)
 
 	assert.Equal(t, d.log, expectedLogger)
 	assert.Equal(t, d.channel, expectedChan)
@@ -38,7 +38,7 @@ func TestDockerStatsNewDockerStats(t *testing.T) {
 func TestDockerStatsConfigureEmptyConfig(t *testing.T) {
 	config := make(map[string]interface{})
 
-	d := newDockerStats(nil, 123, nil)
+	d := newDockerStats(nil, 123, nil).(*DockerStats)
 	d.Configure(config)
 
 	assert.Equal(t, 123, d.Interval())
@@ -48,7 +48,7 @@ func TestDockerStatsConfigure(t *testing.T) {
 	config := make(map[string]interface{})
 	config["interval"] = 9999
 
-	d := newDockerStats(nil, 123, nil)
+	d := newDockerStats(nil, 123, nil).(*DockerStats)
 	d.Configure(config)
 
 	assert.Equal(t, 9999, d.Interval())

--- a/src/fullerite/collector/fullerite.go
+++ b/src/fullerite/collector/fullerite.go
@@ -16,8 +16,12 @@ type Fullerite struct {
 	memStats memStatRetriever
 }
 
+func init() {
+	RegisterCollector("Fullerite", newFullerite)
+}
+
 // newFullerite creates a new Test collector.
-func newFullerite(channel chan metric.Metric, initialInterval int, log *l.Entry) *Fullerite {
+func newFullerite(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	f := new(Fullerite)
 
 	f.log = log

--- a/src/fullerite/collector/fullerite_http.go
+++ b/src/fullerite/collector/fullerite_http.go
@@ -24,8 +24,12 @@ type fulleriteHTTP struct {
 	baseHTTPCollector
 }
 
-// newFulleriteHTTP returns a collector meant to query fullerite's HTTP interface
-func newFulleriteHTTP(channel chan metric.Metric, initialInterval int, log *l.Entry) *fulleriteHTTP {
+func init() {
+	RegisterCollector("FulleriteHTTP", newFulleriteHTTP)
+}
+
+// newFulleriteHTTPCollector returns a collector meant to query fullerite's HTTP interface
+func newFulleriteHTTP(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	inst := new(fulleriteHTTP)
 
 	inst.log = log
@@ -42,6 +46,7 @@ func newFulleriteHTTP(channel chan metric.Metric, initialInterval int, log *l.En
 
 	inst.rspHandler = inst.handleResponse
 	inst.errHandler = inst.handleError
+	inst.SetCollectorType("listener")
 
 	return inst
 }

--- a/src/fullerite/collector/fullerite_http_test.go
+++ b/src/fullerite/collector/fullerite_http_test.go
@@ -16,7 +16,7 @@ func getTestInstance() *fulleriteHTTP {
 	testChannel := make(chan metric.Metric)
 	testLog = l.WithFields(l.Fields{"testing": "fullerite_http"})
 
-	inst := newFulleriteHTTP(testChannel, 12, testLog)
+	inst := newFulleriteHTTP(testChannel, 12, testLog).(*fulleriteHTTP)
 
 	return inst
 }

--- a/src/fullerite/collector/mesos.go
+++ b/src/fullerite/collector/mesos.go
@@ -77,8 +77,12 @@ type MesosStats struct {
 	mesosCache util.MesosLeaderElectInterface
 }
 
+func init() {
+	RegisterCollector("MesosStats", newMesosStats)
+}
+
 // newMesosStats Simple constructor to set properties for the embedded baseCollector.
-func newMesosStats(channel chan metric.Metric, intialInterval int, log *l.Entry) *MesosStats {
+func newMesosStats(channel chan metric.Metric, intialInterval int, log *l.Entry) Collector {
 	m := new(MesosStats)
 
 	m.log = log

--- a/src/fullerite/collector/mesos_slave.go
+++ b/src/fullerite/collector/mesos_slave.go
@@ -50,8 +50,12 @@ type MesosSlaveStats struct {
 	snapshotPort int
 }
 
+func init() {
+	RegisterCollector("MesosSlaveStats", newMesosSlaveStats)
+}
+
 // newMesosSlaveStats Simple constructor to set properties for the embedded baseCollector.
-func newMesosSlaveStats(channel chan metric.Metric, intialInterval int, log *l.Entry) *MesosSlaveStats {
+func newMesosSlaveStats(channel chan metric.Metric, intialInterval int, log *l.Entry) Collector {
 	m := new(MesosSlaveStats)
 
 	m.log = log

--- a/src/fullerite/collector/mesos_slave_test.go
+++ b/src/fullerite/collector/mesos_slave_test.go
@@ -28,7 +28,7 @@ func TestNewMesosSlaveStats(t *testing.T) {
 	i := 10
 	l := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
 
-	sut := newMesosSlaveStats(c, i, l)
+	sut := newMesosSlaveStats(c, i, l).(*MesosSlaveStats)
 
 	assert.Equal(t, c, sut.channel)
 	assert.Equal(t, i, sut.interval)
@@ -41,7 +41,7 @@ func TestNewMesosSlaveStats(t *testing.T) {
 func TestMesosSlaveStatsConfigureDefault(t *testing.T) {
 	config := make(map[string]interface{})
 	c := make(chan metric.Metric)
-	sut := newMesosSlaveStats(c, 10, defaultLog)
+	sut := newMesosSlaveStats(c, 10, defaultLog).(*MesosSlaveStats)
 
 	sut.Configure(config)
 
@@ -56,7 +56,7 @@ func TestMesosSlaveStatsConfigure(t *testing.T) {
 		"slaveSnapshotPort": "1234",
 	}
 	c := make(chan metric.Metric)
-	sut := newMesosSlaveStats(c, 10, defaultLog)
+	sut := newMesosSlaveStats(c, 10, defaultLog).(*MesosSlaveStats)
 
 	sut.Configure(config)
 
@@ -77,7 +77,7 @@ func TestMesosSlaveStatsSendMetrics(t *testing.T) {
 	}
 
 	c := make(chan metric.Metric)
-	sut := newMesosSlaveStats(c, 10, defaultLog)
+	sut := newMesosSlaveStats(c, 10, defaultLog).(*MesosSlaveStats)
 
 	go sut.sendMetrics()
 	actual := <-c
@@ -110,7 +110,7 @@ func TestMesosSlaveStatsGetMetrics(t *testing.T) {
 
 		getSlaveMetricsURL = func(m *MesosSlaveStats, ip string) string { return ts.URL }
 
-		sut := newMesosSlaveStats(nil, 10, defaultLog)
+		sut := newMesosSlaveStats(nil, 10, defaultLog).(*MesosSlaveStats)
 		actual := sut.getSlaveMetrics(httptest.DefaultRemoteAddr)
 
 		assert.Equal(t, expected, actual)
@@ -125,7 +125,7 @@ func TestMesosSlaveStatsGetMetricsHandleErrors(t *testing.T) {
 
 	getSlaveMetricsURL = func(m *MesosSlaveStats, ip string) string { return "" }
 
-	sut := newMesosSlaveStats(nil, 10, defaultLog)
+	sut := newMesosSlaveStats(nil, 10, defaultLog).(*MesosSlaveStats)
 	actual := sut.getSlaveMetrics(httptest.DefaultRemoteAddr)
 
 	assert.Nil(t, actual, "Empty (invalid) URL, which means http client should throw an error; therefore, we expect a nil from getMetrics")
@@ -145,14 +145,14 @@ func TestMesosSlaveStatsGetMetricsHandleNon200s(t *testing.T) {
 
 	getSlaveMetricsURL = func(m *MesosSlaveStats, ip string) string { return ts.URL }
 
-	sut := newMesosSlaveStats(nil, 10, defaultLog)
+	sut := newMesosSlaveStats(nil, 10, defaultLog).(*MesosSlaveStats)
 	actual := sut.getSlaveMetrics(httptest.DefaultRemoteAddr)
 
 	assert.Nil(t, actual, "Server threw a 500, so we should expect nil from getMetrics")
 }
 
 func TestMesosSlaveStatsBuildMetric(t *testing.T) {
-	sut := newMesosSlaveStats(nil, 10, defaultLog)
+	sut := newMesosSlaveStats(nil, 10, defaultLog).(*MesosSlaveStats)
 
 	tests := []struct {
 		name       string

--- a/src/fullerite/collector/mesos_test.go
+++ b/src/fullerite/collector/mesos_test.go
@@ -43,7 +43,7 @@ func TestMesosStatsNewMesosStats(t *testing.T) {
 	i := 10
 	l := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
 
-	sut := newMesosStats(c, i, l)
+	sut := newMesosStats(c, i, l).(*MesosStats)
 
 	assert.Equal(t, c, sut.channel)
 	assert.Equal(t, i, sut.interval)
@@ -70,7 +70,7 @@ func TestMesosStatsConfigure(t *testing.T) {
 
 	for _, test := range tests {
 		config := test.config
-		sut := newMesosStats(nil, 0, defaultLog)
+		sut := newMesosStats(nil, 0, defaultLog).(*MesosStats)
 
 		assert.Nil(t, sut.mesosCache, "Before *baseCollector.Configure() is called, MesosStats.mesosCache should not be created.")
 
@@ -123,7 +123,7 @@ func TestMesosStatsCollect(t *testing.T) {
 		configMap := test.configMap
 		externalIP = func() (string, error) { return test.externalIP, nil }
 
-		sut := newMesosStats(nil, 0, defaultLog)
+		sut := newMesosStats(nil, 0, defaultLog).(*MesosStats)
 		sut.Configure(configMap)
 		sut.Collect()
 
@@ -149,7 +149,7 @@ func TestMesosStatsSendMetrics(t *testing.T) {
 	}
 
 	c := make(chan metric.Metric)
-	sut := newMesosStats(c, 10, defaultLog)
+	sut := newMesosStats(c, 10, defaultLog).(*MesosStats)
 
 	go sut.sendMetrics()
 	actual := <-c
@@ -182,7 +182,7 @@ func TestMesosStatsGetMetrics(t *testing.T) {
 
 		getMetricsURL = func(ip string) string { return ts.URL }
 
-		sut := newMesosStats(nil, 10, defaultLog)
+		sut := newMesosStats(nil, 10, defaultLog).(*MesosStats)
 		actual := getMetrics(sut, httptest.DefaultRemoteAddr)
 
 		assert.Equal(t, expected, actual)
@@ -197,7 +197,7 @@ func TestMesosStatsGetMetricsHandleErrors(t *testing.T) {
 
 	getMetricsURL = func(ip string) string { return "" }
 
-	sut := newMesosStats(nil, 10, defaultLog)
+	sut := newMesosStats(nil, 10, defaultLog).(*MesosStats)
 	actual := getMetrics(sut, httptest.DefaultRemoteAddr)
 
 	assert.Nil(t, actual, "Empty (invalid) URL, which means http client should throw an error; therefore, we expect a nil from getMetrics")
@@ -217,7 +217,7 @@ func TestMesosStatsGetMetricsHandleNon200s(t *testing.T) {
 
 	getMetricsURL = func(ip string) string { return ts.URL }
 
-	sut := newMesosStats(nil, 10, defaultLog)
+	sut := newMesosStats(nil, 10, defaultLog).(*MesosStats)
 	actual := getMetrics(sut, httptest.DefaultRemoteAddr)
 
 	assert.Nil(t, actual, "Server threw a 500, so we should expect nil from getMetrics")

--- a/src/fullerite/collector/mysql_binary_growth.go
+++ b/src/fullerite/collector/mysql_binary_growth.go
@@ -43,8 +43,12 @@ var (
 // log-bin = ../dir
 // datadir = /var/srv/dir
 
+func init() {
+	RegisterCollector("MySQLBinlogGrowth", newMySQLBinlogGrowth)
+}
+
 // newMySQLBinlogGrowth creates a new MySQLBinlogGrowth collector.
-func newMySQLBinlogGrowth(channel chan metric.Metric, initialInterval int, log *l.Entry) *MySQLBinlogGrowth {
+func newMySQLBinlogGrowth(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	// Initialize the collector struct with the default values
 	d := &MySQLBinlogGrowth{
 		baseCollector: baseCollector{

--- a/src/fullerite/collector/mysql_binary_growth_test.go
+++ b/src/fullerite/collector/mysql_binary_growth_test.go
@@ -16,14 +16,14 @@ func newMockMySQLBinlogGrowth() *MySQLBinlogGrowth {
 	c := make(chan metric.Metric, 2)
 	i := 10
 	l := defaultLog
-	return newMySQLBinlogGrowth(c, i, l)
+	return newMySQLBinlogGrowth(c, i, l).(*MySQLBinlogGrowth)
 }
 
 func TestNewMySQLBinlogGrowth(t *testing.T) {
 	c := make(chan metric.Metric)
 	i := 10
 	l := defaultLog.WithFields(l.Fields{"collector": "MySQLBinlog"})
-	m := newMySQLBinlogGrowth(c, i, l)
+	m := newMySQLBinlogGrowth(c, i, l).(*MySQLBinlogGrowth)
 
 	assert.Equal(t, m.Channel(), c)
 	assert.Equal(t, m.Interval(), i)

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -89,7 +89,11 @@ type nestedMetricMap struct {
 	metricMap      map[string]interface{}
 }
 
-func newNerveUWSGI(channel chan metric.Metric, initialInterval int, log *l.Entry) *nerveUWSGICollector {
+func init() {
+	RegisterCollector("NerveUWSGI", newNerveUWSGI)
+}
+
+func newNerveUWSGI(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	col := new(nerveUWSGICollector)
 
 	col.log = log

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -201,7 +201,7 @@ func extractMetricWithType(metrics []metric.Metric,
 }
 
 func getTestNerveUWSGI() *nerveUWSGICollector {
-	return newNerveUWSGI(make(chan metric.Metric), 12, l.WithField("testing", "nerveuwsgi"))
+	return newNerveUWSGI(make(chan metric.Metric), 12, l.WithField("testing", "nerveuwsgi")).(*nerveUWSGICollector)
 }
 
 func TestNerveConfigParsing(t *testing.T) {

--- a/src/fullerite/collector/procstatus.go
+++ b/src/fullerite/collector/procstatus.go
@@ -27,8 +27,12 @@ func (ps ProcStatus) MatchCommandLine() bool {
 	return ps.matchCommandLine
 }
 
+func init() {
+	RegisterCollector("ProcStatus", newProcStatus)
+}
+
 // newProcStatus creates a new Test collector.
-func newProcStatus(channel chan metric.Metric, initialInterval int, log *l.Entry) *ProcStatus {
+func newProcStatus(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	ps := new(ProcStatus)
 
 	ps.log = log

--- a/src/fullerite/collector/procstatus_linux_test.go
+++ b/src/fullerite/collector/procstatus_linux_test.go
@@ -26,7 +26,7 @@ func TestProcStatusCollect(t *testing.T) {
 	channel := make(chan metric.Metric)
 
 	testLog := test_utils.BuildLogger()
-	ps := newProcStatus(channel, 12, testLog)
+	ps := newProcStatus(channel, 12, testLog).(*ProcStatus)
 	ps.Configure(config)
 
 	go ps.Collect()
@@ -52,7 +52,7 @@ func TestProcStatusCollectMetricTypes(t *testing.T) {
 	channel := make(chan metric.Metric)
 
 	testLog := test_utils.BuildLogger()
-	ps := newProcStatus(channel, 12, testLog)
+	ps := newProcStatus(channel, 12, testLog).(*ProcStatus)
 	ps.Configure(config)
 
 	go ps.Collect()
@@ -80,7 +80,7 @@ func TestProcStatusExtractDimensions(t *testing.T) {
 	}
 	config["generatedDimensions"] = dims
 
-	ps := newProcStatus(nil, 12, testLog)
+	ps := newProcStatus(nil, 12, testLog).(*ProcStatus)
 	ps.Configure(config)
 
 	dim := map[string]string{
@@ -103,7 +103,7 @@ func TestProcStatusMetrics(t *testing.T) {
 	}
 	config["generatedDimensions"] = dims
 
-	ps := newProcStatus(nil, 12, testLog)
+	ps := newProcStatus(nil, 12, testLog).(*ProcStatus)
 	ps.Configure(config)
 
 	count := 0
@@ -124,7 +124,7 @@ func TestProcStatusMetrics(t *testing.T) {
 func TestProcStatusMatches(t *testing.T) {
 	assert := assert.New(t)
 	testLog := test_utils.BuildLogger()
-	ps := newProcStatus(nil, 12, testLog)
+	ps := newProcStatus(nil, 12, testLog).(*ProcStatus)
 	config := make(map[string]interface{})
 
 	commGenerator := func(comm string, err error) func() (string, error) {

--- a/src/fullerite/collector/procstatus_test.go
+++ b/src/fullerite/collector/procstatus_test.go
@@ -10,7 +10,7 @@ import (
 func TestProcStatusConfigureEmptyConfig(t *testing.T) {
 	config := make(map[string]interface{})
 
-	ps := newProcStatus(nil, 123, nil)
+	ps := newProcStatus(nil, 123, nil).(*ProcStatus)
 	ps.Configure(config)
 
 	assert.Equal(t, 123, ps.Interval())
@@ -34,7 +34,7 @@ func TestProcStatusConfigure(t *testing.T) {
 		"currentDirectory": regex,
 	}
 
-	ps := newProcStatus(nil, 123, nil)
+	ps := newProcStatus(nil, 123, nil).(*ProcStatus)
 	ps.Configure(config)
 
 	assert.Equal(t, 9999, ps.Interval())

--- a/src/fullerite/collector/test.go
+++ b/src/fullerite/collector/test.go
@@ -22,8 +22,12 @@ type Test struct {
 	generator  valueGenerator
 }
 
+func init() {
+	RegisterCollector("Test", NewTest)
+}
+
 // NewTest creates a new Test collector.
-func NewTest(channel chan metric.Metric, initialInterval int, log *l.Entry) *Test {
+func NewTest(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	t := new(Test)
 
 	t.log = log

--- a/src/fullerite/collector/test_test.go
+++ b/src/fullerite/collector/test_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestTestConfigureEmptyConfig(t *testing.T) {
 	config := make(map[string]interface{})
-	test := NewTest(nil, 123, nil)
+	test := NewTest(nil, 123, nil).(*Test)
 	test.Configure(config)
 
 	assert.Equal(t,
@@ -27,7 +27,7 @@ func TestTestConfigure(t *testing.T) {
 	config["interval"] = 9999
 
 	// the channel and logger don't matter
-	test := NewTest(nil, 12, nil)
+	test := NewTest(nil, 12, nil).(*Test)
 	test.Configure(config)
 
 	assert.Equal(t,
@@ -44,7 +44,7 @@ func TestTestConfigureMetricName(t *testing.T) {
 	testChannel := make(chan metric.Metric)
 	testLogger := test_utils.BuildLogger()
 
-	test := NewTest(testChannel, 123, testLogger)
+	test := NewTest(testChannel, 123, testLogger).(*Test)
 	test.Configure(config)
 
 	go test.Collect()
@@ -69,7 +69,7 @@ func TestTestCollect(t *testing.T) {
 		return 4.0
 	}
 
-	test := NewTest(testChannel, 123, testLogger)
+	test := NewTest(testChannel, 123, testLogger).(*Test)
 	test.Configure(config)
 	test.generator = mockGen
 


### PR DESCRIPTION
This PR follows the pattern @tsheasha came up with for dynamically registering handlers with the core using the golang supported init() function which is called after variable initialization for all code modules. Essentially each collector has an init() function which calls the RegisterCollector function and passes it's config name and the factory method. The RegisterCollector function simply creates a map of the name -> factory Method for all collectors in the package. Thus when we need to construct a collector we simply index into the map and call the associated factory function. Voila!

Updated tests to properly downcast when accesses collector objects through non-Collector interface. 