### PR TITLE
Nerve httpd collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,11 @@ tests: deps diamond_core_test
 		gom test -cover $$pkg || exit 1;\
 	done
 
+qbt:
+	@echo Fast testing $(FULLERITE)
+	@for pkg in $(PKGS); do \
+		gom test -v -cover $$pkg || exit 1;\
+	done
 
 diamond_core_test:
 	@python src/diamond/test.py -d

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"fullerite/config"
 	"fullerite/metric"
 	"fullerite/util"
 	"io/ioutil"
@@ -91,9 +92,8 @@ func (c *NerveHTTPD) Configure(configMap map[string]interface{}) {
 	}
 
 	if val, exists := configMap["status_ttl"]; exists {
-		if t, ok := val.(int); ok {
-			c.statusTTL = time.Duration(t) * time.Second
-		}
+		tmpStatusTTL := config.GetAsInt(val, 3600)
+		c.statusTTL = time.Duration(tmpStatusTTL) * time.Second
 	}
 
 	c.configureCommonParams(configMap)

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -106,7 +106,6 @@ func (c *NerveHTTPD) Collect() {
 		c.log.Warn("Failed to read the contents of file ", c.configFilePath, " because ", err)
 		return
 	}
-
 	servicePortMap, err := util.ParseNerveConfig(&rawFileContents)
 	if err != nil {
 		c.log.Warn("Failed to parse the nerve config at ", c.configFilePath, ": ", err)

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -1,10 +1,19 @@
 package collector
 
 import (
+	"fmt"
 	"fullerite/metric"
+	"fullerite/util"
+	"io/ioutil"
+	"net/http"
+	"sync"
 	"time"
 
 	l "github.com/Sirupsen/logrus"
+)
+
+var (
+	getNerveHTTPDMetrics = (*NerveHTTPD).getMetrics
 )
 
 // NerveHTTPD discovers Apache servers via Nerve config
@@ -12,10 +21,18 @@ import (
 type NerveHTTPD struct {
 	baseCollector
 
-	configFilePath string
-	queryPath      string
-	timeout        int
-	statusTTL      time.Duration
+	configFilePath  string
+	queryPath       string
+	timeout         int
+	statusTTL       time.Duration
+	failedEndPoints map[string]int64
+	mu              *sync.RWMutex
+}
+
+type nerveHTTPDResponse struct {
+	data   []byte
+	err    error
+	status int
 }
 
 func init() {
@@ -27,13 +44,14 @@ func newNerveHTTPD(channel chan metric.Metric, initialInterval int, log *l.Entry
 	c.channel = channel
 	c.interval = initialInterval
 	c.log = log
+	c.mu = new(sync.RWMutex)
 
 	c.name = collectorName
 	c.configFilePath = "/etc/nerve/nerve.conf.json"
 	c.queryPath = "server-status?auto"
 	c.timeout = 2
 	c.statusTTL = time.Duration(60) * time.Minute
-
+	c.failedEndPoints = map[string]int64{}
 	return c
 }
 
@@ -57,5 +75,97 @@ func (c *NerveHTTPD) Configure(configMap map[string]interface{}) {
 
 // Collect the metrics
 func (c *NerveHTTPD) Collect() {
+	rawFileContents, err := ioutil.ReadFile(c.configFilePath)
+	if err != nil {
+		c.log.Warn("Failed to read the contents of file ", c.configFilePath, " because ", err)
+		return
+	}
 
+	servicePortMap, err := util.ParseNerveConfig(&rawFileContents)
+	if err != nil {
+		c.log.Warn("Failed to parse the nerve config at ", c.configFilePath, ": ", err)
+		return
+	}
+	c.log.Debug("Finished parsing Nerve config into ", servicePortMap)
+
+	for port, serviceName := range servicePortMap {
+		if !c.checkIfFailed(serviceName, port) {
+			go c.emitHTTPDMetric(serviceName, port)
+		}
+	}
+}
+
+func (c *NerveHTTPD) emitHTTPDMetric(serviceName string, port int) {
+	metrics := getNerveHTTPDMetrics(c, serviceName, port)
+	for _, metric := range metrics {
+		c.Channel() <- metric
+	}
+}
+
+func (c *NerveHTTPD) checkIfFailed(serviceName string, port int) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	endpoint := fmt.Sprintf("%s:%d", serviceName, port)
+	if lastFailed, ok := c.failedEndPoints[endpoint]; ok {
+		tm := time.Unix(lastFailed, 0)
+		if time.Since(tm) < c.statusTTL {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *NerveHTTPD) getMetrics(serviceName string, port int) []metric.Metric {
+	results := []metric.Metric{}
+	serviceLog := c.log.WithField("service", serviceName)
+
+	endpoint := fmt.Sprintf("http://localhost:%d/%s", port, c.queryPath)
+	serviceLog.Debug("making GET request to ", endpoint)
+
+	httpResponse := fetchApacheMetrics(endpoint, port)
+
+	if httpResponse.status != 200 {
+		c.updateFailedStatus(serviceName, port, httpResponse.status)
+		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", httpResponse.err)
+		return results
+	}
+	return extractApacheMetrics(httpResponse.data)
+}
+
+func extractApacheMetrics(data []byte) []metric.Metric {
+	results := []metric.Metric{}
+	return results
+}
+
+func (c *NerveHTTPD) updateFailedStatus(serviceName string, port int, statusCode int) {
+	if statusCode == 404 {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		endpoint := fmt.Sprintf("%s:%d", serviceName, port)
+		c.failedEndPoints[endpoint] = time.Now().Unix()
+	}
+
+}
+
+func fetchApacheMetrics(endpoint string, timeout int) *nerveHTTPDResponse {
+	response := new(nerveHTTPDResponse)
+	client := http.Client{
+		Timeout: time.Duration(timeout) * time.Second,
+	}
+
+	rsp, err := client.Get(endpoint)
+	response.err = err
+	response.status = rsp.StatusCode
+	if err != nil {
+		return response
+	}
+
+	txt, err := ioutil.ReadAll(rsp.Body)
+	defer rsp.Body.Close()
+	if err != nil {
+		response.err = err
+		return response
+	}
+	response.data = txt
+	return response
 }

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -155,7 +155,12 @@ func (c *NerveHTTPD) getMetrics(serviceName string, port int) []metric.Metric {
 		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", httpResponse.err)
 		return results
 	}
-	return extractApacheMetrics(httpResponse.data)
+	apacheMetrics := extractApacheMetrics(httpResponse.data)
+	metric.AddToAll(&apacheMetrics, map[string]string{
+		"service": serviceName,
+		"port":    strconv.Itoa(port),
+	})
+	return apacheMetrics
 }
 
 func extractApacheMetrics(data []byte) []metric.Metric {

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"fullerite/metric"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 )
@@ -10,6 +11,11 @@ import (
 // and reports metric for them
 type NerveHTTPD struct {
 	baseCollector
+
+	configFilePath string
+	queryPath      string
+	timeout        int
+	statusTTL      time.Duration
 }
 
 func init() {
@@ -23,12 +29,30 @@ func newNerveHTTPD(channel chan metric.Metric, initialInterval int, log *l.Entry
 	c.log = log
 
 	c.name = collectorName
+	c.configFilePath = "/etc/nerve/nerve.conf.json"
+	c.queryPath = "server-status?auto"
+	c.timeout = 2
+	c.statusTTL = time.Duration(60) * time.Minute
+
 	return c
 }
 
 // Configure the collector
 func (c *NerveHTTPD) Configure(configMap map[string]interface{}) {
+	if val, exists := configMap["queryPath"]; exists {
+		c.queryPath = val.(string)
+	}
+	if val, exists := configMap["configFilePath"]; exists {
+		c.configFilePath = val.(string)
+	}
 
+	if val, exists := configMap["status_ttl"]; exists {
+		if t, ok := val.(int); ok {
+			c.statusTTL = time.Duration(t) * time.Second
+		}
+	}
+
+	c.configureCommonParams(configMap)
 }
 
 // Collect the metrics

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -1,0 +1,37 @@
+package collector
+
+import (
+	"fullerite/metric"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+// NerveHTTPD discovers Apache servers via Nerve config
+// and reports metric for them
+type NerveHTTPD struct {
+	baseCollector
+}
+
+func init() {
+	RegisterCollector("NerveHTTPD", newNerveHTTPD)
+}
+
+func newNerveHTTPD(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	c := new(NerveHTTPD)
+	c.channel = channel
+	c.interval = initialInterval
+	c.log = log
+
+	c.name = collectorName
+	return c
+}
+
+// Configure the collector
+func (c *NerveHTTPD) Configure(configMap map[string]interface{}) {
+
+}
+
+// Collect the metrics
+func (c *NerveHTTPD) Collect() {
+
+}

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -43,5 +43,8 @@ func TestExtractApacheMetrics(t *testing.T) {
 	for _, m := range metrics {
 		metricMap[m.Name] = m
 	}
-	assert.Equal(t, 68, metricMap["Uptime"])
+	assert.Equal(t, 99.0, metricMap["TotalAccesses"].Value)
+	assert.Equal(t, 34.0, metricMap["WritingWorkers"].Value)
+	assert.Equal(t, 6.0, metricMap["IdleWorkers"].Value)
+	assert.Equal(t, 6.0, metricMap["StandbyWorkers"].Value)
 }

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -41,7 +41,7 @@ func TestExtractApacheMetrics(t *testing.T) {
 	metrics := extractApacheMetrics(getRawApacheStat())
 	metricMap := map[string]metric.Metric{}
 	for _, m := range metrics {
-		metricMap[m.metricName] = m
+		metricMap[m.Name] = m
 	}
 	assert.Equal(t, 68, metricMap["Uptime"])
 }

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -12,6 +12,22 @@ func getNerveHTTPDCollector() *NerveHTTPD {
 	return newNerveHTTPD(make(chan metric.Metric), 10, l.WithField("testing", "nervehttpd")).(*NerveHTTPD)
 }
 
+func getRawApacheStat() []byte {
+	metric := []byte(`
+Total Accesses: 99
+Total kBytes: 108
+CPULoad: 901.485
+Uptime: 68
+ReqPerSec: 1.45588
+BytesPerSec: 1626.35
+BytesPerReq: 1117.09
+BusyWorkers: 34
+IdleWorkers: 6
+Scoreboard: WWWWWWWW_WW_WWWWWWWWWWWWW_WWW_WWWWWWW__W
+	`)
+	return metric
+}
+
 func TestDefaultConfigNerveHTTPD(t *testing.T) {
 	collector := getNerveHTTPDCollector()
 	collector.Configure(make(map[string]interface{}))
@@ -19,4 +35,13 @@ func TestDefaultConfigNerveHTTPD(t *testing.T) {
 	assert.Equal(t, 10, collector.Interval())
 	assert.Equal(t, "/etc/nerve/nerve.conf.json", collector.configFilePath)
 	assert.Equal(t, "server-status?auto", collector.queryPath)
+}
+
+func TestExtractApacheMetrics(t *testing.T) {
+	metrics := extractApacheMetrics(getRawApacheStat())
+	metricMap := map[string]metric.Metric{}
+	for _, m := range metrics {
+		metricMap[m.metricName] = m
+	}
+	assert.Equal(t, 68, metricMap["Uptime"])
 }

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -42,6 +42,7 @@ func TestDefaultConfigNerveHTTPD(t *testing.T) {
 	assert.Equal(t, 10, collector.Interval())
 	assert.Equal(t, "/etc/nerve/nerve.conf.json", collector.configFilePath)
 	assert.Equal(t, "server-status?auto", collector.queryPath)
+	assert.Equal(t, time.Duration(1)*time.Hour, collector.statusTTL)
 }
 
 func TestCustomConfigNerveHTTPD(t *testing.T) {

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -1,0 +1,22 @@
+package collector
+
+import (
+	"fullerite/metric"
+	"testing"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func getNerveHTTPDCollector() *NerveHTTPD {
+	return newNerveHTTPD(make(chan metric.Metric), 10, l.WithField("testing", "nervehttpd")).(*NerveHTTPD)
+}
+
+func TestDefaultConfigNerveHTTPD(t *testing.T) {
+	collector := getNerveHTTPDCollector()
+	collector.Configure(make(map[string]interface{}))
+
+	assert.Equal(t, 10, collector.Interval())
+	assert.Equal(t, "/etc/nerve/nerve.conf.json", collector.configFilePath)
+	assert.Equal(t, "server-status?auto", collector.queryPath)
+}

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -2,6 +2,8 @@ package collector
 
 import (
 	"fullerite/metric"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	l "github.com/Sirupsen/logrus"
@@ -47,4 +49,17 @@ func TestExtractApacheMetrics(t *testing.T) {
 	assert.Equal(t, 34.0, metricMap["WritingWorkers"].Value)
 	assert.Equal(t, 6.0, metricMap["IdleWorkers"].Value)
 	assert.Equal(t, 6.0, metricMap["StandbyWorkers"].Value)
+	assert.Equal(t, 901.485, metricMap["CPULoad"].Value)
+	assert.Equal(t, 1.45588, metricMap["ReqPerSec"].Value)
+	assert.Equal(t, 1626.35, metricMap["BytesPerSec"].Value)
+}
+
+func TestFetchApacheMetrics(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer ts.Close()
+	endpoint := ts.URL + "/server-status?auto=close"
+	httpResponse := fetchApacheMetrics(endpoint, 10)
+	assert.Equal(t, 404, httpResponse.status)
 }

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	l "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -41,6 +42,20 @@ func TestDefaultConfigNerveHTTPD(t *testing.T) {
 	assert.Equal(t, 10, collector.Interval())
 	assert.Equal(t, "/etc/nerve/nerve.conf.json", collector.configFilePath)
 	assert.Equal(t, "server-status?auto", collector.queryPath)
+}
+
+func TestCustomConfigNerveHTTPD(t *testing.T) {
+	collector := getNerveHTTPDCollector()
+	configMap := map[string]interface{}{
+		"status_ttl":     120,
+		"configFilePath": "/tmp/foobar",
+	}
+	collector.Configure(configMap)
+
+	assert.Equal(t, 10, collector.Interval())
+	assert.Equal(t, "/tmp/foobar", collector.configFilePath)
+	assert.Equal(t, "server-status?auto", collector.queryPath)
+	assert.Equal(t, time.Duration(120)*time.Second, collector.statusTTL)
 }
 
 func TestExtractApacheMetrics(t *testing.T) {

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -1,13 +1,12 @@
 package collector
 
 import (
-	"fullerite/config"
 	"fullerite/metric"
+	"fullerite/util"
 
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -28,25 +27,6 @@ const (
 // all the local endpoints on the given path. The metrics are assumed
 // to be in a UWSGI format.
 //
-// example configuration::
-//
-// {
-//     	"heartbeat_path": "/var/run/nerve/heartbeat",
-//		"instance_id": "srv1-devc",
-//		"services": {
-//	 		"<SERVICE_NAME>.<otherstuff>": {
-//				"host": "<IPADDR>",
-//      	    "port": ###,
-//      	}
-// 		}
-//     "services": {
-//
-// Most imporantly is the port, host and service name. The service name is assumed to be formatted like this::
-//
-type releventNerveConfig struct {
-	Services map[string]map[string]interface{}
-}
-
 // the assumed format is:
 // {
 // 	"gauges": {},
@@ -126,19 +106,13 @@ type nerveUWSGICollector struct {
 }
 
 func (n *nerveUWSGICollector) Collect() {
-	ips, err := getIps()
-	if err != nil {
-		n.log.Warn("Failed to get IPs: ", err)
-		return
-	}
-
 	rawFileContents, err := ioutil.ReadFile(n.configFilePath)
 	if err != nil {
 		n.log.Warn("Failed to read the contents of file ", n.configFilePath, " because ", err)
 		return
 	}
 
-	servicePortMap, err := n.parseNerveConfig(&rawFileContents, ips)
+	servicePortMap, err := util.ParseNerveConfig(&rawFileContents)
 	if err != nil {
 		n.log.Warn("Failed to parse the nerve config at ", n.configFilePath, ": ", err)
 		return
@@ -187,41 +161,6 @@ func (n *nerveUWSGICollector) Configure(configMap map[string]interface{}) {
 	}
 
 	n.configureCommonParams(configMap)
-}
-
-// parseNerveConfig is responsible for taking the JSON string coming in into a map of service:port
-// it will also filter based on only services runnign on this host.
-// To deal with multi-tenancy we actually will return port:service
-func (n *nerveUWSGICollector) parseNerveConfig(raw *[]byte, ips []string) (map[int]string, error) {
-	parsed := new(releventNerveConfig)
-
-	// convert the ips into a map for membership tests
-	ipMap := make(map[string]bool)
-	for _, val := range ips {
-		ipMap[val] = true
-	}
-
-	err := json.Unmarshal(*raw, parsed)
-	if err != nil {
-		return make(map[int]string), err
-	}
-	results := make(map[int]string)
-	for rawServiceName, serviceConfig := range parsed.Services {
-		host := strings.TrimSpace(serviceConfig["host"].(string))
-
-		_, exists := ipMap[host]
-		if exists {
-			name := strings.Split(rawServiceName, ".")[0]
-			port := config.GetAsInt(serviceConfig["port"], -1)
-			if port != -1 {
-				results[port] = name
-			} else {
-				n.log.Warn("Failed to get port from value ", serviceConfig["port"])
-			}
-		}
-	}
-
-	return results, nil
 }
 
 // parseDefault is the fallback parser if no 'Metrics-Schema' is provided in the
@@ -357,35 +296,6 @@ func createMetricFromDatam(rollup string, value interface{}, metricName string, 
 		return m, false
 	}
 	return m, true
-}
-
-// getIps is responsible for getting all the ips that are associated with this NIC
-func getIps() ([]string, error) {
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		return []string{}, err
-	}
-
-	results := []string{}
-	for _, i := range ifaces {
-		addrs, err := i.Addrs()
-		if err != nil {
-			return []string{}, err
-		}
-		for _, addr := range addrs {
-			var ip net.IP
-			switch v := addr.(type) {
-			case *net.IPNet:
-				ip = v.IP
-			case *net.IPAddr:
-				ip = v.IP
-			}
-
-			results = append(results, ip.String())
-		}
-	}
-
-	return results, nil
 }
 
 func queryEndpoint(endpoint string, timeout int) ([]byte, string, error) {

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -258,43 +258,6 @@ func getTestNerveUWSGI() *nerveUWSGICollector {
 	return newNerveUWSGI(make(chan metric.Metric), 12, l.WithField("testing", "nerveuwsgi")).(*nerveUWSGICollector)
 }
 
-func TestNerveConfigParsing(t *testing.T) {
-	expected := map[int]string{
-		22222: "example_service",
-		13752: "example_service",
-	}
-
-	cfgString := getTestNerveConfig()
-	results, err := getTestNerveUWSGI().parseNerveConfig(&cfgString, []string{"10.56.5.21"})
-	assert.Nil(t, err)
-	assert.Equal(t, expected, results)
-}
-
-func TestNerveFilterOnIP(t *testing.T) {
-	cfgString := getTestNerveConfig()
-	results, err := getTestNerveUWSGI().parseNerveConfig(&cfgString, []string{"10.56.2.3"})
-	assert.Nil(t, err)
-	assert.NotNil(t, results)
-	assert.Equal(t, 0, len(results))
-}
-
-func TestHandleBadNerveConfig(t *testing.T) {
-	// b/c there is valid json coming in it won't error, just have an empty response
-	cfgString := []byte("{}")
-	results, err := getTestNerveUWSGI().parseNerveConfig(&cfgString, []string{"10.56.2.3"})
-	assert.Nil(t, err)
-	assert.NotNil(t, results)
-	assert.Equal(t, 0, len(results))
-}
-
-func TestHandlePoorlyFormedJson(t *testing.T) {
-	cfgString := []byte("notjson")
-	results, err := getTestNerveUWSGI().parseNerveConfig(&cfgString, []string{"10.56.2.3"})
-	assert.NotNil(t, err)
-	assert.NotNil(t, results)
-	assert.Equal(t, 0, len(results))
-}
-
 func TestDefaultConfigNerveUWSGI(t *testing.T) {
 	inst := getTestNerveUWSGI()
 	inst.Configure(make(map[string]interface{}))

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -29,6 +29,13 @@ func New(name string) Metric {
 	}
 }
 
+// WithValue returns metric with value of type Gauge
+func WithValue(name string, value float64) Metric {
+	metric := New(name)
+	metric.Value = value
+	return metric
+}
+
 // AddDimension adds a new dimension to the Metric.
 func (m *Metric) AddDimension(name, value string) {
 	m.Dimensions[sanitizeString(name)] = sanitizeString(value)

--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// For dependency injection
+var ipGetter = getIps
+
 // example configuration::
 //
 // {
@@ -25,8 +28,6 @@ import (
 type releventNerveConfig struct {
 	Services map[string]map[string]interface{}
 }
-
-var ipGetter = getIps
 
 // ParseNerveConfig is responsible for taking the JSON string coming in into a map of service:port
 // it will also filter based on only services runnign on this host.

--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -25,7 +25,7 @@ var ipGetter = getIps
 //
 // Most imporantly is the port, host and service name. The service name is assumed to be formatted like this::
 //
-type releventNerveConfig struct {
+type nerveConfigData struct {
 	Services map[string]map[string]interface{}
 }
 
@@ -39,7 +39,7 @@ func ParseNerveConfig(raw *[]byte) (map[int]string, error) {
 	if err != nil {
 		return results, err
 	}
-	parsed := new(releventNerveConfig)
+	parsed := new(nerveConfigData)
 
 	// convert the ips into a map for membership tests
 	ipMap := make(map[string]bool)

--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -1,0 +1,97 @@
+package util
+
+import (
+	"encoding/json"
+	"fullerite/config"
+	"net"
+	"strings"
+)
+
+// example configuration::
+//
+// {
+//     	"heartbeat_path": "/var/run/nerve/heartbeat",
+//		"instance_id": "srv1-devc",
+//		"services": {
+//	 		"<SERVICE_NAME>.<otherstuff>": {
+//				"host": "<IPADDR>",
+//      	    "port": ###,
+//      	}
+// 		}
+//     "services": {
+//
+// Most imporantly is the port, host and service name. The service name is assumed to be formatted like this::
+//
+type releventNerveConfig struct {
+	Services map[string]map[string]interface{}
+}
+
+var ipGetter = getIps
+
+// ParseNerveConfig is responsible for taking the JSON string coming in into a map of service:port
+// it will also filter based on only services runnign on this host.
+// To deal with multi-tenancy we actually will return port:service
+func ParseNerveConfig(raw *[]byte) (map[int]string, error) {
+	results := make(map[int]string)
+	ips, err := ipGetter()
+
+	if err != nil {
+		return results, err
+	}
+	parsed := new(releventNerveConfig)
+
+	// convert the ips into a map for membership tests
+	ipMap := make(map[string]bool)
+	for _, val := range ips {
+		ipMap[val] = true
+	}
+
+	err = json.Unmarshal(*raw, parsed)
+	if err != nil {
+		return results, err
+	}
+
+	for rawServiceName, serviceConfig := range parsed.Services {
+		host := strings.TrimSpace(serviceConfig["host"].(string))
+
+		_, exists := ipMap[host]
+		if exists {
+			name := strings.Split(rawServiceName, ".")[0]
+			port := config.GetAsInt(serviceConfig["port"], -1)
+			if port != -1 {
+				results[port] = name
+			}
+		}
+	}
+
+	return results, nil
+}
+
+// getIps is responsible for getting all the ips that are associated with this NIC
+func getIps() ([]string, error) {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []string{}, err
+	}
+
+	results := []string{}
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return []string{}, err
+		}
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+
+			results = append(results, ip.String())
+		}
+	}
+
+	return results, nil
+}

--- a/src/fullerite/util/nerve_config_test.go
+++ b/src/fullerite/util/nerve_config_test.go
@@ -1,0 +1,110 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestNerveConfig() []byte {
+	raw := `
+	{
+	    "heartbeat_path": "/var/run/nerve/heartbeat",
+	    "instance_id": "srv1-devc",
+	    "services": {
+	        "example_service.main.norcal-devc.superregion:norcal-devc.13752.new": {
+	            "check_interval": 7,
+	            "checks": [
+	                {
+	                    "fall": 2,
+	                    "headers": {},
+	                    "host": "127.0.0.1",
+	                    "open_timeout": 6,
+	                    "port": 6666,
+	                    "rise": 1,
+	                    "timeout": 6,
+	                    "type": "http",
+	                    "uri": "/http/example_service.main/13752/status"
+	                }
+	            ],
+	            "host": "10.56.5.21",
+	            "port": 13752,
+	            "weight": 24,
+	            "zk_hosts": [
+	                "10.40.5.5:22181",
+	                "10.40.5.6:22181",
+	                "10.40.1.17:22181"
+	            ],
+	            "zk_path": "/nerve/superregion:norcal-devc/example_service.main"
+	        },
+	        "example_service.mesosstage_main.norcal-devc.superregion:norcal-devc.13752.new": {
+	            "check_interval": 7,
+	            "checks": [
+	                {
+	                    "fall": 2,
+	                    "headers": {},
+	                    "host": "127.0.0.1",
+	                    "open_timeout": 6,
+	                    "port": 6666,
+	                    "rise": 1,
+	                    "timeout": 6,
+	                    "type": "http",
+	                    "uri": "/http/example_service.mesosstage_main/13752/status"
+	                }
+	            ],
+	            "host": "10.56.5.21",
+	            "port": 22222,
+	            "weight": 24,
+	            "zk_hosts": [
+	                "10.40.5.5:22181",
+	                "10.40.5.6:22181",
+	                "10.40.1.17:22181"
+	            ],
+	            "zk_path": "/nerve/superregion:norcal-devc/example_service.mesosstage_main"
+	        }
+	    }
+	}
+	`
+	return []byte(raw)
+}
+
+func TestNerveConfigParsing(t *testing.T) {
+	expected := map[int]string{
+		22222: "example_service",
+		13752: "example_service",
+	}
+
+	cfgString := getTestNerveConfig()
+	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
+	results, err := ParseNerveConfig(&cfgString)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, results)
+}
+
+func TestNerveFilterOnIP(t *testing.T) {
+	cfgString := getTestNerveConfig()
+	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
+	results, err := ParseNerveConfig(&cfgString)
+	assert.Nil(t, err)
+	assert.NotNil(t, results)
+	assert.Equal(t, 0, len(results))
+}
+
+func TestHandleBadNerveConfig(t *testing.T) {
+	// b/c there is valid json coming in it won't error, just have an empty response
+	cfgString := []byte("{}")
+	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
+	results, err := ParseNerveConfig(&cfgString)
+	assert.Nil(t, err)
+	assert.NotNil(t, results)
+	assert.Equal(t, 0, len(results))
+}
+
+func TestHandlePoorlyFormedJson(t *testing.T) {
+	cfgString := []byte("notjson")
+	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
+	results, err := ParseNerveConfig(&cfgString)
+	assert.NotNil(t, err)
+	assert.NotNil(t, results)
+	assert.Equal(t, 0, len(results))
+}


### PR DESCRIPTION
Implement reporting metrics from apache running inside docker containers discoverable via nerve config.

A majority of services may not have httpd status from them and hence this collector will cache 404 responses for 1 hour and not collect from the services for that time duration.  This avoids spamming unrelated services with `server-status` requests.