### PR TITLE
remove unused bits from server.py

### DIFF
--- a/src/diamond/server.py
+++ b/src/diamond/server.py
@@ -51,14 +51,12 @@ class Server(object):
         # Initialize Members
         self.configfile = configfile
         self.config = None
-        self.modules = {}
 
         # We do this weird process title swap around to get the sync manager
         # title correct for ps
         if setproctitle:
             oldproctitle = getproctitle()
             setproctitle('%s - SyncManager' % getproctitle())
-        self.manager = multiprocessing.Manager()
         if setproctitle:
             setproctitle(oldproctitle)
 


### PR DESCRIPTION
We are not really using multiprocessing manager anymore and neither the modules dictionary.