### PR TITLE
Fix flush collector dimensions

### DIFF
--- a/src/diamond/collector.py
+++ b/src/diamond/collector.py
@@ -301,6 +301,11 @@ class Collector(object):
         """
         Publish a metric with the given name
         """
+        dimensions = None
+        if self.dimensions is not None:
+            dimensions = self.dimensions
+            self.dimensions = None
+
         # Check whitelist/blacklist
         if self.config['metrics_whitelist']:
             if not self.config['metrics_whitelist'].match(name):
@@ -315,11 +320,6 @@ class Collector(object):
         # Get metric TTL
         ttl = float(self.config['interval']) * float(
             self.config['ttl_multiplier'])
-
-        dimensions = None
-        if self.dimensions is not None:
-            dimensions = self.dimensions
-            self.dimensions = None
 
         # Create Metric
         try:


### PR DESCRIPTION
If some metrics are blacklisted the dimensions associated to them are not flushed!
So you'll end up having metrics with wrong dimensions/values