### PR TITLE
create filter-regex to skip intermediate container

### DIFF
--- a/examples/docker-host/DockerStats.conf
+++ b/examples/docker-host/DockerStats.conf
@@ -1,0 +1,3 @@
+{
+        "skipContainerRegex": ".*_.*"
+}

--- a/examples/docker-host/fullerite.conf
+++ b/examples/docker-host/fullerite.conf
@@ -1,0 +1,19 @@
+{
+    "prefix": "fullerite.",
+    "interval": 5,
+    "fulleritePort": 19191,
+    "internalServer": {"port":"29090","path":"/metrics"},
+    "collectorsConfigPath": "/etc/fullerite/conf.d",
+
+    "collectors": ["DockerStats"],
+
+    "handlers": {
+        "Graphite": {
+            "server": "carbon.service.consul",
+            "port": "2003",
+            "interval": "5",
+            "max_buffer_size": 300,
+            "timeout": 2
+        }
+    }
+}

--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -102,8 +102,6 @@ func (d *DockerStats) Configure(configMap map[string]interface{}) {
 	d.configureCommonParams(configMap)
 	if skipRegex, skipExists := configMap["skipContainerRegex"]; skipExists {
 		d.skipRegex = regexp.MustCompile(skipRegex.(string))
-	} else {
-		d.skipRegex = nil
 	}
 }
 

--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -103,8 +103,7 @@ func (d *DockerStats) Configure(configMap map[string]interface{}) {
 	if skipRegex, skipExists := configMap["skipContainerRegex"]; skipExists {
 		d.skipRegex = regexp.MustCompile(skipRegex.(string))
 	} else {
-		defRegex := ".+_.+" // skip ad-hoc container, which are not named properly
-		d.skipRegex = regexp.MustCompile(defRegex)
+		d.skipRegex = nil
 	}
 }
 
@@ -129,9 +128,9 @@ func (d *DockerStats) Collect() {
 			continue
 		}
 
-		if d.skipRegex.MatchString(container.Name) {
-			continue
+		if d.skipRegex != nil && d.skipRegex.MatchString(container.Name) {
 			d.log.Info("Skip container: ", container.Name)
+			continue
 		}
 		if _, ok := d.previousCPUValues[container.ID]; !ok {
 			d.previousCPUValues[container.ID] = new(CPUValues)


### PR DESCRIPTION
Hey y'all,

as I am excited about the update to the dockerstat collector I would like to introduce a filter mechanism to it.
I added `skipContainerRegex` to the config, which allows to define a regex which is filtered out of the collection.

The motivation is, that I don't want to collect metrics about containers which are (e.g.) used during `docker build`, as they only pollute the metrics back end.

An iteration on this would create a meta-container `filtered`, which sums up all stats from all filtered containers.