### PR TITLE
Fix occasional record emission failures

### DIFF
--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -134,9 +134,12 @@ func TestRecordTimings(t *testing.T) {
 	base.emissionTimes.PushBack(emissionTiming{now.Add(minusSixSec), someDur, 0})
 	base.emissionTimes.PushBack(emissionTiming{now.Add(minusFiveSec), someDur, 0})
 
-	go base.recordEmissions(timingsChannel)
-	timingsChannel <- emissionTiming{now, someDur, 0}
+	go func() {
+		timingsChannel <- emissionTiming{now, someDur, 0}
+		close(timingsChannel)
+	}()
 
+	base.recordEmissions(timingsChannel)
 	assert.Equal(t, 1, base.emissionTimes.Len())
 	timingsChannel = nil
 }


### PR DESCRIPTION
This pattern is better because earlier code was vulnerable to
timing bugs. Since recordEmissions is processing messages async.
there was no guarantee that by the time we are asserting emissoinTimes
length it has processed input from channel and removed old emissions.

This code, on other hand - calls recordEmissions syncronously and hence
does not suffer from the problem. Also calling recordEmissions will
block until channel has been read and closed.

Fixes problems I saw - https://travis-ci.org/Yelp/fullerite/jobs/115055658 