### PR TITLE
Make whitelist compulsory for NerveHTTPD

### DIFF
--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -126,7 +126,7 @@ func (c *NerveHTTPD) Collect() {
 	c.log.Debug("Finished parsing Nerve config into ", servicePortMap)
 
 	for port, service := range servicePortMap {
-		if len(c.servicesWhitelist) == 0 || c.serviceInWhitelist(service) {
+		if c.serviceInWhitelist(service) {
 			if !c.checkIfFailed(service.Name, port) {
 				go c.emitHTTPDMetric(service, port)
 			}

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -231,12 +231,6 @@ func TestNerveHTTPDCollectWithEmptyWhiteList(t *testing.T) {
 	defer server.Close()
 	ip, port := parseURL(server.URL)
 
-	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
-		fmt.Fprint(w, string(getRawApacheStat()))
-	}))
-	defer server2.Close()
-	ip2, port2 := parseURL(server2.URL)
-
 	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
 	minimalNerveConfig["services"] = map[string]map[string]interface{}{
 		"test_service.namespace1.and.stuff": {
@@ -244,8 +238,8 @@ func TestNerveHTTPDCollectWithEmptyWhiteList(t *testing.T) {
 			"port": port,
 		},
 		"test_service.namespace2.and.stuff": {
-			"host": ip2,
-			"port": port2,
+			"host": ip,
+			"port": port,
 		},
 	}
 
@@ -291,12 +285,6 @@ func TestNerveHTTPDCollectWhiteListNotConfigured(t *testing.T) {
 	defer server.Close()
 	ip, port := parseURL(server.URL)
 
-	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
-		fmt.Fprint(w, string(getRawApacheStat()))
-	}))
-	defer server2.Close()
-	ip2, port2 := parseURL(server2.URL)
-
 	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
 	minimalNerveConfig["services"] = map[string]map[string]interface{}{
 		"test_service.namespace1.and.stuff": {
@@ -304,8 +292,8 @@ func TestNerveHTTPDCollectWhiteListNotConfigured(t *testing.T) {
 			"port": port,
 		},
 		"test_service.namespace2.and.stuff": {
-			"host": ip2,
-			"port": port2,
+			"host": ip,
+			"port": port,
 		},
 	}
 

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -127,8 +127,9 @@ func TestNerveHTTPDCollect(t *testing.T) {
 	assert.Nil(t, err)
 
 	cfg := map[string]interface{}{
-		"configFilePath": tmpFile.Name(),
-		"queryPath":      "",
+		"configFilePath":    tmpFile.Name(),
+		"queryPath":         "",
+		"servicesWhitelist": []string{"test_service.things"},
 	}
 
 	inst := getNerveHTTPDCollector()
@@ -156,7 +157,7 @@ func TestNerveHTTPDCollect(t *testing.T) {
 	assert.Equal(t, "things", metricMap["TotalAccesses"].Dimensions["service_namespace"])
 }
 
-func TestNerveHTTPDCollectWithWhiteList(t *testing.T) {
+func TestNerveHTTPDCollectWhiteList(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
 		fmt.Fprint(w, string(getRawApacheStat()))
 	}))
@@ -215,11 +216,129 @@ func TestNerveHTTPDCollectWithWhiteList(t *testing.T) {
 	assert.Equal(t, 17, len(actual))
 
 	metricMap := map[string]metric.Metric{}
-	for k, m := range actual {
-		fmt.Println("cane piccolo : ", k)
+	for _, m := range actual {
 		metricMap[m.Name] = m
 	}
 	assert.Equal(t, port2, metricMap["TotalAccesses"].Dimensions["port"])
 	assert.Equal(t, "test_service", metricMap["TotalAccesses"].Dimensions["service_name"])
 	assert.Equal(t, "namespace2", metricMap["TotalAccesses"].Dimensions["service_namespace"])
+}
+
+func TestNerveHTTPDCollectWithEmptyWhiteList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
+		fmt.Fprint(w, string(getRawApacheStat()))
+	}))
+	defer server.Close()
+	ip, port := parseURL(server.URL)
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
+		fmt.Fprint(w, string(getRawApacheStat()))
+	}))
+	defer server2.Close()
+	ip2, port2 := parseURL(server2.URL)
+
+	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
+	minimalNerveConfig["services"] = map[string]map[string]interface{}{
+		"test_service.namespace1.and.stuff": {
+			"host": ip,
+			"port": port,
+		},
+		"test_service.namespace2.and.stuff": {
+			"host": ip2,
+			"port": port2,
+		},
+	}
+
+	tmpFile, err := ioutil.TempFile("", "fullerite_testing")
+	defer os.Remove(tmpFile.Name())
+	assert.Nil(t, err)
+
+	marshalled, err := json.Marshal(minimalNerveConfig)
+	assert.Nil(t, err)
+
+	_, err = tmpFile.Write(marshalled)
+	assert.Nil(t, err)
+
+	cfg := map[string]interface{}{
+		"configFilePath":    tmpFile.Name(),
+		"queryPath":         "",
+		"servicesWhitelist": []string{},
+	}
+
+	inst := getNerveHTTPDCollector()
+	inst.Configure(cfg)
+
+	inst.Collect()
+	actual := []metric.Metric{}
+	flag := true
+	for flag == true {
+		select {
+		case metric := <-inst.Channel():
+			actual = append(actual, metric)
+		case <-time.After(2 * time.Second):
+			flag = false
+			break
+		}
+	}
+
+	assert.Equal(t, 0, len(actual))
+}
+
+func TestNerveHTTPDCollectWhiteListNotConfigured(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
+		fmt.Fprint(w, string(getRawApacheStat()))
+	}))
+	defer server.Close()
+	ip, port := parseURL(server.URL)
+
+	server2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, rsp *http.Request) {
+		fmt.Fprint(w, string(getRawApacheStat()))
+	}))
+	defer server2.Close()
+	ip2, port2 := parseURL(server2.URL)
+
+	minimalNerveConfig := make(map[string]map[string]map[string]interface{})
+	minimalNerveConfig["services"] = map[string]map[string]interface{}{
+		"test_service.namespace1.and.stuff": {
+			"host": ip,
+			"port": port,
+		},
+		"test_service.namespace2.and.stuff": {
+			"host": ip2,
+			"port": port2,
+		},
+	}
+
+	tmpFile, err := ioutil.TempFile("", "fullerite_testing")
+	defer os.Remove(tmpFile.Name())
+	assert.Nil(t, err)
+
+	marshalled, err := json.Marshal(minimalNerveConfig)
+	assert.Nil(t, err)
+
+	_, err = tmpFile.Write(marshalled)
+	assert.Nil(t, err)
+
+	cfg := map[string]interface{}{
+		"configFilePath": tmpFile.Name(),
+		"queryPath":      "",
+	}
+
+	inst := getNerveHTTPDCollector()
+	inst.Configure(cfg)
+
+	inst.Collect()
+	actual := []metric.Metric{}
+	flag := true
+	for flag == true {
+		select {
+		case metric := <-inst.Channel():
+			actual = append(actual, metric)
+		case <-time.After(2 * time.Second):
+			flag = false
+			break
+		}
+	}
+
+	assert.Equal(t, 0, len(actual))
 }


### PR DESCRIPTION
We want to avoid that non-HTTP services are polled. So if the collector receives an empty whitelist won't poll any service (instead of polling all of them as in the previous version).