### PR TITLE
now ignores non-200 HTTP status codes

### DIFF
--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -5,6 +5,7 @@ import (
 	"fullerite/util"
 
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -304,9 +305,10 @@ func queryEndpoint(endpoint string, timeout int) ([]byte, string, error) {
 	}
 
 	rsp, err := client.Get(endpoint)
-	//TODO: Insert check for 4xx
+
 	if (err == nil) && (rsp.StatusCode != 200) {
-		return []byte{}, "Non 200 Status Code. ", err
+		err := errors.New("Non 200 Status Code")
+		return []byte{}, "", err
 	}
 
 	if err != nil {

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -304,6 +304,11 @@ func queryEndpoint(endpoint string, timeout int) ([]byte, string, error) {
 	}
 
 	rsp, err := client.Get(endpoint)
+	//TODO: Insert check for 4xx
+	if (err == nil) && (rsp.StatusCode != 200) {
+		return []byte{}, "Non 200 Status Code. ", err
+	}
+
 	if err != nil {
 		return []byte{}, "", err
 	}


### PR DESCRIPTION
Set func queryEndpoint to ignore any non 200 HTTP status codes to avoid errors.