### PR TITLE
Permit a prefix for HAProxy metrics

### DIFF
--- a/src/diamond/collectors/haproxy/haproxy.py
+++ b/src/diamond/collectors/haproxy/haproxy.py
@@ -151,6 +151,7 @@ class HAProxyCollector(diamond.collector.Collector):
             'pass': "Password",
             'ignore_servers': "Ignore servers, just collect frontend and "
                               + "backend stats",
+            'extra_prefix': "Prefix the metric name with the given string",
         })
         return config_help
 
@@ -165,6 +166,7 @@ class HAProxyCollector(diamond.collector.Collector):
             'user':             'admin',
             'pass':             'password',
             'ignore_servers':   False,
+            'extra_prefix':     None,
         })
         return config
 
@@ -272,7 +274,11 @@ class HAProxyCollector(diamond.collector.Collector):
                 if status:
                     self.dimensions.update({'status': status})
 
-                metric_name = '.'.join(['haproxy', headings[index]])
+                if self._get_config_value(section, 'extra_prefix'):
+                    metric_prefix = self._get_config_value(section, 'extra_prefix') + '_haproxy'
+                else:
+                    metric_prefix = 'haproxy'
+                metric_name = '.'.join([metric_prefix, headings[index]])
                 if section_name:
                     self.dimensions['section_server'] = section_name
                 if headings[index] in self.CUMULATIVE_COUNTERS:

--- a/src/diamond/collectors/haproxy/test/testhaproxy.py
+++ b/src/diamond/collectors/haproxy/test/testhaproxy.py
@@ -18,6 +18,7 @@ class TestHAProxyCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('HAProxyCollector', {
             'interval': 10,
+            'extra_prefix': 'edgestage',
         })
 
         self.collector = HAProxyCollector(config, None)


### PR DESCRIPTION
It is desirable to be able to distinguish between different sets of load balancers all being parsed by the HAProxy collector, so we can set up specific dashboards for those without needing to worry about going back and changing every previous dashboard to filter away a prefix dimension. This lets us pass in such a prefix.