### PR TITLE
Fix bug using protobuf

### DIFF
--- a/src/fullerite/handler/signalfx.go
+++ b/src/fullerite/handler/signalfx.go
@@ -105,9 +105,15 @@ func (s SignalFx) convertToProto(incomingMetric metric.Metric) *DataPoint {
 	}
 
 	for key, value := range s.getSanitizedDimensions(incomingMetric) {
+		// Dimension (protobuf) require a pointer to string
+		// values. We need to create new string objects in the
+		// scope of this for loop not to repeatedly add the
+		// same key:value pairs to the the datapoint.
+		dimKey := key
+		dimValue := value
 		dim := Dimension{
-			Key:   &key,
-			Value: &value,
+			Key:   &dimKey,
+			Value: &dimValue,
 		}
 		datapoint.Dimensions = append(datapoint.Dimensions, &dim)
 	}
@@ -119,13 +125,7 @@ func (s SignalFx) getSanitizedDimensions(incomingMetric metric.Metric) map[strin
 	dimSanitized := make(map[string]string)
 	dimensions := incomingMetric.GetDimensions(s.DefaultDimensions())
 	for key, value := range dimensions {
-		// Dimension (protobuf) require a pointer to string
-		// values. We need to create new string objects in the
-		// scope of this for loop not to repeatedly add the
-		// same key:value pairs to the the datapoint.
-		dimensionKey := signalFxKeySanitize(key)
-		dimensionValue := signalFxValueSanitize(value)
-		dimSanitized[dimensionKey] = dimensionValue
+		dimSanitized[signalFxKeySanitize(key)] = signalFxValueSanitize(value)
 	}
 	return dimSanitized
 }

--- a/src/fullerite/handler/signalfx_test.go
+++ b/src/fullerite/handler/signalfx_test.go
@@ -129,4 +129,9 @@ func TestSignalFxSanitation(t *testing.T) {
 	datapoint2 := s.convertToProto(m2)
 
 	assert.Equal(t, datapoint1.GetMetric(), datapoint2.GetMetric(), "the two metrics should be the same")
+	for i := 0; i < len(datapoint1.GetDimensions())-1; i++ {
+		for j := i + 1; j < len(datapoint1.GetDimensions()); j++ {
+			assert.NotEqual(t, datapoint1.GetDimensions()[i].GetKey(), datapoint1.GetDimensions()[j].GetKey(), "the two dimensions should be different")
+		}
+	}
 }


### PR DESCRIPTION
The problem happened in [singalfx.go|https://github.com/Yelp/fullerite/blob/master/src/fullerite/handler/signalfx.go#L108] module. Once the function `convertToProto()`  is called, a metric is converted into a proper structure, called [Datapoint|https://github.com/Yelp/fullerite/blob/7bf7cd8da66fb187a5a67692ab7add3909dc1a2c/src/fullerite/handler/signalfx.pb.go#L131], ready to be sent to SignalFx . `Datapoint` contains an array of dimensions as pointers to string values. So when the metric dimensions are added to a Datapoint, we need to create new string objects per each dimension key and value so not to repeatedly add the same key:value pairs to the the datapoint.