### PR TITLE
fullerite nerve config parser reports wrong mappings port:service

### DIFF
--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -118,17 +118,17 @@ func (c *NerveHTTPD) Collect() {
 		c.log.Warn("Failed to read the contents of file ", c.configFilePath, " because ", err)
 		return
 	}
-	servicePortMap, err := util.ParseNerveConfig(&rawFileContents)
+	services, err := util.ParseNerveConfig(&rawFileContents)
 	if err != nil {
 		c.log.Warn("Failed to parse the nerve config at ", c.configFilePath, ": ", err)
 		return
 	}
-	c.log.Debug("Finished parsing Nerve config into ", servicePortMap)
+	c.log.Debug("Finished parsing Nerve config into ", services)
 
-	for port, service := range servicePortMap {
+	for _, service := range services {
 		if c.serviceInWhitelist(service) {
-			if !c.checkIfFailed(service.Name, port) {
-				go c.emitHTTPDMetric(service, port)
+			if !c.checkIfFailed(service.Name, service.Port) {
+				go c.emitHTTPDMetric(service, service.Port)
 			}
 		}
 	}

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -118,7 +118,7 @@ func (c *NerveHTTPD) Collect() {
 		c.log.Warn("Failed to read the contents of file ", c.configFilePath, " because ", err)
 		return
 	}
-	services, err := util.ParseNerveConfig(&rawFileContents)
+	services, err := util.ParseNerveConfig(&rawFileContents, true)
 	if err != nil {
 		c.log.Warn("Failed to parse the nerve config at ", c.configFilePath, ": ", err)
 		return

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -131,15 +131,15 @@ func (n *nerveUWSGICollector) Collect() {
 		return
 	}
 
-	servicePortMap, err := util.ParseNerveConfig(&rawFileContents)
+	services, err := util.ParseNerveConfig(&rawFileContents)
 	if err != nil {
 		n.log.Warn("Failed to parse the nerve config at ", n.configFilePath, ": ", err)
 		return
 	}
-	n.log.Debug("Finished parsing Nerve config into ", servicePortMap)
+	n.log.Debug("Finished parsing Nerve config into ", services)
 
-	for port, service := range servicePortMap {
-		go n.queryService(service.Name, port)
+	for _, service := range services {
+		go n.queryService(service.Name, service.Port)
 	}
 }
 

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -131,7 +131,7 @@ func (n *nerveUWSGICollector) Collect() {
 		return
 	}
 
-	services, err := util.ParseNerveConfig(&rawFileContents)
+	services, err := util.ParseNerveConfig(&rawFileContents, false)
 	if err != nil {
 		n.log.Warn("Failed to parse the nerve config at ", n.configFilePath, ": ", err)
 		return

--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -38,6 +38,7 @@ type nerveConfigData struct {
 type NerveService struct {
 	Name      string
 	Namespace string
+	Port      int
 }
 
 // EndPoint defines a struct for endpoints
@@ -49,8 +50,9 @@ type EndPoint struct {
 // ParseNerveConfig is responsible for taking the JSON string coming in into a map of service:port
 // it will also filter based on only services runnign on this host.
 // To deal with multi-tenancy we actually will return port:service
-func ParseNerveConfig(raw *[]byte) (map[int]NerveService, error) {
-	results := make(map[int]NerveService)
+func ParseNerveConfig(raw *[]byte) ([]NerveService, error) {
+	services := make(map[string]NerveService)
+	results := []NerveService{}
 	ips, err := ipGetter()
 
 	if err != nil {
@@ -79,11 +81,15 @@ func ParseNerveConfig(raw *[]byte) (map[int]NerveService, error) {
 			service.Namespace = strings.Split(rawServiceName, ".")[1]
 			port := extractPort(serviceConfig)
 			if port != -1 {
-				results[port] = *service
+				service.Port = port
+				services[service.Name+service.Namespace+":"+strconv.Itoa(port)] = *service
 			}
 		}
 	}
 
+	for _, value := range services {
+		results = append(results, value)
+	}
 	return results, nil
 }
 

--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -50,7 +50,7 @@ type EndPoint struct {
 // ParseNerveConfig is responsible for taking the JSON string coming in into a map of service:port
 // it will also filter based on only services runnign on this host.
 // To deal with multi-tenancy we actually will return port:service
-func ParseNerveConfig(raw *[]byte) ([]NerveService, error) {
+func ParseNerveConfig(raw *[]byte, namespaceIncluded bool) ([]NerveService, error) {
 	services := make(map[string]NerveService)
 	results := []NerveService{}
 	ips, err := ipGetter()
@@ -82,7 +82,11 @@ func ParseNerveConfig(raw *[]byte) ([]NerveService, error) {
 			port := extractPort(serviceConfig)
 			if port != -1 {
 				service.Port = port
-				services[service.Name+service.Namespace+":"+strconv.Itoa(port)] = *service
+				if namespaceIncluded {
+					services[service.Name+service.Namespace+":"+strconv.Itoa(port)] = *service
+				} else {
+					services[service.Name+":"+strconv.Itoa(port)] = *service
+				}
 			}
 		}
 	}

--- a/src/fullerite/util/nerve_config_test.go
+++ b/src/fullerite/util/nerve_config_test.go
@@ -61,6 +61,31 @@ func getTestNerveConfig() []byte {
 	                "10.40.1.17:22181"
 	            ],
 	            "zk_path": "/nerve/superregion:norcal-devc/example_service.mesosstage_main"
+	        },
+	        "example_service.another.norcal-devc.superregion:norcal-devc.13752.new": {
+	            "check_interval": 7,
+	            "checks": [
+	                {
+	                    "fall": 2,
+	                    "headers": {},
+	                    "host": "127.0.0.1",
+	                    "open_timeout": 6,
+	                    "port": 6666,
+	                    "rise": 1,
+	                    "timeout": 6,
+	                    "type": "http",
+	                    "uri": "/http/example_service.another/13752/status"
+	                }
+	            ],
+	            "host": "10.56.5.21",
+	            "port": 22222,
+	            "weight": 24,
+	            "zk_hosts": [
+	                "10.40.5.5:22181",
+	                "10.40.5.6:22181",
+	                "10.40.1.17:22181"
+	            ],
+	            "zk_path": "/nerve/superregion:norcal-devc/example_service.another"
 	        }
 	    }
 	}
@@ -122,16 +147,21 @@ func badURINerveConfig() []byte {
 }
 
 func TestNerveConfigParsing(t *testing.T) {
-	expected := map[int]NerveService{
-		22224: NerveService{Name: "example_service", Namespace: "mesosstage_main"},
-		13752: NerveService{Name: "example_service", Namespace: "main"},
+	expected := map[NerveService]bool{
+		NerveService{Name: "example_service", Namespace: "mesosstage_main", Port: 22224}: true,
+		NerveService{Name: "example_service", Namespace: "main", Port: 13752}:            true,
+		NerveService{Name: "example_service", Namespace: "another", Port: 13752}:         true,
 	}
 
 	cfgString := getTestNerveConfig()
 	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
 	results, err := ParseNerveConfig(&cfgString)
 	assert.Nil(t, err)
-	assert.Equal(t, expected, results)
+	m := make(map[NerveService]bool)
+	for _, r := range results {
+		m[r] = true
+	}
+	assert.Equal(t, expected, m)
 }
 
 func TestNerveFilterOnIP(t *testing.T) {

--- a/src/fullerite/util/nerve_config_test.go
+++ b/src/fullerite/util/nerve_config_test.go
@@ -155,7 +155,7 @@ func TestNerveConfigParsing(t *testing.T) {
 
 	cfgString := getTestNerveConfig()
 	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
-	results, err := ParseNerveConfig(&cfgString)
+	results, err := ParseNerveConfig(&cfgString, true)
 	assert.Nil(t, err)
 	m := make(map[NerveService]bool)
 	for _, r := range results {
@@ -164,10 +164,26 @@ func TestNerveConfigParsing(t *testing.T) {
 	assert.Equal(t, expected, m)
 }
 
+func TestNerveConfigParsingiNoNamespace(t *testing.T) {
+	expected := map[int]bool{
+		22224: true, 13752: true,
+	}
+
+	cfgString := getTestNerveConfig()
+	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
+	results, err := ParseNerveConfig(&cfgString, false)
+	assert.Nil(t, err)
+	m := make(map[int]bool)
+	for _, r := range results {
+		m[r.Port] = true
+	}
+	assert.Equal(t, expected, m)
+}
+
 func TestNerveFilterOnIP(t *testing.T) {
 	cfgString := getTestNerveConfig()
 	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
-	results, err := ParseNerveConfig(&cfgString)
+	results, err := ParseNerveConfig(&cfgString, true)
 	assert.Nil(t, err)
 	assert.NotNil(t, results)
 	assert.Equal(t, 0, len(results))
@@ -177,7 +193,7 @@ func TestHandleBadNerveConfig(t *testing.T) {
 	// b/c there is valid json coming in it won't error, just have an empty response
 	cfgString := []byte("{}")
 	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
-	results, err := ParseNerveConfig(&cfgString)
+	results, err := ParseNerveConfig(&cfgString, true)
 	assert.Nil(t, err)
 	assert.NotNil(t, results)
 	assert.Equal(t, 0, len(results))
@@ -186,7 +202,7 @@ func TestHandleBadNerveConfig(t *testing.T) {
 func TestHandlePoorlyFormedJson(t *testing.T) {
 	cfgString := []byte("notjson")
 	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
-	results, err := ParseNerveConfig(&cfgString)
+	results, err := ParseNerveConfig(&cfgString, true)
 	assert.NotNil(t, err)
 	assert.NotNil(t, results)
 	assert.Equal(t, 0, len(results))
@@ -195,13 +211,13 @@ func TestHandlePoorlyFormedJson(t *testing.T) {
 func TestNoURI(t *testing.T) {
 	cfgString := noURINerveConfig()
 	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
-	results, _ := ParseNerveConfig(&cfgString)
+	results, _ := ParseNerveConfig(&cfgString, true)
 	assert.Equal(t, 0, len(results))
 }
 
 func TestBadURI(t *testing.T) {
 	cfgString := badURINerveConfig()
 	ipGetter = func() ([]string, error) { return []string{"10.56.5.21"}, nil }
-	results, _ := ParseNerveConfig(&cfgString)
+	results, _ := ParseNerveConfig(&cfgString, true)
 	assert.Equal(t, 0, len(results))
 }


### PR DESCRIPTION
Nerve config parser returns a map of port:service. Since the port must be unique we are saying that there cant be more than one service running behind a specific port. That's probably true for paasta but it's not true in a general nerve case.

If we keep using the parser as it is and there are more services using the same port, just one service is returned (the last one processed) and that is wrong. all the services must be returned.
