### PR TITLE
Drop support for older versions of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: go
 
 install: "pip install --user -r requirements-dev.txt"
 go:
-  - 1.4
-  - 1.4.1
-  - 1.4.2
   - 1.5
   - 1.5.1
   - 1.5.2


### PR DESCRIPTION
Go people seem to have broken go-tools support in version earlier than 1.5.x . There are workarounds available but since 1.4.x is ancient lets just build against 1.5.x 