### PR TITLE
Add whitelisting for UWSGINerveWorkerStats collector

### DIFF
--- a/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
+++ b/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
@@ -423,8 +423,10 @@ func DoTesting(t *testing.T, firstResponse string, secondResponse string, result
 	}
 
 	if badIP == "" {
+		// If whitelisting fails, non_whitelisted_service will send on a closed channel
 		minimalNerveConfig := util.CreateMinimalNerveConfig(map[string]util.EndPoint{
 			"test_service.things.and.stuff": util.EndPoint{goodIP, goodPort},
+			"non_whitelisted_service.things.and.stuff": util.EndPoint{goodIP, goodPort},
 		})
 		marshalled, err := json.Marshal(minimalNerveConfig)
 		assert.Nil(t, err)
@@ -449,7 +451,7 @@ func DoTesting(t *testing.T, firstResponse string, secondResponse string, result
 	cfg := map[string]interface{}{
 		"configFilePath":   tmpFile.Name(),
 		"queryPath":        "",
-		"serviceWhitelist": []string{"test_service"},
+		"servicesWhitelist": []string{"test_service"},
 	}
 
 	inst := getTestNerveUWSGIWorkerStats()

--- a/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
+++ b/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
@@ -447,8 +447,9 @@ func DoTesting(t *testing.T, firstResponse string, secondResponse string, result
 	assert.Nil(t, err)
 
 	cfg := map[string]interface{}{
-		"configFilePath": tmpFile.Name(),
-		"queryPath":      "",
+		"configFilePath":   tmpFile.Name(),
+		"queryPath":        "",
+		"serviceWhitelist": []string{"test_service"},
 	}
 
 	inst := getTestNerveUWSGIWorkerStats()


### PR DESCRIPTION
This adds trivial whitelisting support. This is needed to make stats collection opt-in for services. For example, a service that is advertised in nerve, but does not support the stats endpoint would not want to be constantly spewing 404s.

I think in the long term, we're going to want to add something like pattern-based whitelisting. I can imagine that this will get a bit annoying if you are going to have to whitelist tons of services. At the very least, we might want to add in an "all" or "*" special-case.