### PR TITLE
Add http dropwizard collector

### DIFF
--- a/src/fullerite/collector/http_dropwizard.go
+++ b/src/fullerite/collector/http_dropwizard.go
@@ -1,0 +1,97 @@
+package collector
+
+import (
+	"fullerite/config"
+	"fullerite/dropwizard"
+	"fullerite/metric"
+
+	"fmt"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+type httpDropwizardCollector struct {
+	baseCollector
+
+	endpoints []ServiceEndpoint
+	timeout   int
+}
+
+// ServiceEndpoint defines a struct for endpoints
+type ServiceEndpoint struct {
+	Name string
+	Port string
+	Path string
+}
+
+func init() {
+	RegisterCollector("HttpDropwizard", newHTTPDropwizard)
+}
+
+func newHTTPDropwizard(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	col := new(httpDropwizardCollector)
+
+	col.log = log
+	col.channel = channel
+	col.interval = initialInterval
+
+	col.name = "HttpDropwizard"
+	col.timeout = 3
+	return col
+}
+
+func (h *httpDropwizardCollector) Configure(configMap map[string]interface{}) {
+	if val, exists := configMap["endpoints"]; exists {
+		val := val.([]interface{})
+		h.endpoints = make([]ServiceEndpoint, len(val))
+		index := 0
+		for _, e := range val {
+			endpoint := config.GetAsMap(e)
+			h.endpoints[index] = ServiceEndpoint{
+				Name: endpoint["service_name"],
+				Port: endpoint["port"],
+				Path: endpoint["path"],
+			}
+			index++
+		}
+	}
+
+	if val, exists := configMap["http_timeout"]; exists {
+		h.timeout = config.GetAsInt(val, 2)
+	}
+
+	h.configureCommonParams(configMap)
+}
+
+func (h *httpDropwizardCollector) Collect() {
+	for _, endpoint := range h.endpoints {
+		go h.queryService(endpoint)
+	}
+}
+
+func (h *httpDropwizardCollector) queryService(s ServiceEndpoint) {
+	serviceLog := h.log.WithField("service", s.Name)
+
+	endpoint := fmt.Sprintf("http://localhost:%s/%s", s.Port, s.Path)
+	serviceLog.Debug("making GET request to ", endpoint)
+
+	rawResponse, schemaVer, err := queryEndpoint(endpoint, h.timeout)
+	if err != nil {
+		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", err)
+		return
+	}
+	metrics, err := dropwizard.Parse(rawResponse, schemaVer, true)
+	if err != nil {
+		serviceLog.Warn("Failed to parse response into metrics: ", err)
+		return
+	}
+
+	metric.AddToAll(&metrics, map[string]string{
+		"service": s.Name,
+		"port":    s.Port,
+	})
+	serviceLog.Debug("Sending ", len(metrics), " to channel")
+	for _, m := range metrics {
+		h.Channel() <- m
+	}
+}

--- a/src/fullerite/collector/http_dropwizard.go
+++ b/src/fullerite/collector/http_dropwizard.go
@@ -10,6 +10,9 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
+// The HTTP Dropwizard Collector allows to collect metrics emitted by java/python services
+// with one of the schemas defined at dropwizard/base_parser.go#L80.
+// User needs to specify port and path where the service'metrics endpoint is setup.
 type httpDropwizardCollector struct {
 	baseCollector
 
@@ -19,8 +22,11 @@ type httpDropwizardCollector struct {
 
 // ServiceEndpoint defines a struct for endpoints
 type ServiceEndpoint struct {
+	// Name is the service name
 	Name string
+	// Port is the service metrics endpoint port
 	Port string
+	// Path is the service metrics endpoint path (i.e. status/metrics)
 	Path string
 }
 

--- a/src/fullerite/collector/http_dropwizard_test.go
+++ b/src/fullerite/collector/http_dropwizard_test.go
@@ -1,0 +1,45 @@
+package collector
+
+import (
+	"fullerite/metric"
+	"testing"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func getTestHTTPDropwizard() *httpDropwizardCollector {
+	return newHTTPDropwizard(make(chan metric.Metric), 12, l.WithField("test", "httpDropwizard")).(*httpDropwizardCollector)
+}
+
+func TestDefaultConfigHttpDropwizard(t *testing.T) {
+	c := getTestHTTPDropwizard()
+	c.Configure(make(map[string]interface{}))
+
+	assert.Equal(t, 12, c.Interval())
+	assert.Equal(t, 3, c.timeout)
+	assert.Nil(t, c.endpoints)
+}
+
+func TestConfigHttpDropwizard(t *testing.T) {
+	service := map[string]string{}
+	service["service_name"] = "test_name"
+	service["port"] = "3400"
+	service["path"] = "path0/path1"
+	endpoints := make([]interface{}, 1)
+	endpoints[0] = service
+	cfg := map[string]interface{}{
+		"interval":     5,
+		"http_timeout": 10,
+		"endpoints":    endpoints,
+	}
+
+	inst := getTestHTTPDropwizard()
+	inst.Configure(cfg)
+
+	assert.Equal(t, 5, inst.Interval())
+	assert.Equal(t, 10, inst.timeout)
+	assert.Equal(t, "test_name", inst.endpoints[0].Name)
+	assert.Equal(t, "3400", inst.endpoints[0].Port)
+	assert.Equal(t, "path0/path1", inst.endpoints[0].Path)
+}


### PR DESCRIPTION
...for those services not registered in Nerve that want to emit dropwizard metrics.

config expected: 
`{
  "endpoints": [
    {
      "service_name": "serv0",
      "port": "3400",
      "path": "status/metrics"
    }
]
}`
