### PR TITLE
Http alive copy headers

### DIFF
--- a/src/fullerite/handler/signalfx.go
+++ b/src/fullerite/handler/signalfx.go
@@ -157,12 +157,16 @@ func (s *SignalFx) emitMetrics(metrics []metric.Metric) bool {
 		return false
 	}
 
-	s.httpClient.SetHeader(map[string]string{
+	customHeader := map[string]string{
 		"X-SF-TOKEN":   s.authToken,
 		"Content-Type": "application/x-protobuf",
-	})
+	}
 
-	rsp, err := s.httpClient.MakeRequest("POST", s.endpoint, bytes.NewBuffer(serialized))
+	rsp, err := s.httpClient.MakeRequest(
+		"POST",
+		s.endpoint,
+		bytes.NewBuffer(serialized),
+		customHeader)
 
 	if err != nil {
 		s.log.Error("Failed to make request ", err,

--- a/src/fullerite/util/http_alive.go
+++ b/src/fullerite/util/http_alive.go
@@ -5,7 +5,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"sync"
 	"time"
 )
 
@@ -13,7 +12,6 @@ import (
 type HTTPAlive struct {
 	client    *http.Client
 	transport *http.Transport
-	mu        sync.Mutex
 }
 
 // HTTPAliveResponse returns a response
@@ -47,8 +45,6 @@ func (connection *HTTPAlive) Configure(timeout time.Duration,
 // MakeRequest make a new http request
 func (connection *HTTPAlive) MakeRequest(method string,
 	uri string, body io.Reader, header map[string]string) (*HTTPAliveResponse, error) {
-	connection.mu.Lock()
-	defer connection.mu.Unlock()
 	req, err := http.NewRequest(method, uri, body)
 
 	if err != nil {

--- a/src/fullerite/util/http_alive.go
+++ b/src/fullerite/util/http_alive.go
@@ -5,14 +5,15 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"sync"
 	"time"
 )
 
 // HTTPAlive implements a simple way of reusing http connections
 type HTTPAlive struct {
-	client       *http.Client
-	transport    *http.Transport
-	customHeader map[string]string
+	client    *http.Client
+	transport *http.Transport
+	mu        sync.Mutex
 }
 
 // HTTPAliveResponse returns a response
@@ -43,16 +44,11 @@ func (connection *HTTPAlive) Configure(timeout time.Duration,
 	}
 }
 
-// SetHeader for setting some custom headers
-func (connection *HTTPAlive) SetHeader(header map[string]string) {
-	connection.customHeader = header
-}
-
 // MakeRequest make a new http request
 func (connection *HTTPAlive) MakeRequest(method string,
-	uri string, body io.Reader) (*HTTPAliveResponse, error) {
-
-	defer connection.resetCustomHeader()
+	uri string, body io.Reader, header map[string]string) (*HTTPAliveResponse, error) {
+	connection.mu.Lock()
+	defer connection.mu.Unlock()
 	req, err := http.NewRequest(method, uri, body)
 
 	if err != nil {
@@ -60,7 +56,7 @@ func (connection *HTTPAlive) MakeRequest(method string,
 	}
 
 	// Apply user provided headers
-	for key, value := range connection.customHeader {
+	for key, value := range header {
 		req.Header.Set(key, value)
 	}
 
@@ -88,10 +84,6 @@ func (connection *HTTPAlive) submitRequest(req *http.Request) (*HTTPAliveRespons
 	httpAliveResponse.StatusCode = rsp.StatusCode
 	httpAliveResponse.Header = rsp.Header
 	return httpAliveResponse, nil
-}
-
-func (connection *HTTPAlive) resetCustomHeader() {
-	connection.customHeader = make(map[string]string)
 }
 
 func discardResponseBody(body io.ReadCloser) {

--- a/src/fullerite/util/http_alive_test.go
+++ b/src/fullerite/util/http_alive_test.go
@@ -21,15 +21,16 @@ func TestMakeRequest(t *testing.T) {
 	httpClient.Configure(time.Duration(10)*time.Second, time.Minute, 10)
 	assert.Equal(t, 10, httpClient.transport.MaxIdleConnsPerHost)
 
-	httpClient.SetHeader(map[string]string{
+	customHeader := map[string]string{
 		"foo": "bar",
-	})
+	}
 
-	assert.Equal(t, httpClient.customHeader["foo"], "bar")
-
-	resp, err := httpClient.MakeRequest("GET", ts.URL, bytes.NewBufferString("fullerite"))
+	resp, err := httpClient.MakeRequest(
+		"GET",
+		ts.URL,
+		bytes.NewBufferString("fullerite"),
+		customHeader)
 
 	assert.Nil(t, err)
 	assert.Equal(t, string(resp.Body), "done\n")
-	assert.Empty(t, httpClient.customHeader)
 }


### PR DESCRIPTION
This code makes sure that - we are individually setting headers for each request via the function rather than header being a property of http client. 

It is more thread safe, this way.