### PR TITLE
Add optional dimensional blacklisting and enable it for nerve_uwsgi collector

### DIFF
--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -111,7 +111,9 @@ func (n *nerveUWSGICollector) queryService(serviceName string, port int) {
 	})
 	serviceLog.Debug("Sending ", len(metrics), " to channel")
 	for _, m := range metrics {
-		n.Channel() <- m
+		if !n.ContainsBlacklistedDimension(m.Dimensions) {
+			n.Channel() <- m
+		}
 	}
 }
 


### PR DESCRIPTION
Add the ability to blacklist certain dimensions. Datapoints that match these dimensions will not be emitted. Controlling excessive DPM (Datapoints Per Minute) helps alleviate various performance problems and reduces cost. This is especially relevant to dropwizard metrics where stats like m1_rate, m5_rate, m15_rate etc don't need to be emitted as they can be easily computed by downstream analytics backends. 

Currently, I have enabled this only for the nerve_uwsgi collector. Usage of this feature is optional and can be configured for individual collectors at host level. The collector config file parses the blacklist field as a map where key is the name of the dimension and value is a regex matching the values you don't want to emit. Ex: {"rollup": "p*"} will filter out all percentiles and {"rollup": "p95"} will only filter out p95 aggregations.

