### PR TITLE
Handle nil dimension values

### DIFF
--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -109,6 +109,8 @@ func (parser *BaseParser) metricFromMap(metricMap map[string]interface{},
 				// Handle nil valued dimensions
 				if strVal, ok := dimVal.(string); ok {
 					dims[dimName] = strVal
+				} else {
+					dims[dimName] = "null"
 				}
 			}
 			continue

--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -106,7 +106,10 @@ func (parser *BaseParser) metricFromMap(metricMap map[string]interface{},
 		// See uwsgi_metric.go:68 for explanation on the range over value
 		if rollup == "dimensions" {
 			for dimName, dimVal := range value.(map[string]interface{}) {
-				dims[dimName] = dimVal.(string)
+				// Handle nil valued dimensions
+				if strVal, ok := dimVal.(string); ok {
+					dims[dimName] = strVal
+				}
 			}
 			continue
 		}


### PR DESCRIPTION
So, with the addition dimensions on uwsgi_metrics, we have the possibility of deserializing nil values dimensions. We should handle that case - my approach here is to drop any dimensions which have nil values. Alternatively we could encode them as a default "None" string etc, but I think the less action we take on the part of the service we're collecting from the better. 