### PR TITLE
Fix invalid test assumptions

### DIFF
--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -103,8 +103,11 @@ func (parser *BaseParser) metricFromMap(metricMap map[string]interface{},
 
 	for rollup, value := range metricMap {
 		// First check for dimension set if present
+		// See uwsgi_metric.go:68 for explanation on the range over value
 		if rollup == "dimensions" {
-			dims = value.(map[string]string)
+			for dimName, dimVal := range value.(map[string]interface{}) {
+				dims[dimName] = dimVal.(string)
+			}
 			continue
 		}
 

--- a/src/fullerite/dropwizard/uwsgi_metric_test.go
+++ b/src/fullerite/dropwizard/uwsgi_metric_test.go
@@ -81,7 +81,7 @@ func TestUWSGIMetricConversionDims(t *testing.T) {
 
 		// this will not create a metric
 		"units":      "events/second",
-		"dimensions": map[string]string{"run": "test"},
+		"dimensions": map[string]interface{}{"run": "test"},
 	}
 	testMeters["pyramid_uwsgi_metrics.tweens.4xx-responses"] = map[string]interface{}{
 		"count":     366116,
@@ -92,7 +92,7 @@ func TestUWSGIMetricConversionDims(t *testing.T) {
 
 		// this will not create a metric
 		"units":      "events/second",
-		"dimensions": map[string]string{"run": "test"},
+		"dimensions": map[string]interface{}{"run": "test"},
 	}
 	parser := NewUWSGIMetric([]byte(``), "", false)
 


### PR DESCRIPTION
It turns out [uwsgi_metric.go:68](https://github.com/Yelp/fullerite/blob/master/src/fullerite/dropwizard/uwsgi_metric.go#L68) was indeed correct about the need to walk the map[string]interface{}. The reason the previous test was passing was that the value was typed as a map[string]string and thus type assertion was passing. But unmarshalling JSON returns map[string]interface{} for dictionaries. Updating the type in the test caused the previous PR to properly fail, this change fixes the parsing and updates the tests to have valid assumptions.