### PR TITLE
These tests require additional libraries to run

### DIFF
--- a/src/diamond/blacklist_test.txt
+++ b/src/diamond/blacklist_test.txt
@@ -55,3 +55,9 @@ TestNagiosStatsCollector
 TestSmartCollector
 TestElbCollector
 TestMySQLCollector
+TestPgbouncerCollector
+TestSlonyCollector
+TestMongoDBCollector
+TestMongoMultiHostDBCollector
+TestTokuMXCollector
+TestPgbouncerCollector


### PR DESCRIPTION
They are currently just not running via travis because
they require additional libraries to run and hence they appear to
be passing. But in fact - if necessary client libraies are installed
these tests are failing.