### PR TITLE
Add capability to collect metrics for tmpfs in DiskSpaceCollector

### DIFF
--- a/src/diamond/collectors/diskspace/diskspace.py
+++ b/src/diamond/collectors/diskspace/diskspace.py
@@ -145,7 +145,7 @@ class DiskSpaceCollector(diamond.collector.Collector):
                         or mount_point.startswith('/sys')):
                     continue
 
-                if '/' in device and mount_point.startswith('/'):
+                if ( '/' in device or 'tmpfs' == device) and mount_point.startswith('/'):
                     try:
                         stat = os.stat(mount_point)
                         major = os.major(stat.st_dev)


### PR DESCRIPTION
Listing "tmpfs" as a filesystem to collect metrics for in DiskSpace collector's config is insufficient. This PR enables the collector to do so. The tmpfs devices are named "tmpfs" and the condition "'/' in device" does not take this into account. Tested locally by running the collector and everything looks good
