### PR TITLE
[WIP] Make python test env consistent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
 install:
-  - "pip install --user -r requirements-dev.txt"
+  - "apt-cache policy libxml2-dev"
+  - "pip install --user tox"
   - bash scripts/gitcookie.sh
 go:
   - 1.6
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ clean:
 	@rm -f $(BEATIT) bin/$(BEATIT)
 	@rm -rf pkg/*/$(FULLERITE)
 	@rm -rf build fullerite*.deb fullerite*.rpm
+	@rm -rf ./.tox
 # Let's keep the generated file in the repo for ease of development.
 #	@rm -f $(GEN_PROTO_SFX)
 
@@ -73,10 +74,10 @@ qbt:
 	done
 
 diamond_core_test:
-	@python src/diamond/test.py -d
+	@tox -e diamond_core_test
 
 diamond_collector_test:
-	@python src/diamond/test.py
+	@tox -e diamond_collector_test
 
 coverage_report: deps
 	@echo Creating a coverage rport for $(FULLERITE)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 configobj
-mock
+mock==2.0.0
+lxml==2.2.4

--- a/src/diamond/collectors/kafkastat/test/testkafka.py
+++ b/src/diamond/collectors/kafkastat/test/testkafka.py
@@ -175,6 +175,7 @@ class TestKafkaCollector(CollectorTestCase):
             'GarbageCollector.PSMarkSweep.CollectionTime': 160,
         }
 
+        print publish_mock.call_args_list
         self.assertPublishedMany(publish_mock, expected_metrics)
 
 ###############################################################################

--- a/src/diamond/test.py
+++ b/src/diamond/test.py
@@ -10,6 +10,7 @@ import traceback
 import optparse
 import logging
 import configobj
+from mock import call
 
 try:
     import cPickle as pickle
@@ -158,8 +159,7 @@ class CollectorTestCase(unittest.TestCase):
             expected_value=len(value)
             self.assertEqual(actual_value, expected_value, message)
             for i, v in enumerate(value):
-                call = calls[i]
-                assert (key, v) in call
+                assert call(key, v) in calls
         else:
             self.assertEqual(actual_value, expected_value, message)
             if expected_value:

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py26
+skipsdist = True
+[testenv]
+deps = -r{toxinidir}/requirements-dev.txt
+[testenv:diamond_core_test]
+commands = python {toxinidir}/src/diamond/test.py -d {posargs}
+[testenv:diamond_collector_test]
+commands = python {toxinidir}/src/diamond/test.py {posargs}


### PR DESCRIPTION
This should make the python test environment more consistent by using
tox to create a virtualenv and install the requirements

@dichiarafrancesco this should sort out the tests, at least it now passes locally so should be good if it also passes in travis.