### PR TITLE
Add /proc/<pid>/fd collector

### DIFF
--- a/src/diamond/collectors/procpid/proc_pid.py
+++ b/src/diamond/collectors/procpid/proc_pid.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+
+"""
+Collect /proc/{pid}/ stats for a specific set of pids
+
+
+"""
+import diamond.collector
+import os
+import subprocess
+
+
+class ProcPidCollector(diamond.collector.Collector):
+
+    def get_default_config_help(self):
+        config_help = super(ProcPidCollector, self).get_default_config_help()
+        config_help.update({
+            'pid_paths': 'Dict of name to pid file',
+            'ls': 'Path to ls command',
+            'sudo_cmd': 'Path to sudo',
+        })
+        return config_help
+
+    def get_default_config(self):
+        """
+        Returns the default collector settings
+        """
+        config = super(ProcPidCollector, self).get_default_config()
+        config.update({
+            'pid_paths': {},
+            'ls': '/bin/ls',
+            'sudo_cmd': '/usr/bin/sudo',
+        })
+        return config
+
+    def get_proc_path(self, pid_path):
+        with open(pid_path) as fp:
+            pid = fp.read().strip()
+        proc_path = os.path.join('/proc', pid)
+        return proc_path
+
+    def get_fds(self, proc_path):
+        proc_path = os.path.join(proc_path, 'fd')
+
+        command = [self.config['ls'], proc_path]
+        command.insert(0, self.config['sudo_cmd'])
+
+        process = subprocess.Popen(command,
+                                   stdout=subprocess.PIPE,
+                                   stderr=subprocess.PIPE)
+        output, errors = process.communicate()
+        if errors:
+            raise Exception(errors)
+        return len(output.splitlines())
+
+    def collect(self):
+        """
+        Collector pid_proc stats
+        """
+        for service, pid_path in self.config['pid_paths'].items():
+            fds = self.get_fds(self.get_proc_path(pid_path))
+            try:
+                self.dimensions = {}
+                self.dimensions['service'] = service
+                self.publish('proc.pid.fds', fds)
+            except Exception, e:
+                self.log.error("ProcPidCollector Error: %s", e)

--- a/src/diamond/collectors/procpid/proc_pid.py
+++ b/src/diamond/collectors/procpid/proc_pid.py
@@ -60,8 +60,7 @@ class ProcPidCollector(diamond.collector.Collector):
         for service, pid_path in self.config['pid_paths'].items():
             fds = self.get_fds(self.get_proc_path(pid_path))
             try:
-                self.dimensions = {}
-                self.dimensions['service'] = service
-                self.publish('proc.pid.fds', fds)
+                self.dimensions = {'service': service}
+                self.publish('proc_pid_stats.fds', fds)
             except Exception, e:
                 self.log.error("ProcPidCollector Error: %s", e)

--- a/src/diamond/collectors/procpid/test/testprocpid.py
+++ b/src/diamond/collectors/procpid/test/testprocpid.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# coding=utf-8
+################################################################################
+
+from test import CollectorTestCase
+from test import get_collector_config
+from test import unittest
+from mock import Mock
+from mock import mock_open
+from mock import patch
+from mock import call
+
+from diamond.collector import Collector
+from proc_pid import ProcPidCollector
+import subprocess
+
+################################################################################
+
+
+class TestProcPidCollector(CollectorTestCase):
+    TEST_CONFIG = {'pid_paths': {'service1': '/var/run/service1.pid',
+                                 'service2': '/var/run/service2.pid'}}
+
+    def setUp(self):
+        config = get_collector_config('ProcPidCollector',
+                                      self.TEST_CONFIG)
+
+        self.collector = ProcPidCollector(config, None)
+        self.collector.config.update(self.TEST_CONFIG)
+
+    def test_import(self):
+        self.assertTrue(ProcPidCollector)
+
+    def test_get_config_help(self):
+        self.collector.get_default_config_help()
+
+    def test_get_default_config(self):
+        ret = self.collector.get_default_config()
+        assert ret['ls'] == '/bin/ls'
+        assert ret['sudo_cmd'] == '/usr/bin/sudo'
+
+    def test_get_proc_path(self):
+        mock_open_file = mock_open(read_data='2312')
+        with patch('proc_pid.open', mock_open_file):
+            ret = self.collector.get_proc_path('/var/whatever')
+            mock_open_file.assert_called_with('/var/whatever')
+            assert ret == '/proc/2312'
+
+    @patch('proc_pid.subprocess.Popen')
+    def test_get_fds(self, mock_popen):
+        mock_proc_ret = ("0\n1\n2\n3\n4\n5\n6", None)
+        mock_popen.return_value = Mock(communicate=Mock(return_value=mock_proc_ret))
+        ret = self.collector.get_fds('/proc/2312')
+        mock_popen.assert_called_with(['/usr/bin/sudo', '/bin/ls', '/proc/2312/fd'],
+                                      stdout=subprocess.PIPE,
+                                      stderr=subprocess.PIPE)
+        assert ret == 7
+
+    def mock_get_fds_side(self, path):
+        if '1' in path:
+            return 3
+        else:
+            return 5
+
+    def mock_get_proc_path_side(self, path):
+        if 'service1' in path:
+            return '/proc/1'
+        else:
+            return '/proc/2'
+
+    @patch.object(Collector, 'publish')
+    @patch('proc_pid.ProcPidCollector.get_fds')
+    @patch('proc_pid.ProcPidCollector.get_proc_path')
+    def test_collect(self, mock_get_proc_path, mock_get_fds, mock_publish):
+        mock_get_fds.side_effect = self.mock_get_fds_side
+        mock_get_proc_path.side_effect = self.mock_get_proc_path_side
+        self.collector.collect()
+        mock_get_proc_path.assert_has_calls([call('/var/run/service1.pid'),
+                                             call('/var/run/service2.pid')],
+                                            any_order=True)
+        mock_get_fds.assert_has_calls([call('/proc/1'),
+                                       call('/proc/2')],
+                                      any_order=True)
+        self.assertPublished(mock_publish, 'proc.pid.fds', [5, 3])
+
+
+
+################################################################################
+if __name__ == "__main__":
+    unittest.main()

--- a/src/diamond/collectors/procpid/test/testprocpid.py
+++ b/src/diamond/collectors/procpid/test/testprocpid.py
@@ -81,7 +81,7 @@ class TestProcPidCollector(CollectorTestCase):
         mock_get_fds.assert_has_calls([call('/proc/1'),
                                        call('/proc/2')],
                                       any_order=True)
-        self.assertPublished(mock_publish, 'proc.pid.fds', [5, 3])
+        self.assertPublished(mock_publish, 'proc_pid_stats.fds', [5, 3])
 
 
 

--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -154,27 +154,33 @@ class CollectorTestCase(unittest.TestCase):
         message = '%s: actual number of calls %d, expected %d' % (
             key, actual_value, expected_value)
 
-        self.assertEqual(actual_value, expected_value, message)
+        if isinstance(value, list):
+            expected_value=len(value)
+            self.assertEqual(actual_value, expected_value, message)
+            for i, v in enumerate(value):
+                call = calls[i]
+                assert (key, v) in call
+        else:
+            self.assertEqual(actual_value, expected_value, message)
+            if expected_value:
+                actual_value = calls[0][0][1]
+                expected_value = value
+                precision = 0
 
-        if expected_value:
-            actual_value = calls[0][0][1]
-            expected_value = value
-            precision = 0
+                if isinstance(value, tuple):
+                    expected_value, precision = expected_value
 
-            if isinstance(value, tuple):
-                expected_value, precision = expected_value
+                message = '%s: actual %r, expected %r' % (key,
+                                                          actual_value,
+                                                          expected_value)
 
-            message = '%s: actual %r, expected %r' % (key,
-                                                      actual_value,
-                                                      expected_value)
-
-            if precision is not None:
-                self.assertAlmostEqual(float(actual_value),
-                                       float(expected_value),
-                                       places=precision,
-                                       msg=message)
-            else:
-                self.assertEqual(actual_value, expected_value, message)
+                if precision is not None:
+                    self.assertAlmostEqual(float(actual_value),
+                                           float(expected_value),
+                                           places=precision,
+                                           msg=message)
+                else:
+                    self.assertEqual(actual_value, expected_value, message)
 
     def assertUnpublishedMany(self, mock, dict, expected_value=0):
         return self.assertPublishedMany(mock, dict, expected_value)


### PR DESCRIPTION
This is a diamond collector that counts the number of file descriptors a
certain pid is using. It finds the pid for each service specified in the
config file by looking at a pid file also specified in the config.

It could be extended to collect other data from /proc/<pid>/*

@dichiarafrancesco I tidied up a bit and added some tests, no rush to review this one given that we've shipped the work in progress version already