### PR TITLE
Support new version of uwsgi metrics serialized format

### DIFF
--- a/src/fullerite/dropwizard/uwsgi_metric.go
+++ b/src/fullerite/dropwizard/uwsgi_metric.go
@@ -3,11 +3,62 @@ package dropwizard
 import (
 	"encoding/json"
 	"fullerite/metric"
+	"strconv"
+	"strings"
 )
 
 // UWSGIMetric parser for UWSGI metrics
 type UWSGIMetric struct {
 	BaseParser
+	UWSGIVersion string `json:"version"`
+}
+
+// Non-exported specific format for uWSGI 1.3.0 version metrics
+// Input metrics are expected in the form of:
+// {
+// 	"gauges": [],
+// 	"histograms": [],
+// 	"version": "xxx",
+// 	"timers": [
+// 		{
+//          "name": "pyramid_uwsgi_metrics.tweens.status.metrics",
+// 			"count": ###,
+// 			"p98": ###,
+// 			...
+// 		},
+// 		{
+//          "name": "pyramid_uwsgi_metrics.tweens.lookup",
+// 			"count": ###,
+// 			...
+// 		}
+// 	],
+// 	"meters": [
+// 		{
+//          "name": "pyramid_uwsgi_metrics.tweens.XXX",
+//			"count": ###,
+//			"mean_rate": ###,
+// 			"m1_rate": ###
+// 		}
+// 	],
+// 	"counters": {
+//		{
+//          "name": "myname",
+//			"count": ###,
+// 	]
+// }
+//
+// The logic behind this structural change is to support metric-specific
+// dimensions without requiring key modification to differentiate the same
+// metric name with different dimension sets. This way all metric objects under
+// a given type are supplied as a list of objects, rather than a map keyed by object
+// name. Thus objects with the same name can have different dimension sets.
+type uwsgiFormat struct {
+	ServiceDims map[string]interface{} `json:"service_dims"`
+	Counters    []map[string]interface{}
+	Gauges      []map[string]interface{}
+	Histograms  []map[string]interface{}
+	Meters      []map[string]interface{}
+	Timers      []map[string]interface{}
 }
 
 // NewUWSGIMetric creates new parser for uwsgi metrics
@@ -16,7 +67,25 @@ func NewUWSGIMetric(data []byte, schemaVer string, ccEnabled bool) *UWSGIMetric 
 	parser.data = data
 	parser.schemaVer = schemaVer
 	parser.ccEnabled = ccEnabled
+	err := json.Unmarshal(data, parser)
+	if err != nil {
+		// Assign a nil version that's easy to manage
+		parser.UWSGIVersion = "0.0.0"
+	}
 	return parser
+}
+
+func (parser *UWSGIMetric) parseArrOfMap(metricArray []map[string]interface{}, metricType string) []metric.Metric {
+	results := []metric.Metric{}
+
+	for _, metricData := range metricArray {
+		if name, ok := metricData["name"]; ok {
+			delete(metricData, "name")
+			tempResults := parser.metricFromMap(metricData, name.(string), metricType)
+			results = append(results, tempResults...)
+		}
+	}
+	return results
 }
 
 func (parser *UWSGIMetric) parseMapOfMap(metricMap map[string]map[string]interface{}, metricType string) []metric.Metric {
@@ -41,14 +110,27 @@ func (parser *UWSGIMetric) Parse() ([]metric.Metric, error) {
 // it into raw metrics. We first check that the metrics returned have a float value
 // otherwise we skip the metric.
 func (parser *UWSGIMetric) parseUWSGIMetrics10() ([]metric.Metric, error) {
-	parsed := new(Format)
+	results := []metric.Metric{}
+	if isNewUWSGI(parser.UWSGIVersion) {
+		parsed := new(uwsgiFormat)
 
-	err := json.Unmarshal(parser.data, parsed)
-	if err != nil {
-		return []metric.Metric{}, err
+		err := json.Unmarshal(parser.data, parsed)
+		if err != nil {
+			return []metric.Metric{}, err
+		}
+
+		results = extractUWSGIParsedMetric(parser, parsed)
+
+	} else {
+		parsed := new(Format)
+
+		err := json.Unmarshal(parser.data, parsed)
+		if err != nil {
+			return []metric.Metric{}, err
+		}
+
+		results = extractParsedMetric(parser, parsed)
 	}
-
-	results := extractParsedMetric(parser, parsed)
 
 	return results, nil
 }
@@ -56,22 +138,67 @@ func (parser *UWSGIMetric) parseUWSGIMetrics10() ([]metric.Metric, error) {
 // parseUWSGIMetrics11 will parse UWSGI metrics under the assumption of
 // the response header containing a Metrics-Schema version 'uwsgi.1.1'.
 func (parser *UWSGIMetric) parseUWSGIMetrics11() ([]metric.Metric, error) {
-	parsed := new(Format)
+	results := []metric.Metric{}
+	if isNewUWSGI(parser.UWSGIVersion) {
+		parsed := new(uwsgiFormat)
 
-	err := json.Unmarshal(parser.data, parsed)
-	if err != nil {
-		return []metric.Metric{}, err
+		err := json.Unmarshal(parser.data, parsed)
+		if err != nil {
+			return []metric.Metric{}, err
+		}
+
+		results = extractUWSGIParsedMetric(parser, parsed)
+		for k, v := range parsed.ServiceDims {
+			metric.AddToAll(&results, map[string]string{k: v.(string)})
+		}
+
+	} else {
+		parsed := new(Format)
+
+		err := json.Unmarshal(parser.data, parsed)
+		if err != nil {
+			return []metric.Metric{}, err
+		}
+
+		results = extractParsedMetric(parser, parsed)
+		for k, v := range parsed.ServiceDims {
+			metric.AddToAll(&results, map[string]string{k: v.(string)})
+		}
 	}
 
-	results := extractParsedMetric(parser, parsed)
-
-	// This is necessary as Go doesn't allow us to type assert
-	// map[string]interface{} as map[string]string.
-	// Basically go doesn't allow type assertions for interface{}'s nested
-	// inside data structures across the entire structure since it is a linearly
-	// complex action
-	for k, v := range parsed.ServiceDims {
-		metric.AddToAll(&results, map[string]string{k: v.(string)})
-	}
 	return results, nil
+}
+
+func isNewUWSGI(s string) bool {
+	var base_ver = []int{1, 3, 0}
+
+	for idx, elem := range strings.Split(s, ".") {
+
+		v, err := strconv.Atoi(elem)
+		if err != nil || v < base_ver[idx] {
+			return false
+		}
+		if v > base_ver[idx] {
+			return true
+		}
+	}
+	return true
+}
+
+func extractUWSGIParsedMetric(parser *UWSGIMetric, parsed *uwsgiFormat) []metric.Metric {
+	results := []metric.Metric{}
+	appendIt := func(metrics []metric.Metric, typeDimVal string) {
+		if !parser.isCCEnabled() {
+			metric.AddToAll(&metrics, map[string]string{"type": typeDimVal})
+		}
+		results = append(results, metrics...)
+	}
+
+	appendIt(parser.parseArrOfMap(parsed.Gauges, metric.Gauge), "gauge")
+	appendIt(parser.parseArrOfMap(parsed.Counters, metric.Counter), "counter")
+	appendIt(parser.parseArrOfMap(parsed.Histograms, metric.Gauge), "histogram")
+	appendIt(parser.parseArrOfMap(parsed.Meters, metric.Gauge), "meter")
+	appendIt(parser.parseArrOfMap(parsed.Timers, metric.Gauge), "timer")
+
+	return results
 }

--- a/src/fullerite/dropwizard/uwsgi_metric.go
+++ b/src/fullerite/dropwizard/uwsgi_metric.go
@@ -67,11 +67,9 @@ func NewUWSGIMetric(data []byte, schemaVer string, ccEnabled bool) *UWSGIMetric 
 	parser.data = data
 	parser.schemaVer = schemaVer
 	parser.ccEnabled = ccEnabled
-	err := json.Unmarshal(data, parser)
-	if err != nil {
-		// Assign a nil version that's easy to manage
-		parser.UWSGIVersion = "0.0.0"
-	}
+	parser.UWSGIVersion = "0.0.0"
+	// Overwrite default version string if it exists in the payload
+	json.Unmarshal(data, parser)
 	return parser
 }
 

--- a/src/fullerite/dropwizard/uwsgi_metric_test.go
+++ b/src/fullerite/dropwizard/uwsgi_metric_test.go
@@ -139,6 +139,60 @@ func TestUWSGIMetricConversionDims(t *testing.T) {
 	}
 }
 
+func TestUWSGIVersionChecker(t *testing.T) {
+	assert.True(t, isNewUWSGI("1.3.0"))
+	assert.False(t, isNewUWSGI("1.2.1"))
+	assert.True(t, isNewUWSGI("1.4.0"))
+}
+
+func TestUWSGIMetricConversionNewFormat(t *testing.T) {
+	var jsonBlob = []byte(`{
+        "version": "1.3.0",
+        "gauges": [],
+        "histograms": [],
+        "meters": [],
+        "timers": [],
+        "counters": [
+            {
+                "name": "tests.my_counter",
+                "count": 17.0,
+                "dimensions": {
+                    "test": "counter",
+                    "two": "four"
+                }
+            },
+            {
+                "name": "tests.my_counter",
+                "count": 17.0,
+                "dimensions": {
+                    "test": "other",
+                    "two": "five"
+                }
+            }
+        ]
+    }`)
+
+	parser := NewUWSGIMetric(jsonBlob, "", false)
+	assert.Equal(t, "1.3.0", parser.UWSGIVersion)
+
+	actual, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Failed to parse input json: %s", err)
+	}
+	assert.Equal(t, 2, len(actual))
+
+	for _, m := range actual {
+		assert.Equal(t, "counter", m.MetricType)
+		assert.Equal(t, 4, len(m.Dimensions))
+		assert.Equal(t, "tests.my_counter", m.Name)
+		assert.True(
+			t,
+			(m.Dimensions["test"] == "counter" && m.Dimensions["two"] == "four") ||
+				(m.Dimensions["test"] == "other" && m.Dimensions["two"] == "five"),
+		)
+	}
+}
+
 func TestUWSGIMetricConversionCumulativeCountersEnabled(t *testing.T) {
 	testMeters := make(map[string]map[string]interface{})
 	testMeters["pyramid_uwsgi_metrics.tweens.5xx-responses"] = map[string]interface{}{


### PR DESCRIPTION
In order to properly support dimensionalized uwsgi metrics we need to be able to differentiate between metrics with the same name but different dimension sets. With the current dropwizard format, where metric objects are indexed by name inside the type dictionary, this isn't possible without somehow mutating the name to reflect the dimension set (i.e. perhaps appending the dim key hash etc). However the simplest solution is to have each type key (i.e. "counters", "gauges") simply map to a list of metric objects, thus not requiring uniqueness of name. Conceptual this fits better as well I think.

The PR includes updated tests, and is backwards compatible to existing behavior. I do think it's a bit clunky (with the extra extraction function) and could benefit from a little generic function love (i.e. the parser.parseMapOfMap could be replaced with a generic function pointer with the correct type and then we could simply reassign based on the format and use the same function without the extra extraction function. But that would require touching the BaseParser code and be a little bit more far reaching, so perhaps the next PR will be refactoring that.