### PR TITLE
Collect CPU throttled periods/time from docker collector

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -183,6 +183,8 @@ func (d DockerStats) buildMetrics(container *docker.Container, containerStats *d
 		buildDockerMetric("DockerMemoryUsed", metric.Gauge, float64(containerStats.MemoryStats.Usage)),
 		buildDockerMetric("DockerMemoryLimit", metric.Gauge, float64(containerStats.MemoryStats.Limit)),
 		buildDockerMetric("DockerCpuPercentage", metric.Gauge, cpuPercentage),
+		buildDockerMetric("DockerCpuThrottledPeriods", metric.CumulativeCounter, float64(containerStats.CPUStats.ThrottlingData.ThrottledPeriods)),
+		buildDockerMetric("DockerCpuThrottledNanoseconds", metric.CumulativeCounter, float64(containerStats.CPUStats.ThrottlingData.ThrottledTime)),
 	}
 	for netiface := range containerStats.Networks {
 		// legacy format

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -76,6 +76,8 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	stats.Networks["eth0"] = docker.NetworkStats{RxBytes: 10, TxBytes: 20}
 	stats.MemoryStats.Usage = 50
 	stats.MemoryStats.Limit = 70
+	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
+	stats.CPUStats.ThrottlingData.ThrottledTime = 456
 
 	containerJSON := []byte(`
 	{
@@ -113,6 +115,8 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, baseDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, baseDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, baseDims},
+		metric.Metric{"DockerCpuThrottledPeriods", "cumcounter", 123, baseDims},
+		metric.Metric{"DockerCpuThrottledNanoseconds", "cumcounter", 456, baseDims},
 		metric.Metric{"DockerTxBytes", "cumcounter", 20, netDims},
 		metric.Metric{"DockerRxBytes", "cumcounter", 10, netDims},
 		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
@@ -141,6 +145,8 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 	stats := new(docker.Stats)
 	stats.MemoryStats.Usage = 50
 	stats.MemoryStats.Limit = 70
+	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
+	stats.CPUStats.ThrottlingData.ThrottledTime = 456
 
 	containerJSON := []byte(`
 	{
@@ -168,6 +174,8 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, expectedDims},
+		metric.Metric{"DockerCpuThrottledPeriods", "cumcounter", 123, expectedDims},
+		metric.Metric{"DockerCpuThrottledNanoseconds", "cumcounter", 456, expectedDims},
 		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
 	}
 


### PR DESCRIPTION
Since we added CPU throttling to Paasta with Yelp/paasta#564 / Yelp/paasta#504, it would be great to have metrics showing when/how much containers are hitting their CPU caps.