### PR TITLE
Implement collector buffer size

### DIFF
--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -8,7 +8,6 @@ import (
 
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 )
 
@@ -16,13 +15,7 @@ func startCollectors(c config.Config) (collectors []collector.Collector) {
 	log.Info("Starting collectors...")
 
 	for _, name := range c.Collectors {
-		configFile := strings.Join([]string{c.CollectorsConfigPath, name}, "/") + ".conf"
-		// Since collector naems can be defined with a space in order to instantiate multiple
-		// instances of the same collector, we want their files
-		// will not have that space and needs to have it replaced with an underscore
-		// instead
-		configFile = strings.Replace(configFile, " ", "_", -1)
-		conf, err := config.ReadCollectorConfig(configFile)
+		conf, err := c.GetCollectorConfig(name)
 		if err != nil {
 			log.Error("Collector config failed to load for: ", name)
 			continue

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -133,7 +133,7 @@ func readFromCollector(collector collector.Collector,
 
 		for i := range handlers {
 			if _, exists := handlers[i].CollectorChannels()[c]; exists {
-				handlers[i].CollectorChannels()[c] <- m
+				handlers[i].CollectorChannels()[c].Channel <- m
 			}
 		}
 	}

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -132,8 +132,8 @@ func readFromCollector(collector collector.Collector,
 		}
 
 		for i := range handlers {
-			if _, exists := handlers[i].CollectorChannels()[c]; exists {
-				handlers[i].CollectorChannels()[c].Channel <- m
+			if _, exists := handlers[i].CollectorEndpoints()[c]; exists {
+				handlers[i].CollectorEndpoints()[c].Channel <- m
 			}
 		}
 	}

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -147,8 +147,8 @@ func TestCollectorPrefix(t *testing.T) {
 	collector.SetInterval(1)
 	collector.Configure(c)
 
-	collectorChannel := map[string]chan metric.Metric{
-		"Test": make(chan metric.Metric),
+	collectorChannel := map[string]handler.CollectorEnd{
+		"Test": handler.CollectorEnd{make(chan metric.Metric), 1},
 	}
 
 	testHandler := handler.New("Log")

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -152,7 +152,7 @@ func TestCollectorPrefix(t *testing.T) {
 	}
 
 	testHandler := handler.New("Log")
-	testHandler.SetCollectorChannels(collectorChannel)
+	testHandler.SetCollectorEndpoints(collectorChannel)
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/src/fullerite/collectors_test.go
+++ b/src/fullerite/collectors_test.go
@@ -163,7 +163,7 @@ func TestCollectorPrefix(t *testing.T) {
 	}()
 	go func() {
 		defer wg.Done()
-		testMetric := <-collectorChannel["Test"]
+		testMetric := <-collectorChannel["Test"].Channel
 		assert.Equal(t, "px.hello", testMetric.Name)
 	}()
 	readFromCollector(collector, []handler.Handler{testHandler})

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"reflect"
 	"strconv"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -54,6 +55,18 @@ func ReadCollectorConfig(configFile string) (c map[string]interface{}, e error) 
 		return c, err
 	}
 	return c, nil
+}
+
+// GetCollectorConfig returns collector config. given a name
+func (conf Config) GetCollectorConfig(name string) (map[string]interface{}, error) {
+	configFile := strings.Join([]string{conf.CollectorsConfigPath, name}, "/") + ".conf"
+	// Since collector naems can be defined with a space in order to instantiate multiple
+	// instances of the same collector, we want their files
+	// will not have that space and needs to have it replaced with an underscore
+	// instead
+	configFile = strings.Replace(configFile, " ", "_", -1)
+	collectorConf, err := ReadCollectorConfig(configFile)
+	return collectorConf, err
 }
 
 // GetAsFloat parses a string to a float or returns the float if float is passed in

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -440,6 +440,7 @@ stopReading:
 			currentBufferSize++
 
 			if int(currentBufferSize) >= collectorEnd.BufferSize {
+				base.log.Info("Buffer full - ", currentBufferSize, " emitting ", len(metrics), " metrics")
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 
 				// will get copied into this call, meaning it's ok to clear it
@@ -448,6 +449,7 @@ stopReading:
 			}
 		case <-flusher:
 			if currentBufferSize > 0 {
+				base.log.Info("Timer with currentBuffersize - ", currentBufferSize, " emitting ", len(metrics), " metrics")
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 				metrics = make([]metric.Metric, 0, collectorEnd.BufferSize)
 				currentBufferSize = 0

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -440,6 +440,7 @@ stopReading:
 			currentBufferSize++
 
 			if int(currentBufferSize) >= collectorEnd.BufferSize {
+				base.log.Debug("Full: ", currentBufferSize, " col: ", collectorName)
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 
 				// will get copied into this call, meaning it's ok to clear it
@@ -448,6 +449,7 @@ stopReading:
 			}
 		case <-flusher:
 			if currentBufferSize > 0 {
+				base.log.Debug("Time: ", currentBufferSize, " col: ", collectorName)
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 				metrics = make([]metric.Metric, 0, collectorEnd.BufferSize)
 				currentBufferSize = 0

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -422,7 +422,6 @@ func (base *BaseHandler) listenForMetrics(
 
 	metrics := make([]metric.Metric, 0, collectorEnd.BufferSize)
 	currentBufferSize := 0
-	base.log.Info("Buffer size selected is ", collectorEnd.BufferSize, " for collector ", collectorName)
 
 	ticker := time.NewTicker(time.Duration(base.Interval()) * time.Second)
 	flusher := ticker.C

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -34,6 +34,7 @@ func RegisterHandler(name string, f func(chan metric.Metric, int, int, time.Dura
 	handlerConstructs[name] = f
 }
 
+// CollectorEnd defines a endpoint from which handler reads metrics from collector
 type CollectorEnd struct {
 	Channel  chan metric.Metric
 	Interval int
@@ -422,7 +423,7 @@ func (base *BaseHandler) listenForMetrics(
 	metrics := make([]metric.Metric, 0, base.MaxBufferSize())
 	currentBufferSize := 0
 
-	base.log.Info("Creating handler to run every", base.Interval())
+	base.log.Info("Creating handler to run every", collectorEnd.Interval)
 
 	ticker := time.NewTicker(time.Duration(collectorEnd.Interval) * time.Second)
 	flusher := ticker.C

--- a/src/fullerite/handler/handler.go
+++ b/src/fullerite/handler/handler.go
@@ -440,7 +440,6 @@ stopReading:
 			currentBufferSize++
 
 			if int(currentBufferSize) >= collectorEnd.BufferSize {
-				base.log.Info("Buffer full - ", currentBufferSize, " emitting ", len(metrics), " metrics")
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 
 				// will get copied into this call, meaning it's ok to clear it
@@ -449,7 +448,6 @@ stopReading:
 			}
 		case <-flusher:
 			if currentBufferSize > 0 {
-				base.log.Info("Timer with currentBuffersize - ", currentBufferSize, " emitting ", len(metrics), " metrics")
 				go base.emitAndTime(metrics, emitFunc, emissionResults)
 				metrics = make([]metric.Metric, 0, collectorEnd.BufferSize)
 				currentBufferSize = 0

--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -182,6 +182,34 @@ func TestHandlerRunFlushInterval(t *testing.T) {
 	base.channel <- metric.Metric{}
 }
 
+func TestHandlerBufferSize(t *testing.T) {
+	base := BaseHandler{}
+	base.log = l.WithField("testing", "basehandler_flush")
+	base.interval = 5
+	base.maxBufferSize = 100
+	base.channel = make(chan metric.Metric)
+	base.collectorEndpoints = map[string]CollectorEnd{
+		"collector1": CollectorEnd{make(chan metric.Metric), 3},
+	}
+
+	emitFunc := func(metrics []metric.Metric) bool {
+		assert.Equal(t, 3, len(metrics))
+		return true
+	}
+
+	go base.run(emitFunc)
+	base.CollectorEndpoints()["collector1"].Channel <- metric.New("testMetric")
+	base.CollectorEndpoints()["collector1"].Channel <- metric.New("testMetric1")
+	base.CollectorEndpoints()["collector1"].Channel <- metric.New("testMetric2")
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, uint64(3), base.metricsSent)
+	assert.Equal(t, uint64(0), base.metricsDropped)
+
+	// This is just to stop goroutines that have been started before
+	base.channel <- metric.Metric{}
+	base.CollectorEndpoints()["collector1"].Channel <- metric.Metric{}
+}
+
 func TestHandlerRun(t *testing.T) {
 	base := BaseHandler{}
 	base.log = l.WithField("testing", "basehandler_run")

--- a/src/fullerite/handlers_test.go
+++ b/src/fullerite/handlers_test.go
@@ -36,11 +36,11 @@ func checkEmission(t *testing.T, coll string, h handler.Handler, expected bool) 
 		Dimensions: map[string]string{"collector": coll},
 	}
 	writeToHandlers([]handler.Handler{h}, m)
-	ch, _ := h.CollectorChannels()[coll]
-	if !expected && ch != nil {
+	_, ok := h.CollectorChannels()[coll]
+	if !expected && ok {
 		assert.Fail(t, fmt.Sprintf("Was not expecting a collector channel for %s", coll))
 	}
-	if expected && ch == nil {
+	if expected && !ok {
 		assert.Fail(t, fmt.Sprintf("Was expecting a collector channel for %s", coll))
 	}
 }

--- a/src/fullerite/handlers_test.go
+++ b/src/fullerite/handlers_test.go
@@ -36,7 +36,7 @@ func checkEmission(t *testing.T, coll string, h handler.Handler, expected bool) 
 		Dimensions: map[string]string{"collector": coll},
 	}
 	writeToHandlers([]handler.Handler{h}, m)
-	_, ok := h.CollectorChannels()[coll]
+	_, ok := h.CollectorEndpoints()[coll]
 	if !expected && ok {
 		assert.Fail(t, fmt.Sprintf("Was not expecting a collector channel for %s", coll))
 	}

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -26,7 +26,7 @@ var log = logrus.WithFields(logrus.Fields{"app": "fullerite"})
 func initLogrus(ctx *cli.Context) {
 	logrus.SetFormatter(&logrus.TextFormatter{
 		DisableColors:   true,
-		TimestampFormat: time.RFC822,
+		TimestampFormat: time.RFC850,
 		FullTimestamp:   true,
 	})
 


### PR DESCRIPTION
This is initial draft of per-collector buffer sizes configuration. I still need to write some more tests for new behaviour.

But overall the idea is - since we have one goroutine for each collector,  now using a huge batch size like `300` is not useful, since lot of collectors that emit fewer metrics will never fill the buffer.  Using a per collector `max_buffer_size` on the other hand, enables us to configure batch size for each collector. This will make sure metrics are immediately emitted as soon as `max_buffer_size` is filled, rather than waiting for timer to fire. 
