### PR TITLE
Get vagrant environment working again; add multiple-collector example…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,8 +14,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # 192.168.33.210-229
   nodes = [
-    { name: 'test', memory: '512', box: 'trusty',  master: true, },
+    { name: 'fullerite-vm1', memory: '512', box: 'trusty',  master: true, },
   ]
+
+  go_tgz = "go1.7.3.linux-amd64.tar.gz"
 
   if Vagrant.has_plugin?("vagrant-cachier")
     config.cache.scope = :box
@@ -42,10 +44,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vm_config.vm.synced_folder sync_dir.fetch(:source), sync_dir.fetch(:dest)
       end
 
-      vm_config.vm.provision "shell", inline: "apt-get update && apt-get -y dist-upgrade && apt-get install -y git"
-      vm_config.vm.provision "shell", privileged: true, inline: "[ ! -f go1.5.2.linux-amd64.tar.gz ] && wget -q https://storage.googleapis.com/golang/go1.5.2.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.5.2.linux-amd64.tar.gz"
+      vm_config.vm.provision "shell", inline: "apt-get update && apt-get -y dist-upgrade && apt-get install -y git python-pip"
+      vm_config.vm.provision "shell", privileged: true, inline: "[ ! -f #{go_tgz} ] && wget -q https://storage.googleapis.com/golang/#{go_tgz} && tar -C /usr/local -xzf #{go_tgz}"
       vm_config.vm.provision "shell", inline: "echo 'PATH=/usr/local/go/bin:$PATH' >> .profile"
-      vm_config.vm.provision "shell", privileged: true, inline: "cp /vagrant/vagrant/fullerite.conf /etc/fullerite.conf"
+      vm_config.vm.provision "shell", inline: "pip install --user -r /vagrant/requirements-dev.txt"
+      vm_config.vm.provision "shell", privileged: true, inline: "mkdir /etc/fullerite && cp /vagrant/vagrant/fullerite.conf /etc/fullerite.conf && rsync -r /vagrant/vagrant/conf.d/ /etc/fullerite/conf.d/"
 
     end
 

--- a/vagrant/conf.d/Test_Test1.conf
+++ b/vagrant/conf.d/Test_Test1.conf
@@ -1,0 +1,5 @@
+{
+  "interval": "10",
+  "metricName": "TestMetric1",
+  "collectorName": "Test"
+}

--- a/vagrant/conf.d/Test_Test2.conf
+++ b/vagrant/conf.d/Test_Test2.conf
@@ -1,0 +1,5 @@
+{
+  "interval": "30",
+  "metricName": "TestMetric2",
+  "collectorName": "Test"
+}

--- a/vagrant/fullerite.conf
+++ b/vagrant/fullerite.conf
@@ -6,14 +6,10 @@
         "host": "vagrant"
     },
     "fulleritePort": 19191,
-
-    "collectors": {
-        "Test": {
-            "metricName": "TestMetric",
-            "interval": 10
-        }
-    },
-
+    "diamondCollectorsPath": "/usr/share/fullerite/diamond/collectors",
+    "collectorsConfigPath": "/etc/fullerite/conf.d",
+    "diamondCollectors": [],
+    "collectors": ["Test Test1", "Test Test2"],
     "handlers": {
         "Log": {
             "interval": "10",


### PR DESCRIPTION
… conf

The Vagrantfile was left behind after some changes to config/config.go. This
gets it working again, by:

* Updating to go 1.7.3
* Including pip in the dev environment, so diamond tests work
* Rejigged the /etc/fullerite.conf to reflect config.go changes
* added /etc/fullerite/conf.d as per ^^

So this now works:

    vagrant up
    vagrant ssh
    cd /vagrant
    make
    bin/fullerite

I was also investigating running multiple instances of the same type of
collector (with different config), which turns out is already implemented. So
i've also made the vagrant environment highlight this (via two instances of
TestCollector)