### PR TITLE
Eventtime vs processtime

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -58,7 +58,6 @@ func newDockerStats(channel chan metric.Metric, initialInterval int, log *l.Entr
 	d.previousCPUValues = make(map[string]*CPUValues)
 	d.dockerClient, _ = docker.NewClient(endpoint)
 	d.compiledRegex = make(map[string]*Regex)
-
 	return d
 }
 
@@ -196,6 +195,7 @@ func buildDockerMetric(name string, metricType string, value float64) (m metric.
 	m = metric.New(name)
 	m.MetricType = metricType
 	m.Value = value
+	m.MetricTime = time.Now()
 	return m
 }
 

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -6,6 +6,7 @@ import (
 
 	"reflect"
 	"testing"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 	"github.com/fsouza/go-dockerclient"
@@ -101,20 +102,27 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 		"service_name":  "my_service",
 		"instance_name": "main",
 	}
+	now := time.Now()
 	expectedMetrics := []metric.Metric{
-		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
-		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
-		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
-		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
-		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
-		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
+		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims, now},
+		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims, now},
+		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims, now},
+		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims, now},
+		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims, now},
+		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen, now},
 	}
 
 	d := getSUT()
 	d.Configure(config)
 	ret := d.buildMetrics(container, stats, 0.5)
 
-	assert.Equal(t, ret, expectedMetrics)
+	var newMet metric.Metric
+	res := []metric.Metric{}
+	for _, met := range ret {
+		newMet = metric.Metric{met.Name, met.MetricType, met.Value, met.Dimensions, now}
+		res = append(res, newMet)
+	}
+	assert.Equal(t, res, expectedMetrics)
 }
 
 func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
@@ -159,20 +167,28 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 	expectedDimsGen := map[string]string{
 		"service_name": "my_service",
 	}
+	//waitForFullTime(time.Second)
+	now := time.Now()
 	expectedMetrics := []metric.Metric{
-		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims},
-		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims},
-		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
-		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
-		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
-		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
+		metric.Metric{"DockerRxBytes", "cumcounter", 10, expectedDims, now},
+		metric.Metric{"DockerTxBytes", "cumcounter", 20, expectedDims, now},
+		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims, now},
+		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims, now},
+		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims, now},
+		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen, now},
 	}
 
 	d := getSUT()
 	d.Configure(config)
 	ret := d.buildMetrics(container, stats, 0.5)
 
-	assert.Equal(t, ret, expectedMetrics)
+	var newMet metric.Metric
+	res := []metric.Metric{}
+	for _, met := range ret {
+		newMet = metric.Metric{met.Name, met.MetricType, met.Value, met.Dimensions, now}
+		res = append(res, newMet)
+	}
+	assert.Equal(t, res, expectedMetrics)
 }
 
 func TestDockerStatsCalculateCPUPercent(t *testing.T) {

--- a/src/fullerite/collector/mesos_slave_test.go
+++ b/src/fullerite/collector/mesos_slave_test.go
@@ -69,7 +69,8 @@ func TestMesosSlaveStatsSendMetrics(t *testing.T) {
 	oldGetMetrics := getSlaveMetrics
 	defer func() { getSlaveMetrics = oldGetMetrics }()
 
-	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
+	now := time.Now()
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}, now}
 	getSlaveMetrics = func(m *MesosSlaveStats, ip string) map[string]float64 {
 		return map[string]float64{
 			"test": 0.1,
@@ -81,7 +82,7 @@ func TestMesosSlaveStatsSendMetrics(t *testing.T) {
 
 	go sut.sendMetrics()
 	actual := <-c
-
+	actual.SetTime(now)
 	assert.Equal(t, expected, actual)
 }
 

--- a/src/fullerite/collector/mesos_test.go
+++ b/src/fullerite/collector/mesos_test.go
@@ -141,7 +141,8 @@ func TestMesosStatsSendMetrics(t *testing.T) {
 	oldGetMetrics := getMetrics
 	defer func() { getMetrics = oldGetMetrics }()
 
-	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
+	now := time.Now()
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}, now}
 	getMetrics = func(m *MesosStats, ip string) map[string]float64 {
 		return map[string]float64{
 			"test": 0.1,
@@ -153,7 +154,7 @@ func TestMesosStatsSendMetrics(t *testing.T) {
 
 	go sut.sendMetrics()
 	actual := <-c
-
+	actual.SetTime(now)
 	assert.Equal(t, expected, actual)
 }
 
@@ -224,17 +225,19 @@ func TestMesosStatsGetMetricsHandleNon200s(t *testing.T) {
 }
 
 func TestMesosStatsBuildMetric(t *testing.T) {
-	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}}
+	now := time.Now()
+	expected := metric.Metric{"mesos.test", "gauge", 0.1, map[string]string{}, now}
 
 	actual := buildMetric("test", 0.1)
-
+	actual.SetTime(now)
 	assert.Equal(t, expected, actual)
 }
 
 func TestMesosStatsBuildMetricCumCounter(t *testing.T) {
-	expected := metric.Metric{"mesos.master.slave_reregistrations", metric.CumulativeCounter, 0.1, map[string]string{}}
+	now := time.Now()
+	expected := metric.Metric{"mesos.master.slave_reregistrations", metric.CumulativeCounter, 0.1, map[string]string{}, now}
 
 	actual := buildMetric("master.slave_reregistrations", 0.1)
-
+	actual.SetTime(now)
 	assert.Equal(t, expected, actual)
 }

--- a/src/fullerite/handler/graphite.go
+++ b/src/fullerite/handler/graphite.go
@@ -85,7 +85,7 @@ func (g Graphite) convertToGraphite(incomingMetric metric.Metric) (datapoint str
 	for _, key := range keys {
 		datapoint = fmt.Sprintf("%s.%s.%s", datapoint, key, dimensions[key])
 	}
-	datapoint = fmt.Sprintf("%s %f %s\n", datapoint, incomingMetric.Value, incomingMetric.MetricTime)
+	datapoint = fmt.Sprintf("%s %f %d\n", datapoint, incomingMetric.Value, incomingMetric.MetricTime.Unix())
 	return datapoint
 }
 

--- a/src/fullerite/handler/graphite.go
+++ b/src/fullerite/handler/graphite.go
@@ -85,7 +85,7 @@ func (g Graphite) convertToGraphite(incomingMetric metric.Metric) (datapoint str
 	for _, key := range keys {
 		datapoint = fmt.Sprintf("%s.%s.%s", datapoint, key, dimensions[key])
 	}
-	datapoint = fmt.Sprintf("%s %f %d\n", datapoint, incomingMetric.Value, time.Now().Unix())
+	datapoint = fmt.Sprintf("%s %f %s\n", datapoint, incomingMetric.Value, incomingMetric.MetricTime)
 	return datapoint
 }
 

--- a/src/fullerite/handler/log_test.go
+++ b/src/fullerite/handler/log_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"fullerite/metric"
 	"time"
 
@@ -39,14 +40,15 @@ func TestLogConfigure(t *testing.T) {
 }
 
 func TestConvertToLog(t *testing.T) {
-
+	now := time.Now()
 	h := getTestLogHandler(12, 13)
 	m := metric.New("TestMetric")
+	m.SetTime(now)
 
 	dpString, err := h.convertToLog(m)
 	if err != nil {
 		t.Errorf("convertToLog failed to convert %q: err", m, err)
 	}
-
-	assert.Equal(t, "{\"name\":\"TestMetric\",\"type\":\"gauge\",\"value\":0,\"dimensions\":{}}", dpString)
+	nowFmt := now.Format(time.RFC3339Nano)
+	assert.Equal(t, fmt.Sprintf("{\"name\":\"TestMetric\",\"type\":\"gauge\",\"value\":0,\"dimensions\":{},\"time\":\"%s\"}", nowFmt), dpString)
 }

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -1,6 +1,10 @@
 package metric
 
-import "strings"
+import (
+	"strings"
+	"fmt"
+	"time"
+)
 
 // The different types of metrics that are supported
 const (
@@ -15,6 +19,7 @@ type Metric struct {
 	Name       string            `json:"name"`
 	MetricType string            `json:"type"`
 	Value      float64           `json:"value"`
+	MetricTime string            `json:"time"`
 	Dimensions map[string]string `json:"dimensions"`
 }
 
@@ -25,6 +30,7 @@ func New(name string) Metric {
 		Name:       sanitizeString(name),
 		MetricType: "gauge",
 		Value:      0.0,
+		MetricTime: fmt.Sprintf("%d", time.Now().Unix()),
 		Dimensions: make(map[string]string),
 	}
 }

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -2,7 +2,6 @@ package metric
 
 import (
 	"strings"
-	"fmt"
 	"time"
 )
 
@@ -19,8 +18,8 @@ type Metric struct {
 	Name       string            `json:"name"`
 	MetricType string            `json:"type"`
 	Value      float64           `json:"value"`
-	MetricTime string            `json:"time"`
 	Dimensions map[string]string `json:"dimensions"`
+	MetricTime time.Time         `json:"time"`
 }
 
 // New returns a new metric with name. Default metric type is "gauge"
@@ -30,9 +29,14 @@ func New(name string) Metric {
 		Name:       sanitizeString(name),
 		MetricType: "gauge",
 		Value:      0.0,
-		MetricTime: fmt.Sprintf("%d", time.Now().Unix()),
 		Dimensions: make(map[string]string),
+		MetricTime: time.Now(),
 	}
+}
+
+// SetTime to metric
+func (m *Metric) SetTime(mtime time.Time) {
+	m.MetricTime = mtime
 }
 
 // AddDimension adds a new dimension to the Metric.

--- a/src/fullerite/metric/metric_test.go
+++ b/src/fullerite/metric/metric_test.go
@@ -330,7 +330,7 @@ func TestSanitizeDimensionNameOverwriteCleanDirty(t *testing.T) {
 func TestAddDimensions(t *testing.T) {
 	m1 := metric.New("TestMetric")
 	m2 := metric.New("TestMetric")
-
+	m2.SetTime(m1.MetricTime)
 	dimensions := map[string]string{
 		"TestDimension":    "TestValue",
 		"Dirty:=Dimension": "Dirty:=Value",


### PR DESCRIPTION
As described in #205 the timestamp processed (e.g. by the graphite) handler is not the timestamp at which a metric was sampled.

This PR introduces a field that stores the timestamp at sample time (eventtime), which can be used by the handlers instead of the handler' processing time.

```
bash-4.3# make
Cleaning fullerite...
Getting dependencies...
Linting fullerite sources...
Building fullerite...
Building beatit...
...............
----------------------------------------------------------------------
Ran 15 tests in 0.016s

OK
Testing fullerite
ok  	beatit	0.014s	coverage: 22.2% of statements
ok  	fullerite	3.028s	coverage: 39.4% of statements
ok  	fullerite/collector	7.515s	coverage: 81.1% of statements
ok  	fullerite/config	0.008s	coverage: 78.1% of statements
ok  	fullerite/handler	3.020s	coverage: 57.3% of statements
ok  	fullerite/internalserver	0.464s	coverage: 88.1% of statements
ok  	fullerite/metric	0.005s	coverage: 81.8% of statements
ok  	fullerite/util	0.008s	coverage: 93.2% of statements
bash-4.3#
```