### PR TITLE
Fix goroutine leak coming out of docker collector

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -130,7 +130,7 @@ func (d *DockerStats) Collect() {
 func (d DockerStats) getDockerContainerInfo(container *docker.Container) {
 	errC := make(chan error, 1)
 	statsC := make(chan *docker.Stats, 1)
-	done := make(chan bool)
+	done := make(chan bool, 1)
 
 	go func() {
 		errC <- d.dockerClient.Stats(docker.StatsOptions{container.ID, statsC, false, done, time.Second * time.Duration(d.interval)})


### PR DESCRIPTION
The collector is leaking goroutines because writing to a unbuffered
channel on which no one is listening will block forever and hence
will leak caller goroutine.

This problem seems to have been exaberated when we migrated to go 1.5