### PR TITLE
Add custom dimensions to smem metrics by parsing /proc/PID/cmdline

### DIFF
--- a/src/fullerite/collector/smem.go
+++ b/src/fullerite/collector/smem.go
@@ -5,15 +5,20 @@
 //   "user": "some-user", <-- This user should be able to access the /proc/<pid>/smaps files listed in the whitelist below
 //   "procsWhitelist": "apache2|tmux",
 //   "smemPath": "/usr/bin/smem" <-- Path to the smem executable
+//   "dimensionsFromCmdline": {"worker_id": "apache worker ([0-9]+)"}
 // }
 
 package collector
 
 import (
+	"fmt"
 	"fullerite/config"
 	"fullerite/metric"
 	"fullerite/util"
+	"io/ioutil"
 	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 
 	l "github.com/Sirupsen/logrus"
@@ -25,23 +30,27 @@ type smemStatLine struct {
 	uss  float64
 	rss  float64
 	vss  float64
+	pid  int
 }
 
 // SmemStats Collector to record smem stats
 type SmemStats struct {
 	baseCollector
-	user               string
-	whitelistedProcs   string
-	smemPath           string
-	whitelistedMetrics []string
+	user                  string
+	whitelistedProcs      string
+	smemPath              string
+	whitelistedMetrics    []string
+	dimensionsFromCmdline map[string]string
 }
 
 var (
-	requiredConfigs = []string{"user", "procsWhitelist"}
-	execCommand     = exec.Command
-	commandOutput   = (*exec.Cmd).Output
-	getSmemStats    = (*SmemStats).getSmemStats
-	allMetrics      = []string{"rss", "vss", "pss", "uss"}
+	requiredConfigs     = []string{"user", "procsWhitelist"}
+	execCommand         = exec.Command
+	commandOutput       = (*exec.Cmd).Output
+	getSmemStats        = (*SmemStats).getSmemStats
+	getCustomDimensions = (*SmemStats).getCustomDimensions
+	readCmdline         = (*SmemStats).readCmdline
+	allMetrics          = []string{"rss", "vss", "pss", "uss"}
 )
 
 func init() {
@@ -85,28 +94,59 @@ func (s *SmemStats) Configure(configMap map[string]interface{}) {
 	} else {
 		s.whitelistedMetrics = allMetrics
 	}
+
+	if dimensionsFromCmdline, exists := configMap["dimensionsFromCmdline"]; exists {
+		s.dimensionsFromCmdline = config.GetAsMap(dimensionsFromCmdline)
+	}
 }
 
-// Collect periodically call smem periodically
+// Collect calls smem periodically
 func (s *SmemStats) Collect() {
 	if s.whitelistedProcs == "" || s.user == "" || s.smemPath == "" {
 		return
 	}
 
 	for _, stat := range getSmemStats(s) {
+		dims := getCustomDimensions(s, stat.pid)
 		for _, element := range s.whitelistedMetrics {
+			var m metric.Metric
 			switch element {
 			case "pss":
-				s.Channel() <- metric.WithValue(stat.proc+".smem.pss", stat.pss)
+				m = metric.WithValue(stat.proc+".smem.pss", stat.pss)
 			case "uss":
-				s.Channel() <- metric.WithValue(stat.proc+".smem.uss", stat.uss)
+				m = metric.WithValue(stat.proc+".smem.uss", stat.uss)
 			case "vss":
-				s.Channel() <- metric.WithValue(stat.proc+".smem.vss", stat.vss)
+				m = metric.WithValue(stat.proc+".smem.vss", stat.vss)
 			case "rss":
-				s.Channel() <- metric.WithValue(stat.proc+".smem.rss", stat.rss)
+				m = metric.WithValue(stat.proc+".smem.rss", stat.rss)
+			}
+			m.AddDimensions(dims)
+			s.Channel() <- m
+		}
+	}
+}
+
+func (s *SmemStats) readCmdline(fileName string) ([]byte, error) {
+	return ioutil.ReadFile(fileName)
+}
+
+func (s *SmemStats) getCustomDimensions(pid int) map[string]string {
+	dimensions := make(map[string]string)
+	if pid != 0 {
+		for name, rexStr := range s.dimensionsFromCmdline {
+			data, err := readCmdline(s, fmt.Sprintf("/proc/%d/cmdline", pid))
+			if err != nil {
+				s.log.Warn(err.Error())
+			} else {
+				rex, _ := regexp.Compile(rexStr)
+				match := rex.FindStringSubmatch(string(data))
+				if len(match) > 1 {
+					dimensions[name] = string(match[1])
+				}
 			}
 		}
 	}
+	return dimensions
 }
 
 func (s *SmemStats) getSmemStats() []smemStatLine {
@@ -118,7 +158,7 @@ func (s *SmemStats) getSmemStats() []smemStatLine {
 		"-u", s.user,
 		s.smemPath,
 		"-P", s.whitelistedProcs,
-		"-c", "pss uss rss vss name")
+		"-c", "pss uss rss vss name pid")
 	if out, err = commandOutput(cmd); err != nil {
 		s.log.Error(err.Error())
 		return nil
@@ -134,12 +174,14 @@ func (s *SmemStats) parseSmemLines(out string) []smemStatLine {
 
 	for _, line := range lines {
 		parts := strings.Fields(line)
+		pid, _ := strconv.Atoi(parts[5])
 		stats = append(stats, smemStatLine{
 			proc: parts[4],
 			pss:  util.StrToFloat(parts[0]),
 			uss:  util.StrToFloat(parts[1]),
 			rss:  util.StrToFloat(parts[2]),
 			vss:  util.StrToFloat(parts[3]),
+			pid:  pid,
 		})
 	}
 

--- a/src/fullerite/collector/smem_test.go
+++ b/src/fullerite/collector/smem_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var smemOutput = `    5     343     864    2442180 apache2
+var smemOutput = `    5     343     864    2442180 apache2 1234
 `
 
 func TestNewSmemStats(t *testing.T) {
@@ -73,10 +73,12 @@ func TestSmemStatsConfigure(t *testing.T) {
 func TestSmemStatsCollect(t *testing.T) {
 	oldExecCommand := execCommand
 	oldCommandOutput := commandOutput
+	oldGetCustomDimensions := getCustomDimensions
 
 	defer func() {
 		execCommand = oldExecCommand
 		commandOutput = oldCommandOutput
+		getCustomDimensions = oldGetCustomDimensions
 	}()
 
 	execCommand = func(string, ...string) *exec.Cmd {
@@ -87,12 +89,19 @@ func TestSmemStatsCollect(t *testing.T) {
 		return []byte(smemOutput), nil
 	}
 
+	getCustomDimensions = func(_ *SmemStats, pid int) map[string]string {
+		return map[string]string{
+			"dim1": "val1",
+		}
+	}
+
+	expectedDims := map[string]string{"dim1": "val1"}
 	actual := []metric.Metric{}
 	expected := []metric.Metric{
-		metric.Metric{Name: "apache2.smem.pss", MetricType: "gauge", Value: 5, Dimensions: map[string]string{}},
-		metric.Metric{Name: "apache2.smem.uss", MetricType: "gauge", Value: 343, Dimensions: map[string]string{}},
-		metric.Metric{Name: "apache2.smem.vss", MetricType: "gauge", Value: 2.44218e+06, Dimensions: map[string]string{}},
-		metric.Metric{Name: "apache2.smem.rss", MetricType: "gauge", Value: 864, Dimensions: map[string]string{}},
+		metric.Metric{Name: "apache2.smem.pss", MetricType: "gauge", Value: 5, Dimensions: expectedDims},
+		metric.Metric{Name: "apache2.smem.uss", MetricType: "gauge", Value: 343, Dimensions: expectedDims},
+		metric.Metric{Name: "apache2.smem.vss", MetricType: "gauge", Value: 2.44218e+06, Dimensions: expectedDims},
+		metric.Metric{Name: "apache2.smem.rss", MetricType: "gauge", Value: 864, Dimensions: expectedDims},
 	}
 
 	c := make(chan metric.Metric)
@@ -151,4 +160,24 @@ func TestSmemStatsCollectNotCalled(t *testing.T) {
 
 		assert.False(t, getSmemStatsCalled)
 	}
+}
+
+func TestGetCustomDimensions(t *testing.T) {
+	oldReadCmdline := readCmdline
+	defer func() { readCmdline = oldReadCmdline }()
+
+	readCmdline = func(_ *SmemStats, _ string) ([]byte, error) {
+		return []byte("apache worker 1"), nil
+	}
+
+	s := newSmemStats(nil, 0, nil).(*SmemStats)
+	s.dimensionsFromCmdline = map[string]string{
+		"worker_id": ".* worker ([0-9]+)$",
+	}
+
+	expectedDims := map[string]string{
+		"worker_id": "1",
+	}
+
+	assert.Equal(t, getCustomDimensions(s, 123), expectedDims)
 }


### PR DESCRIPTION
I need to add 2 custom dimensions for Apache and uWSGI metrics: the
worker id and the process type (master, worker, http, mule).
These info can be obtained from /proc/PID/cmdline and are the same you
can see when running ps aux.

This PR allows users to extract those values and add them as dimensions.

I tested it on my machine using: "dimensionsFromCmdline":{"worker_id":
".* worker ([0-9]+)$","process_type":".* uWSGI ([^ ]+).*"}}.

This change will NOT change the number of datapoints emitted, but it
will create more timeseries. However the worker_id is always a number
between 0 and N and is reused when a worker gets restarted, so this won't
generate an infinite number of timeseries.