### PR TITLE
Fix diamond collector specs

### DIFF
--- a/src/diamond/collectors/jolokia/test/testjolokia.py
+++ b/src/diamond/collectors/jolokia/test/testjolokia.py
@@ -40,7 +40,7 @@ class TestJolokiaCollector(CollectorTestCase):
         metrics = self.get_metrics()
         self.setDocExample(collector=self.collector.__class__.__name__,
                            metrics=metrics,
-                           defaultpath=self.collector.config['path'])
+                           defaultpath=self.collector.config['url_path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
@@ -89,7 +89,7 @@ class TestJolokiaCollector(CollectorTestCase):
         metrics = self.get_metrics()
         self.setDocExample(collector=self.collector.__class__.__name__,
                            metrics=metrics,
-                           defaultpath=self.collector.config['path'])
+                           defaultpath=self.collector.config['url_path'])
         self.assertPublishedMany(publish_mock, metrics)
 
     def test_should_escape_jolokia_domains(self):

--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -49,6 +49,8 @@ def get_collector_config(key, value):
     config['collectors'] = {}
     config['collectors']['default'] = {}
     config['collectors']['default']['hostname_method'] = "uname_short"
+    config['fulleritePort'] = 19190
+    config['interval'] = 10
     config['collectors'][key] = value
     return config
 


### PR DESCRIPTION
Since a collector uses its own config now, we must have these explicitly specified in test file.