### PR TITLE
Remove Xenfix

### DIFF
--- a/src/diamond/collectors/cpu/cpu.py
+++ b/src/diamond/collectors/cpu/cpu.py
@@ -56,7 +56,6 @@ class CPUCollector(diamond.collector.Collector):
         config.update({
             'path':     'cpu',
             'percore':  'True',
-            'xenfix':   None,
             'simple':   'False',
             'normalize': 'False',
             'enableAggregation': 'False',
@@ -164,24 +163,6 @@ class CPUCollector(diamond.collector.Collector):
                         metrics[metric_name] = long(stats[s]) / ncpus
                     else:
                         metrics[metric_name] = long(stats[s])
-
-            # Check for a bug in xen where the idle time is doubled for guest
-            # See https://bugzilla.redhat.com/show_bug.cgi?id=624756
-            if self.config['xenfix'] is None or self.config['xenfix'] is True:
-                if os.path.isdir('/proc/xen'):
-                    total = 0
-                    for metric_name in metrics.keys():
-                        if 'cpu0.' in metric_name:
-                            total += int(metrics[metric_name])
-                    if total > 110:
-                        self.config['xenfix'] = True
-                        for mname in metrics.keys():
-                            if '.idle' in mname:
-                                metrics[mname] = float(metrics[mname]) / 2
-                    elif total > 0:
-                        self.config['xenfix'] = False
-                else:
-                    self.config['xenfix'] = False
 
             for metric_name in metrics.keys():
                 metric_value = metrics[metric_name]


### PR DESCRIPTION
This change was added to adjust for this bug:
https://bugzilla.redhat.com/show_bug.cgi?id=624756
However this bug was fixed as of 2012 with this update:
http://rhn.redhat.com/errata/RHSA-2012-0862.html (see fix list)

Furthermore, I've verified this on some AWS machines (which are running Xen hypervisors), following the gist of the reproduction steps in the bug report above. Each CPU now reports the proper jiffies per time unit measured (with the default configured to 100 USER_HZ). Since this Xenfix is aggressive (i.e. it runs if True OR None) many of our AWS machines are reporting incorrect CPU time values.