### PR TITLE
Exclude Container name and id from DockerStat metric dimensions

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -30,7 +30,7 @@ type DockerStats struct {
 	skipRegex         *regexp.Regexp
 	endpoint          string
 	mu                *sync.Mutex
-	lessDimensions    bool
+	emit_image_name   bool
 }
 
 // CPUValues struct contains the last cpu-usage values in order to compute properly the current values.
@@ -63,7 +63,7 @@ func newDockerStats(channel chan metric.Metric, initialInterval int, log *l.Entr
 	d.name = "DockerStats"
 	d.previousCPUValues = make(map[string]*CPUValues)
 	d.compiledRegex = make(map[string]*Regex)
-	d.lessDimensions = false
+	d.emit_image_name = false
 	return d
 }
 
@@ -88,11 +88,11 @@ func (d *DockerStats) Configure(configMap map[string]interface{}) {
 	} else {
 		d.endpoint = endpoint
 	}
-	if lessDimensions, exists := configMap["lessDimensions"]; exists {
-		if boolean, ok := lessDimensions.(bool); ok {
-			d.lessDimensions = boolean
+	if emit_image_name, exists := configMap["emit_image_name"]; exists {
+		if boolean, ok := emit_image_name.(bool); ok {
+			d.emit_image_name = boolean
 		} else {
-			d.log.Warn("Failed to cast lessDimensions: ", reflect.TypeOf(lessDimensions))
+			d.log.Warn("Failed to cast emit_image_name: ", reflect.TypeOf(emit_image_name))
 		}
 	}
 
@@ -206,7 +206,7 @@ func (d DockerStats) buildMetrics(container *docker.Container, containerStats *d
 		ret = append(ret, rxb)
 	}
 	additionalDimensions := map[string]string{}
-	if d.lessDimensions {
+	if d.emit_image_name {
 		stringList := strings.Split(container.Config.Image, ":")
 		additionalDimensions = map[string]string{
 			"image_name": stringList[0],

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -128,6 +128,79 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	assert.Equal(t, ret, expectedMetrics)
 }
 
+func TestDockerStatsBuildwithlessDimensions(t *testing.T) {
+	config := make(map[string]interface{})
+	envVars := []byte(`
+	{
+		"service_name":  {
+			"MESOS_TASK_ID": "[^\\.]*"
+		},
+		"instance_name": {
+			"MESOS_TASK_ID": "\\.([^\\.]*)\\."}
+	}`)
+	var val map[string]interface{}
+
+	err := json.Unmarshal(envVars, &val)
+	assert.Equal(t, err, nil)
+	config["generatedDimensions"] = val
+
+	stats := new(docker.Stats)
+	stats.Networks = make(map[string]docker.NetworkStats)
+	stats.Networks["eth0"] = docker.NetworkStats{RxBytes: 10, TxBytes: 20}
+	stats.MemoryStats.Usage = 50
+	stats.MemoryStats.Limit = 70
+	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
+	stats.CPUStats.ThrottlingData.ThrottledTime = 456
+
+	containerJSON := []byte(`
+	{
+        "ID": "test-id",
+		"Name": "test-container",
+		"Config": {
+			"Env": [
+				"MESOS_TASK_ID=my--service.main.blablagit6bdsadnoise"
+			],
+            "Image": "test image"
+		}
+	}`)
+	var container *docker.Container
+	err = json.Unmarshal(containerJSON, &container)
+	assert.Equal(t, err, nil)
+
+	baseDims := map[string]string{
+		"image_name":    "test image",
+		"service_name":  "my_service",
+		"instance_name": "main",
+	}
+	netDims := map[string]string{
+		"image_name":    "test image",
+		"iface":         "eth0",
+		"service_name":  "my_service",
+		"instance_name": "main",
+	}
+
+	expectedDimsGen := map[string]string{
+		"service_name":  "my_service",
+		"instance_name": "main",
+	}
+	expectedMetrics := []metric.Metric{
+		metric.Metric{"DockerMemoryUsed", "gauge", 50, baseDims},
+		metric.Metric{"DockerMemoryLimit", "gauge", 70, baseDims},
+		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, baseDims},
+		metric.Metric{"DockerCpuThrottledPeriods", "cumcounter", 123, baseDims},
+		metric.Metric{"DockerCpuThrottledNanoseconds", "cumcounter", 456, baseDims},
+		metric.Metric{"DockerTxBytes", "cumcounter", 20, netDims},
+		metric.Metric{"DockerRxBytes", "cumcounter", 10, netDims},
+		metric.Metric{"DockerContainerCount", "counter", 1, expectedDimsGen},
+	}
+
+	d := getSUT()
+	d.Configure(config)
+	d.lessDimensions = true
+	ret := d.buildMetrics(container, stats, 0.5)
+	assert.Equal(t, ret, expectedMetrics)
+}
+
 func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 	config := make(map[string]interface{})
 	envVars := []byte(`
@@ -170,6 +243,7 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 	expectedDimsGen := map[string]string{
 		"service_name": "my_service",
 	}
+
 	expectedMetrics := []metric.Metric{
 		metric.Metric{"DockerMemoryUsed", "gauge", 50, expectedDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, expectedDims},

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -128,7 +128,7 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	assert.Equal(t, ret, expectedMetrics)
 }
 
-func TestDockerStatsBuildwithlessDimensions(t *testing.T) {
+func TestDockerStatsBuildwithemit_image_name(t *testing.T) {
 	config := make(map[string]interface{})
 	envVars := []byte(`
 	{
@@ -196,7 +196,7 @@ func TestDockerStatsBuildwithlessDimensions(t *testing.T) {
 
 	d := getSUT()
 	d.Configure(config)
-	d.lessDimensions = true
+	d.emit_image_name = true
 	ret := d.buildMetrics(container, stats, 0.5)
 	assert.Equal(t, ret, expectedMetrics)
 }


### PR DESCRIPTION
Please suggest a better name for the boolean flag than lessDimensions if you have one. I have tested my change manually on some hosts. Check the image_name dimension in SignalFx for confirmation. Also, I have another concern that about my change. There could be multiple containers with the same image running at the same time. So, multiple data points for same MTS could be reported to SignalFx at the same time. Will that be an issue for SingalFx? If so, I can de-dupe the data points.