### PR TITLE
Add support for uwsgi_metrics dimensions

### DIFF
--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -99,8 +99,15 @@ func (parser *BaseParser) metricFromMap(metricMap map[string]interface{},
 	metricName string,
 	metricType string) []metric.Metric {
 	results := []metric.Metric{}
+	dims := make(map[string]string)
 
 	for rollup, value := range metricMap {
+		// First check for dimension set if present
+		if rollup == "dimensions" {
+			dims = value.(map[string]string)
+			continue
+		}
+
 		mName := metricName
 		mType := metricType
 		matched, _ := regexp.MatchString("m[0-9]+_rate", rollup)
@@ -123,6 +130,7 @@ func (parser *BaseParser) metricFromMap(metricMap map[string]interface{},
 		}
 	}
 
+	metric.AddToAll(&results, dims)
 	return results
 }
 

--- a/src/fullerite/dropwizard/uwsgi_metric_test.go
+++ b/src/fullerite/dropwizard/uwsgi_metric_test.go
@@ -70,6 +70,75 @@ func TestUWSGIMetricConversion(t *testing.T) {
 	}
 }
 
+func TestUWSGIMetricConversionDims(t *testing.T) {
+	testMeters := make(map[string]map[string]interface{})
+	testMeters["pyramid_uwsgi_metrics.tweens.5xx-responses"] = map[string]interface{}{
+		"count":     957,
+		"mean_rate": 0.0006172935981330262,
+		"m15_rate":  2.8984757611832113e-41,
+		"m5_rate":   1.8870959302511822e-119,
+		"m1_rate":   3e-323,
+
+		// this will not create a metric
+		"units":      "events/second",
+		"dimensions": map[string]string{"run": "test"},
+	}
+	testMeters["pyramid_uwsgi_metrics.tweens.4xx-responses"] = map[string]interface{}{
+		"count":     366116,
+		"mean_rate": 0.2333071157843687,
+		"m15_rate":  0.22693345170298124,
+		"m5_rate":   0.21433439128223822,
+		"m1_rate":   0.14771304656654516,
+
+		// this will not create a metric
+		"units":      "events/second",
+		"dimensions": map[string]string{"run": "test"},
+	}
+	parser := NewUWSGIMetric([]byte(``), "", false)
+
+	actual := parser.parseMapOfMap(testMeters, "metricType")
+
+	// only the numbers are made
+	assert.Equal(t, 10, len(actual))
+	for _, m := range actual {
+		assert.Equal(t, "metricType", m.MetricType)
+
+		assert.Equal(t, 2, len(m.Dimensions))
+
+		rollup, exists := m.GetDimensionValue("rollup")
+		assert.True(t, exists)
+
+		run, exists := m.GetDimensionValue("run")
+		assert.True(t, exists)
+		assert.Equal(t, run, "test")
+
+		switch m.Name {
+		case "pyramid_uwsgi_metrics.tweens.5xx-responses":
+			val, exists := map[string]float64{
+				"mean_rate": 0.0006172935981330262,
+				"m15_rate":  2.8984757611832113e-41,
+				"m5_rate":   1.8870959302511822e-119,
+				"m1_rate":   3e-323,
+				"count":     957,
+			}[rollup]
+			assert.True(t, exists, "unknown rollup "+rollup)
+			assert.Equal(t, val, m.Value)
+		case "pyramid_uwsgi_metrics.tweens.4xx-responses":
+			val, exists := map[string]float64{
+				"count":     366116,
+				"mean_rate": 0.2333071157843687,
+				"m15_rate":  0.22693345170298124,
+				"m5_rate":   0.21433439128223822,
+				"m1_rate":   0.14771304656654516,
+			}[rollup]
+			assert.True(t, exists, "unknown rollup "+rollup)
+			assert.Equal(t, val, m.Value, "mismatching value on rollup "+rollup)
+		default:
+			t.Fatalf("unknown metric name %s", m.Name)
+		}
+	}
+}
+
 func TestUWSGIMetricConversionCumulativeCountersEnabled(t *testing.T) {
 	testMeters := make(map[string]map[string]interface{})
 	testMeters["pyramid_uwsgi_metrics.tweens.5xx-responses"] = map[string]interface{}{


### PR DESCRIPTION
This PR allows uwsgi_metrics to have per-metric dimension support. The parsing change is backwards compatible (no issues if the "dimensions" field is not present in the map) and should be completely transparent to both the uwsgi side. 

I am a bit curious about the ability to cast a `map[string]interface{}` directly to a `map[string]string` as is done in at base_parser.go:107 based on the notes [here](https://github.com/Yelp/fullerite/blob/master/src/fullerite/dropwizard/uwsgi_metric.go#L68), but the tests seem to pass without complaint. Perhaps we can refactor that dimension application, and furthermore avoid the split between schema types since application of an empty map is effectively a no-op anyways.

Let me know if I may have missed something with the testing that could raise issues.