### PR TITLE
New Yaml (and JSON) file/shell collector; some rando Makefile fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ deps:
 	@go get github.com/Masterminds/glide
 	@cd src/github.com/Masterminds/glide && git checkout --quiet v0.12.3
 	@go build -o bin/glide github.com/Masterminds/glide/
+	@rm -rf $(GOPATH)/src/$(FULLERITE)/vendor/
 	@cd $(GOPATH)/src/$(FULLERITE) && $(GLIDE) install
 	@go build -o bin/golint fullerite/vendor/github.com/golang/lint/golint/
 	@go build -o bin/gocyclo fullerite/vendor/github.com/fzipp/gocyclo/

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,13 @@ tests: deps diamond_core_test diamond_collector_test
 qbt:
 	@echo Fast testing $(FULLERITE)
 	@for pkg in $(PKGS); do \
-		go test -v -cover $$pkg || exit 1;\
+		go test -v -cover $(GO_TEST_ARGS) $$pkg || exit 1;\
+	done
+
+qct:
+	@echo Fast testing fullerite collectors
+	@for pkg in $(FULLERITE)/collector; do \
+		go test -v -cover $$pkg $(GO_TEST_ARGS) || exit 1;\
 	done
 
 diamond_core_test:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -44,7 +44,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vm_config.vm.synced_folder sync_dir.fetch(:source), sync_dir.fetch(:dest)
       end
 
-      vm_config.vm.provision "shell", inline: "apt-get update && apt-get -y dist-upgrade && apt-get install -y git python-pip"
+      vm_config.vm.provision "shell", inline: "apt-get update && apt-get -y dist-upgrade && apt-get install -y git python-pip python-mock"
       vm_config.vm.provision "shell", privileged: true, inline: "[ ! -f #{go_tgz} ] && wget -q https://storage.googleapis.com/golang/#{go_tgz} && tar -C /usr/local -xzf #{go_tgz}"
       vm_config.vm.provision "shell", inline: "echo 'PATH=/usr/local/go/bin:$PATH' >> .profile"
       vm_config.vm.provision "shell", inline: "pip install --user -r /vagrant/requirements-dev.txt"

--- a/src/fullerite/collector/yaml.go
+++ b/src/fullerite/collector/yaml.go
@@ -1,0 +1,201 @@
+package collector
+
+import (
+	"fullerite/metric"
+	"io/ioutil"
+	"os/exec"
+	"regexp"
+	"strconv"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/ghodss/yaml"
+)
+
+const (
+	defaultYamlCollectorName = "YamlMetrics"
+	defaultYamlSource        = "/var/lib/fullerite/yaml_metrics.yaml"
+	defaultYamlMetricPrefix  = "YamlMetrics"
+)
+
+// YamlMetrics collector extracts metrics from YAML data files
+// Currently only supports top-level keys
+// Converts truthy/falsey values to 1/0 respectively
+// Otherwise, emits any keys with numeric (or stringy numeric) values
+//   config:
+//     yamlSource       - location of YAML/JSON file to read
+//     yamlKeyWhitelist - array of regexps to filter keys processed,
+//                        useful in particular for facter or similar output
+//
+type YamlMetrics struct {
+	baseCollector
+	metricPrefix     string
+	yamlSource       string
+	YamlKeyWhitelist []string
+}
+
+func init() {
+	RegisterCollector("YamlMetrics", NewYamlMetrics)
+}
+
+// NewYamlMetrics returns a initial collector, to be configured
+func NewYamlMetrics(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	c := new(YamlMetrics)
+
+	c.log = log
+	c.channel = channel
+	c.interval = initialInterval
+
+	c.name = defaultYamlCollectorName
+	c.yamlSource = defaultYamlSource
+	c.metricPrefix = defaultYamlMetricPrefix
+	return c
+}
+
+// Configure takes a dictionary of values with which the handler can configure itself
+func (c *YamlMetrics) Configure(configMap map[string]interface{}) {
+	if yamlSource, exists := configMap["yamlSource"]; exists {
+		c.yamlSource = yamlSource.(string)
+	}
+	if v, exists := configMap["yamlKeyWhitelist"]; exists {
+		switch val := v.(type) {
+		case []interface{}:
+			for _, v := range val {
+				c.YamlKeyWhitelist = append(c.YamlKeyWhitelist, v.(string))
+			}
+		case []string:
+			c.YamlKeyWhitelist = val
+		}
+	}
+	if metricPrefix, exists := configMap["metricPrefix"]; exists {
+		c.metricPrefix = metricPrefix.(string)
+	}
+	c.configureCommonParams(configMap)
+}
+
+func processYamlAcceptedValues(v interface{}) (float64, bool) {
+	switch value := v.(type) {
+	case string:
+		f, err := strconv.ParseFloat(value, 64)
+		if err == nil {
+			return f, true
+		}
+		b, err := strconv.ParseBool(value)
+		if err == nil {
+			if b {
+				return 1, true
+			}
+			return 0, true
+		}
+	case float64:
+		return value, true
+	case bool:
+		if value {
+			return 1, true
+		}
+		return 0, true
+	}
+	return 0, false
+}
+
+func (c *YamlMetrics) yamlKeyMatchesWhitelist(k string) bool {
+	for _, w := range c.YamlKeyWhitelist {
+		ok, err := regexp.Match(w, []byte(k))
+		if err != nil {
+			c.log.Error("Invalid regexp in yamlKeyWhitelist: ", k)
+			continue
+		}
+		if ok {
+			return true
+		}
+	}
+	return false
+}
+
+// GetMetrics Get metrics from the YAML supplied
+func (c *YamlMetrics) GetMetrics(yamlData []byte) map[string]float64 {
+	m := make(map[string]interface{})
+	metrics := make(map[string]float64)
+	if len(yamlData) == 0 {
+		return metrics
+	}
+	err := yaml.Unmarshal(yamlData, &m)
+	if err != nil {
+		c.log.Error("Could not unmarshall YAML: ", err.Error())
+	}
+	// only keep values that convert to float
+	for k, v := range m {
+		if len(c.YamlKeyWhitelist) > 0 && !c.yamlKeyMatchesWhitelist(k) {
+			continue
+		}
+		if newVal, ok := processYamlAcceptedValues(v); ok == true {
+			metrics[k] = newVal
+		}
+	}
+	return metrics
+}
+
+// Collect Compares box IP against leader IP and if true, sends data.
+func (c *YamlMetrics) Collect() {
+	go c.sendMetrics()
+}
+
+func (c *YamlMetrics) getYamlFromFile(file string) ([]byte, error) {
+	y, err := ioutil.ReadFile(c.yamlSource)
+	return y, err
+}
+
+func (c *YamlMetrics) getYamlFromExec(command string) ([]byte, error) {
+	y, err := exec.Command(command).Output()
+	return y, err
+}
+
+func (c *YamlMetrics) getYamlFromShell(pipeline string) ([]byte, error) {
+	y, err := exec.Command("sh", "-c", pipeline).Output()
+	return y, err
+}
+
+func extractYamlSourceMethodAndSource(s string) (string, string) {
+	if ok, _ := regexp.MatchString("^file:", s); ok {
+		return "file", s[len("file:"):len(s)]
+	}
+	if ok, _ := regexp.MatchString("^exec:", s); ok {
+		return "exec", s[len("exec:"):len(s)]
+	}
+	if ok, _ := regexp.MatchString("^shell:", s); ok {
+		return "shell", s[len("shell:"):len(s)]
+	}
+	return "file", s
+}
+
+// sendMetrics Send to baseCollector channel.
+func (c *YamlMetrics) sendMetrics() {
+	method, source := extractYamlSourceMethodAndSource(c.yamlSource)
+	var y []byte
+	var err error
+	if method == "file" {
+		y, err = c.getYamlFromFile(source)
+	} else if method == "shell" {
+		y, err = c.getYamlFromShell(source)
+	} else if method == "exec" {
+		y, err = c.getYamlFromExec(source)
+	}
+	if err != nil {
+		c.log.Error("Could not get YAML from source: ", err.Error())
+		return
+	}
+	for k, v := range c.GetMetrics(y) {
+		s := c.buildMetric(k, v)
+		c.Channel() <- s
+	}
+}
+
+// buildMetric Takes a k/v, adds common dimensions, and returns a metric to send
+func (c *YamlMetrics) buildMetric(k string, v float64) metric.Metric {
+	metricName := k
+	if c.metricPrefix != "" {
+		metricName = c.metricPrefix + "." + k
+	}
+	m := metric.New(metricName)
+	m.Value = v
+	return m
+}

--- a/src/fullerite/collector/yaml.go
+++ b/src/fullerite/collector/yaml.go
@@ -147,8 +147,12 @@ func (c *YamlMetrics) getFulleriteFormatMetrics(m []interface{}) (metrics []metr
 
 // simple k/v format; only keep values that convert to float
 func (c *YamlMetrics) getSimpleFormatMetrics(m map[string]interface{}) (metrics []metric.Metric) {
+	if len(c.yamlKeyWhitelist) == 0 {
+		c.log.Error("Must specify yamlKeyWhitelist for simple format metrics")
+		return metrics
+	}
 	for k, v := range m {
-		if len(c.yamlKeyWhitelist) > 0 && !c.yamlKeyMatchesWhitelist(k) {
+		if !c.yamlKeyMatchesWhitelist(k) {
 			continue
 		}
 		if newVal, ok := processYamlAcceptedValues(v); ok {

--- a/src/fullerite/collector/yaml.go
+++ b/src/fullerite/collector/yaml.go
@@ -170,6 +170,7 @@ func (c *YamlMetrics) GetMetrics(yamlData []byte) (metrics []metric.Metric) {
 	if err != nil {
 		c.log.Error("Could not unmarshal YAML: ", err.Error())
 		c.log.Debug(fmt.Sprintf("%s", yamlData))
+		return metrics
 	}
 	if f, ok := m["format"]; ok && f.(string) == "fullerite" {
 		switch val := m["metrics"].(type) {

--- a/src/fullerite/collector/yaml.go
+++ b/src/fullerite/collector/yaml.go
@@ -73,14 +73,7 @@ func (c *YamlMetrics) Configure(configMap map[string]interface{}) {
 		c.yamlSource = yamlSource.(string)
 	}
 	if v, exists := configMap["yamlKeyWhitelist"]; exists {
-		switch val := v.(type) {
-		case []interface{}:
-			for _, v := range val {
-				c.yamlKeyWhitelist = append(c.yamlKeyWhitelist, v.(string))
-			}
-		case []string:
-			c.yamlKeyWhitelist = val
-		}
+		c.yamlKeyWhitelist = config.GetAsSlice(v)
 	}
 	if metricPrefix, exists := configMap["metricPrefix"]; exists {
 		c.metricPrefix = metricPrefix.(string)

--- a/src/fullerite/collector/yaml_test.go
+++ b/src/fullerite/collector/yaml_test.go
@@ -1,0 +1,338 @@
+package collector
+
+import (
+	"fmt"
+	"fullerite/metric"
+	"fullerite/test_utils"
+	"io/ioutil"
+	"os"
+
+	"testing"
+	"time"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/Sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYamlMetricsConfigureEmptyConfig(t *testing.T) {
+	config := make(map[string]interface{})
+	testLog := test_utils.BuildLogger()
+	c := NewYamlMetrics(nil, 123, testLog).(*YamlMetrics)
+	c.Configure(config)
+
+	assert.Equal(t,
+		c.Interval(),
+		123,
+		"should be the default collection interval",
+	)
+
+	assert.Equal(t,
+		c.yamlSource,
+		"/var/lib/fullerite/yaml_metrics.yaml",
+		"should be the default yamlSource",
+	)
+
+}
+
+func TestYamlMetricsConfigure(t *testing.T) {
+	config := make(map[string]interface{})
+	testLog := test_utils.BuildLogger()
+	config["interval"] = 9999
+	config["yamlSource"] = "/tmp/yaml_metrics.yaml"
+
+	// the channel and logger don't matter
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	c.Configure(config)
+
+	assert.Equal(t,
+		c.Interval(),
+		9999,
+		"should be the defined interval",
+	)
+
+	assert.Equal(t,
+		"/tmp/yaml_metrics.yaml",
+		c.yamlSource,
+		"should be the new yaml file",
+	)
+
+}
+
+func TestYamlMetricsGetMetricSimple(t *testing.T) {
+	testLog := test_utils.BuildLogger()
+	y := []byte(heredoc.Doc(`---
+		test1: 123
+		test2: 456
+  `))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t,
+		float64(123),
+		metrics["test1"],
+		"test1 value is correct",
+	)
+	assert.Equal(t,
+		float64(456),
+		metrics["test2"],
+		"test2 value is correct",
+	)
+}
+
+func TestYamlMetricsGetMetricWithStrings(t *testing.T) {
+	testLog := test_utils.BuildLogger()
+	y := []byte(heredoc.Doc(`---
+		test1: 123
+		test2: wibble
+  `))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t,
+		float64(123),
+		metrics["test1"],
+		"test1 value is correct",
+	)
+	_, ok := metrics["test2"]
+	assert.Equal(t,
+		false,
+		ok,
+		"test2 value does not exist",
+	)
+}
+
+func TestYamlMetricsGetMetricShouldReturnEmptyAndProduceErrorOnBrokenYaml(t *testing.T) {
+	y := []byte(`THIS IS NOT YAML`)
+	nullLog, hook := test.NewNullLogger()
+	testLog := test_utils.BuildLogger()
+	testLog.Logger = nullLog
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t, 1, len(hook.Entries), "We got one error message")
+	assert.Equal(t, 0, len(metrics), "metrics list should be empty")
+}
+
+func TestYamlMetricsGetMetricShouldReturnEmptyAndProduceNoErrorOnEmptyYaml(t *testing.T) {
+	y := []byte(``)
+	nullLog, hook := test.NewNullLogger()
+	testLog := test_utils.BuildLogger()
+	testLog.Logger = nullLog
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t, 0, len(hook.Entries), "We did not get error message")
+	assert.Equal(t, 0, len(metrics), "metrics list should be empty")
+}
+
+func TestYamlMetricsGetMetricWithNestedValues(t *testing.T) {
+	testLog := test_utils.BuildLogger()
+	y := []byte(heredoc.Doc(`---
+		nested:
+		- 123
+		- 1234
+		test1: 123
+	`))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t,
+		float64(123),
+		metrics["test1"],
+		"test1 value is correct",
+	)
+	_, ok := metrics["nested"]
+	assert.Equal(t,
+		false,
+		ok,
+		"nested value does not exist",
+	)
+}
+
+func TestYamlMetricsGetMetricWithBooleanValues(t *testing.T) {
+	testLog := test_utils.BuildLogger()
+	y := []byte(heredoc.Doc(`---
+		test_stringy_true: 'true'
+		test_stringy_false: 'false'
+		test_real_true: true
+		test_real_false: false
+	`))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t, 4, len(metrics), "we should have 4 metrics returned")
+	assert.Equal(t, float64(1), metrics["test_stringy_true"], "stringy true is handled as 1")
+	assert.Equal(t, float64(0), metrics["test_stringy_false"], "stringy false is handled as 0")
+	assert.Equal(t, float64(1), metrics["test_real_true"], "real true is handled as 1")
+	assert.Equal(t, float64(0), metrics["test_real_false"], "real false is handled as 0")
+}
+
+func TestYamlMetricsGetMetricWithJsonInput(t *testing.T) {
+	testLog := test_utils.BuildLogger()
+	y := []byte(heredoc.Doc(`{
+		"test1": 123,
+		"test2": "123",
+		"test_stringy_true": "true",
+		"test_stringy_false": "false",
+		"test_real_true": true,
+		"test_real_false": false
+	}`))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t, 6, len(metrics), "we should have 6 metrics returned")
+	assert.Equal(t, float64(123), metrics["test1"], "naked float is returned normally")
+	assert.Equal(t, float64(123), metrics["test2"], "string float is returned as float")
+	assert.Equal(t, float64(1), metrics["test_stringy_true"], "stringy true is handled as 1")
+	assert.Equal(t, float64(0), metrics["test_stringy_false"], "stringy false is handled as 0")
+	assert.Equal(t, float64(1), metrics["test_real_true"], "real true is handled as 1")
+	assert.Equal(t, float64(0), metrics["test_real_false"], "real false is handled as 0")
+}
+
+func TestYamlMetricsGetMetricsWithWhitelist(t *testing.T) {
+	config := make(map[string]interface{})
+	a := make([]interface{}, 2)
+	a[0] = "uptime"
+	a[1] = "^sfx_"
+	config["yamlKeyWhitelist"] = a
+	config["interval"] = 9999
+	y := []byte(heredoc.Doc(`---
+		uptime: 123
+		should_be_sfx_filtered: 123
+		sfx_wibble: 666
+		sfx_wobble: should_not_happen
+	`))
+	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
+	c.Configure(config)
+	metrics := c.GetMetrics(y)
+	assert.Equal(t, 2, len(metrics), "we should have two metrics matching filter: uptime, sfx_wibble")
+	assert.Equal(t, float64(123), metrics["uptime"], "uptime is present andi correct")
+	assert.Equal(t, float64(666), metrics["sfx_wibble"], "sfx_wibble is present and correct")
+	_, ok1 := metrics["sfx_wobble"]
+	assert.Equal(t, false, ok1, "sfx_wobble key should still be omitted, as it is not numeric/bool")
+	_, ok2 := metrics["should_be_sfx_filtered"]
+	assert.Equal(t, false, ok2, "should_be_sfx_filtered key should be filtered out by whitelist")
+}
+
+func TestYamlMetricsCollectOnceDefaultPrefix(t *testing.T) {
+	testLogger := test_utils.BuildLogger()
+	config := make(map[string]interface{})
+	yamlFile := "/tmp/yaml_metrics.yaml"
+	defer os.Remove(yamlFile)
+	config["yamlSource"] = yamlFile
+	y := []byte(heredoc.Doc(`---
+		test1: 123
+	`))
+	err := ioutil.WriteFile(yamlFile, y, 0644)
+	if err != nil {
+		t.Fatal("Could not write YAML file")
+	}
+	testChannel := make(chan metric.Metric)
+	c := NewYamlMetrics(testChannel, 123, testLogger).(*YamlMetrics)
+	c.Configure(config)
+	go c.Collect()
+	select {
+	case m := <-c.Channel():
+		assert.Equal(t, "YamlMetrics.test1", m.Name)
+		assert.Equal(t, float64(123), m.Value)
+		return
+	case <-time.After(4 * time.Second):
+		t.Fail()
+	}
+}
+
+func TestYamlMetricsCollectOnceNoPrefix(t *testing.T) {
+	testLogger := test_utils.BuildLogger()
+	config := make(map[string]interface{})
+	yamlFile := "/tmp/yaml_metrics.yaml"
+	defer os.Remove(yamlFile)
+	config["yamlSource"] = yamlFile
+	config["metricPrefix"] = ""
+	y := []byte(heredoc.Doc(`---
+		test1: 123
+	`))
+	err := ioutil.WriteFile(yamlFile, y, 0644)
+	if err != nil {
+		t.Fatal("Could not write YAML file")
+	}
+	testChannel := make(chan metric.Metric)
+	c := NewYamlMetrics(testChannel, 123, testLogger).(*YamlMetrics)
+	c.Configure(config)
+	go c.Collect()
+	select {
+	case m := <-c.Channel():
+		assert.Equal(t, "test1", m.Name)
+		assert.Equal(t, float64(123), m.Value)
+		return
+	case <-time.After(4 * time.Second):
+		t.Fail()
+	}
+}
+
+func TestYamlMetricsCollectOnceNewPrefix(t *testing.T) {
+	testLogger := test_utils.BuildLogger()
+	config := make(map[string]interface{})
+	yamlFile := "/tmp/yaml_metrics.yaml"
+	defer os.Remove(yamlFile)
+	config["yamlSource"] = yamlFile
+	config["metricPrefix"] = "wibble"
+	y := []byte(heredoc.Doc(`---
+		test1: 123
+	`))
+	err := ioutil.WriteFile(yamlFile, y, 0644)
+	if err != nil {
+		t.Fatal("Could not write YAML file")
+	}
+	testChannel := make(chan metric.Metric)
+	c := NewYamlMetrics(testChannel, 123, testLogger).(*YamlMetrics)
+	c.Configure(config)
+	go c.Collect()
+	select {
+	case m := <-c.Channel():
+		assert.Equal(t, "wibble.test1", m.Name)
+		assert.Equal(t, float64(123), m.Value)
+		return
+	case <-time.After(4 * time.Second):
+		t.Fail()
+	}
+}
+
+func TestYamlMetricsCollectNoShellExec(t *testing.T) {
+	testLogger := test_utils.BuildLogger()
+	config := make(map[string]interface{})
+	execFile := "/tmp/yaml_metrics_exec.yaml"
+	defer os.Remove(execFile)
+	config["yamlSource"] = fmt.Sprintf("exec:%s", execFile)
+	y := []byte(heredoc.Doc(`#!/bin/sh
+		echo "{test1: 123, test2: 456}"
+	`))
+	err := ioutil.WriteFile(execFile, y, 0700)
+	if err != nil {
+		t.Fatal("Could not write exec file")
+	}
+	testChannel := make(chan metric.Metric)
+	c := NewYamlMetrics(testChannel, 123, testLogger).(*YamlMetrics)
+	c.Configure(config)
+	go c.Collect()
+	select {
+	case m := <-c.Channel():
+		assert.Equal(t, "YamlMetrics.test1", m.Name)
+		assert.Equal(t, float64(123), m.Value)
+		return
+	case <-time.After(4 * time.Second):
+		t.Fail()
+	}
+}
+
+func TestYamlMetricsCollectShellExec(t *testing.T) {
+	testLogger := test_utils.BuildLogger()
+	config := make(map[string]interface{})
+	shellCommand := `echo 123 | sed 's/\(.*\)/{testshell: \1}/'`
+	config["yamlSource"] = fmt.Sprintf("shell:%s", shellCommand)
+	testChannel := make(chan metric.Metric)
+	c := NewYamlMetrics(testChannel, 123, testLogger).(*YamlMetrics)
+	c.Configure(config)
+	go c.Collect()
+	select {
+	case m := <-c.Channel():
+		assert.Equal(t, "YamlMetrics.testshell", m.Name)
+		assert.Equal(t, float64(123), m.Value)
+		return
+	case <-time.After(4 * time.Second):
+		t.Fail()
+	}
+}

--- a/src/fullerite/collector/yaml_test.go
+++ b/src/fullerite/collector/yaml_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/MakeNowJust/heredoc"
+	l "github.com/Sirupsen/logrus"
 	"github.com/Sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -20,19 +21,8 @@ func TestYamlMetricsConfigureEmptyConfig(t *testing.T) {
 	testLog := test_utils.BuildLogger()
 	c := NewYamlMetrics(nil, 123, testLog).(*YamlMetrics)
 	c.Configure(config)
-
-	assert.Equal(t,
-		c.Interval(),
-		123,
-		"should be the default collection interval",
-	)
-
-	assert.Equal(t,
-		c.yamlSource,
-		"/var/lib/fullerite/yaml_metrics.yaml",
-		"should be the default yamlSource",
-	)
-
+	assert.Equal(t, c.Interval(), 123, "should be the default collection interval")
+	assert.Equal(t, c.yamlSource, "/var/lib/fullerite/yaml_metrics.yaml", "should be the default yamlSource")
 }
 
 func TestYamlMetricsConfigure(t *testing.T) {
@@ -40,64 +30,48 @@ func TestYamlMetricsConfigure(t *testing.T) {
 	testLog := test_utils.BuildLogger()
 	config["interval"] = 9999
 	config["yamlSource"] = "/tmp/yaml_metrics.yaml"
-
-	// the channel and logger don't matter
 	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
 	c.Configure(config)
+	assert.Equal(t, c.Interval(), 9999, "should be the defined interval")
+	assert.Equal(t, "/tmp/yaml_metrics.yaml", c.yamlSource, "should be the new yaml file")
+}
 
-	assert.Equal(t,
-		c.Interval(),
-		9999,
-		"should be the defined interval",
-	)
-
-	assert.Equal(t,
-		"/tmp/yaml_metrics.yaml",
-		c.yamlSource,
-		"should be the new yaml file",
-	)
-
+func getMetricsTestHarness(y []byte, log *l.Entry, config map[string]interface{}) []metric.Metric {
+	if log == nil {
+		log = test_utils.BuildLogger()
+	}
+	if len(config) == 0 {
+		config = make(map[string]interface{})
+		config["metricPrefix"] = ""
+	}
+	c := NewYamlMetrics(nil, 12, log).(*YamlMetrics)
+	c.Configure(config)
+	return c.GetMetrics(y)
 }
 
 func TestYamlMetricsGetMetricSimple(t *testing.T) {
-	testLog := test_utils.BuildLogger()
 	y := []byte(heredoc.Doc(`---
 		test1: 123
 		test2: 456
   `))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t,
-		float64(123),
-		metrics["test1"],
-		"test1 value is correct",
-	)
-	assert.Equal(t,
-		float64(456),
-		metrics["test2"],
-		"test2 value is correct",
-	)
+	should := []metric.Metric{
+		{Name: "test1", Value: 123},
+		{Name: "test2", Value: 456},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
 }
 
 func TestYamlMetricsGetMetricWithStrings(t *testing.T) {
-	testLog := test_utils.BuildLogger()
 	y := []byte(heredoc.Doc(`---
 		test1: 123
 		test2: wibble
   `))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t,
-		float64(123),
-		metrics["test1"],
-		"test1 value is correct",
-	)
-	_, ok := metrics["test2"]
-	assert.Equal(t,
-		false,
-		ok,
-		"test2 value does not exist",
-	)
+	should := []metric.Metric{
+		{Name: "test1", Value: 123},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
 }
 
 func TestYamlMetricsGetMetricShouldReturnEmptyAndProduceErrorOnBrokenYaml(t *testing.T) {
@@ -105,8 +79,7 @@ func TestYamlMetricsGetMetricShouldReturnEmptyAndProduceErrorOnBrokenYaml(t *tes
 	nullLog, hook := test.NewNullLogger()
 	testLog := test_utils.BuildLogger()
 	testLog.Logger = nullLog
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
+	metrics := getMetricsTestHarness(y, testLog, nil)
 	assert.Equal(t, 1, len(hook.Entries), "We got one error message")
 	assert.Equal(t, 0, len(metrics), "metrics list should be empty")
 }
@@ -116,71 +89,162 @@ func TestYamlMetricsGetMetricShouldReturnEmptyAndProduceNoErrorOnEmptyYaml(t *te
 	nullLog, hook := test.NewNullLogger()
 	testLog := test_utils.BuildLogger()
 	testLog.Logger = nullLog
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
+	metrics := getMetricsTestHarness(y, testLog, nil)
 	assert.Equal(t, 0, len(hook.Entries), "We did not get error message")
 	assert.Equal(t, 0, len(metrics), "metrics list should be empty")
 }
 
 func TestYamlMetricsGetMetricWithNestedValues(t *testing.T) {
-	testLog := test_utils.BuildLogger()
 	y := []byte(heredoc.Doc(`---
 		nested:
 		- 123
 		- 1234
 		test1: 123
 	`))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t,
-		float64(123),
-		metrics["test1"],
-		"test1 value is correct",
-	)
-	_, ok := metrics["nested"]
-	assert.Equal(t,
-		false,
-		ok,
-		"nested value does not exist",
-	)
+	should := []metric.Metric{
+		{Name: "test1", Value: 123},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
+}
+
+func TestYamlMetricsGetMetricWithFulleriteFormatNoMetrics(t *testing.T) {
+	y := []byte(heredoc.Doc(`---
+		format: fullerite
+		metrics:
+		test3: 456
+	`))
+	metrics := getMetricsTestHarness(y, nil, nil)
+	assert.Equal(t, 0, len(metrics), "no metrics are returned")
+}
+
+func TestYamlMetricsGetMetricWithFulleriteFormat(t *testing.T) {
+	y := []byte(heredoc.Doc(`---
+		format: fullerite
+		test3: 456
+		metrics:
+		  - name: test1
+		    value: 123
+		    type: gauge
+		    dimensions:
+		      dim1: dim1_value
+		      dim2: dim2_value
+		  - name: test2
+		    value: 789
+		    type: gauge
+		    dimensions:
+		      dim1: dim1_value
+		      dim2: dim2_value
+	`))
+	should := []metric.Metric{
+		{Name: "test1", Value: 123, MetricType: "gauge"},
+		{Name: "test2", Value: 789, MetricType: "gauge"},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	assert.Equal(t, 2, len(metrics), "two metrics are returned")
+	for i, v := range metrics {
+		s := should[i]
+		assert.Equal(t, s.Name, v.Name, fmt.Sprintf("%d: %s name is correct", i, s.Name))
+		assert.Equal(t, s.Value, v.Value, fmt.Sprintf("%d: %s value is correct", i, s.Name))
+		assert.Equal(t, s.MetricType, v.MetricType, fmt.Sprintf("%d: %s type is correct", i, s.MetricType))
+		assert.Equal(t, "dim1_value", v.Dimensions["dim1"], "dim1 is correct")
+		assert.Equal(t, "dim2_value", v.Dimensions["dim2"], "dim1 is correct")
+	}
+}
+
+func TestYamlMetricsGetMetricWithFulleriteFormatBogusMetrics(t *testing.T) {
+	y := []byte(heredoc.Doc(`---
+		format: fullerite
+		metrics:
+		  - name: true_is_not_valid
+		    value: true
+		    type: gauge
+		  - name: string_number_is_not_valid
+		    value: "123"
+		    type: gauge
+		  - name: string_is_not_valid
+		    value: "wibble"
+		    type: gauge
+		test3: 456
+	`))
+	nullLog, hook := test.NewNullLogger()
+	testLog := test_utils.BuildLogger()
+	testLog.Logger = nullLog
+	metrics := getMetricsTestHarness(y, testLog, nil)
+	assert.Equal(t, 0, len(metrics), "no metrics are returned")
+	assert.Equal(t, 3, len(hook.Entries), "We got error messages for each bogus case")
+}
+
+func TestYamlMetricsGetMetricWithFulleriteFormatNoDimensions(t *testing.T) {
+	y := []byte(heredoc.Doc(`---
+		format: fullerite
+		metrics:
+		  - name: test1
+		    value: 123
+		    type: gauge
+		  - name: test2
+		    value: 789
+		    type: gauge
+	`))
+	should := []metric.Metric{
+		{Name: "test1", Value: 123},
+		{Name: "test2", Value: 789},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
+}
+
+func compareShouldAndGot(t *testing.T, should []metric.Metric, got []metric.Metric) {
+	expectedNum := len(should)
+	count := 0
+	assert.Equal(t, len(should), len(got), fmt.Sprintf("we should have %d metrics", len(should)))
+	for _, v1 := range should {
+		for _, v2 := range got {
+			if v1.Name == v2.Name {
+				assert.Equal(t, v2.Value, v1.Value, fmt.Sprintf("%s value is correct", v2.Name))
+				count += 1
+			}
+		}
+	}
+	assert.Equal(t, expectedNum, count, "We got the expected number Name matches")
 }
 
 func TestYamlMetricsGetMetricWithBooleanValues(t *testing.T) {
-	testLog := test_utils.BuildLogger()
 	y := []byte(heredoc.Doc(`---
 		test_stringy_true: 'true'
 		test_stringy_false: 'false'
 		test_real_true: true
 		test_real_false: false
 	`))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t, 4, len(metrics), "we should have 4 metrics returned")
-	assert.Equal(t, float64(1), metrics["test_stringy_true"], "stringy true is handled as 1")
-	assert.Equal(t, float64(0), metrics["test_stringy_false"], "stringy false is handled as 0")
-	assert.Equal(t, float64(1), metrics["test_real_true"], "real true is handled as 1")
-	assert.Equal(t, float64(0), metrics["test_real_false"], "real false is handled as 0")
+	should := []metric.Metric{
+		{Name: "test_stringy_true", Value: 1},
+		{Name: "test_stringy_false", Value: 0},
+		{Name: "test_real_true", Value: 1},
+		{Name: "test_real_false", Value: 0},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
 }
 
 func TestYamlMetricsGetMetricWithJsonInput(t *testing.T) {
-	testLog := test_utils.BuildLogger()
 	y := []byte(heredoc.Doc(`{
-		"test1": 123,
-		"test2": "123",
+		"test_json_real_value": 123,
+		"test_json_string_value": "123",
 		"test_stringy_true": "true",
 		"test_stringy_false": "false",
 		"test_real_true": true,
 		"test_real_false": false
 	}`))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t, 6, len(metrics), "we should have 6 metrics returned")
-	assert.Equal(t, float64(123), metrics["test1"], "naked float is returned normally")
-	assert.Equal(t, float64(123), metrics["test2"], "string float is returned as float")
-	assert.Equal(t, float64(1), metrics["test_stringy_true"], "stringy true is handled as 1")
-	assert.Equal(t, float64(0), metrics["test_stringy_false"], "stringy false is handled as 0")
-	assert.Equal(t, float64(1), metrics["test_real_true"], "real true is handled as 1")
-	assert.Equal(t, float64(0), metrics["test_real_false"], "real false is handled as 0")
+	should := []metric.Metric{
+		{Name: "test_json_real_value", Value: 123},
+		{Name: "test_json_string_value", Value: 123},
+		{Name: "test_stringy_true", Value: 1},
+		{Name: "test_stringy_false", Value: 0},
+		{Name: "test_real_true", Value: 1},
+		{Name: "test_real_false", Value: 0},
+	}
+	metrics := getMetricsTestHarness(y, nil, nil)
+	compareShouldAndGot(t, should, metrics)
 }
 
 func TestYamlMetricsGetMetricsWithWhitelist(t *testing.T) {
@@ -190,22 +254,19 @@ func TestYamlMetricsGetMetricsWithWhitelist(t *testing.T) {
 	a[1] = "^sfx_"
 	config["yamlKeyWhitelist"] = a
 	config["interval"] = 9999
+	config["metricPrefix"] = ""
 	y := []byte(heredoc.Doc(`---
 		uptime: 123
 		should_be_sfx_filtered: 123
 		sfx_wibble: 666
 		sfx_wobble: should_not_happen
 	`))
-	c := NewYamlMetrics(nil, 12, testLog).(*YamlMetrics)
-	c.Configure(config)
-	metrics := c.GetMetrics(y)
-	assert.Equal(t, 2, len(metrics), "we should have two metrics matching filter: uptime, sfx_wibble")
-	assert.Equal(t, float64(123), metrics["uptime"], "uptime is present andi correct")
-	assert.Equal(t, float64(666), metrics["sfx_wibble"], "sfx_wibble is present and correct")
-	_, ok1 := metrics["sfx_wobble"]
-	assert.Equal(t, false, ok1, "sfx_wobble key should still be omitted, as it is not numeric/bool")
-	_, ok2 := metrics["should_be_sfx_filtered"]
-	assert.Equal(t, false, ok2, "should_be_sfx_filtered key should be filtered out by whitelist")
+	should := []metric.Metric{
+		{Name: "uptime", Value: 123},
+		{Name: "sfx_wibble", Value: 666},
+	}
+	metrics := getMetricsTestHarness(y, nil, config)
+	compareShouldAndGot(t, should, metrics)
 }
 
 func TestYamlMetricsCollectOnceDefaultPrefix(t *testing.T) {

--- a/src/fullerite/collector/yaml_test.go
+++ b/src/fullerite/collector/yaml_test.go
@@ -405,7 +405,8 @@ func TestYamlMetricsCollectNoShellExec(t *testing.T) {
 	config := make(map[string]interface{})
 	execFile := "/tmp/yaml_metrics_exec.yaml"
 	defer os.Remove(execFile)
-	config["yamlSource"] = fmt.Sprintf("exec:%s", execFile)
+	config["yamlSource"] = execFile
+	config["yamlSourceMethod"] = "exec"
 	config["yamlKeyWhitelist"] = getYamlMetricsDefaultWhitelist()
 	config["yamlFormat"] = "simple"
 	y := []byte(heredoc.Doc(`#!/bin/sh
@@ -434,7 +435,8 @@ func TestYamlMetricsCollectNoShellExec(t *testing.T) {
 func TestYamlMetricsCollectShellExec(t *testing.T) {
 	config := make(map[string]interface{})
 	shellCommand := `echo 123 | sed 's/\(.*\)/{testshell: \1}/'`
-	config["yamlSource"] = fmt.Sprintf("shell:%s", shellCommand)
+	config["yamlSource"] = shellCommand
+	config["yamlSourceMethod"] = "shell"
 	config["yamlKeyWhitelist"] = getYamlMetricsDefaultWhitelist()
 	config["yamlFormat"] = "simple"
 	testChannel := make(chan metric.Metric)

--- a/src/fullerite/glide.lock
+++ b/src/fullerite/glide.lock
@@ -1,5 +1,5 @@
-hash: 1be30f98f0d5700480517e402bfc82755012592819fc4b4ea885c2cbb10fd305
-updated: 2017-06-06T07:15:06.415575466-07:00
+hash: f3417f9a8ceb48af4b474523936d4a7f2da6ea99d7e56ec14048c4ddd8bac00d
+updated: 2017-08-10T21:35:51.269239596+01:00
 imports:
 - name: github.com/alyu/configparser
   version: 26b2fe18bee125de2a3090d6fadb7e280e63eba6
@@ -29,6 +29,8 @@ imports:
   - external/golang.org/x/sys/unix
 - name: github.com/fzipp/gocyclo
   version: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
+- name: github.com/ghodss/yaml
+  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/golang/lint
   version: 8f348af5e29faa4262efdc14302797f23774e477
   subpackages:
@@ -50,17 +52,23 @@ imports:
   - thrift
 - name: github.com/Sirupsen/logrus
   version: d26492970760ca5d33129d2d799e34be5c4782eb
+  subpackages:
+  - hooks/test
 - name: golang.org/x/sys
   version: b90f89a1e7a9c1f6b918820b3daa7f08488c8594
   subpackages:
   - unix
 - name: golang.org/x/tools
   version: 92d42b9ff15f625347a13b6aeafd04a33537ce91
+- name: gopkg.in/yaml.v2
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports:
 - name: github.com/davecgh/go-spew
   version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
+- name: github.com/MakeNowJust/heredoc
+  version: bb23615498cded5e105af4ce27de75b089cbe851
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:

--- a/src/fullerite/glide.yaml
+++ b/src/fullerite/glide.yaml
@@ -11,24 +11,29 @@ import:
 - package: github.com/fsouza/go-dockerclient
   version: 02a8beb401b20e112cff3ea740545960b667eab1
 - package: github.com/golang/protobuf
+  version: 98fa357170587e470c5f27d3c3ea0947b71eb455
   subpackages:
   - proto
-  version: 98fa357170587e470c5f27d3c3ea0947b71eb455
 - package: github.com/pkg/profile
   version: 7b053ad66e2a49baca9cc97b982dcea0e182bda4
 - package: github.com/prometheus/procfs
 - package: github.com/samuel/go-thrift
+  version: e9042807f4f5bf47563df6992d3ea0857313e2be
   subpackages:
   - examples/scribe
   - thrift
-  version: e9042807f4f5bf47563df6992d3ea0857313e2be
-- package: github.com/golang/lint/golint
+- package: github.com/golang/lint
   version: 8f348af5e29faa4262efdc14302797f23774e477
+  subpackages:
+  - golint
 - package: golang.org/x/tools
 - package: github.com/fzipp/gocyclo
-  varsion: 6acd4345c835499920e8426c7e4e8d7a34f1bb83
+- package: gopkg.in/yaml.v2
+- package: github.com/ghodss/yaml
+  version: ~1.0.0
 testImport:
 - package: github.com/stretchr/testify
   subpackages:
   - assert
   - require
+- package: github.com/MakeNowJust/heredoc


### PR DESCRIPTION
This collector gets YAML (or JSON) from a source and returns metrics for each
k/v found at the top level that can be converted to a float (including
booleans).

Sources can be a file (eg /etc/mcollective/facts.yaml), or a shell pipeline or simple exec.

This is designed to be run with multiple instantiations, for different sources and intervals.

## yamlMetricsKeyWhitelist option in YamlMetrics collector

When reading arbitrary YAML files - like the facter/mco /etc/mcollective/facts.yaml file -
it's necessary to whitelist certain keys, to prevent processing what could be
quite a lot of data and creating unnecessary/confusing signalfx DPs.

## Boolean support to YamlMetrics

stringy or proper boolean values in Simple (eg Factor-like) Yaml are converted to 1 (true) and
0 (false).

## Fix up glide.* to import yaml libs; fix annoying case issue with logrus

Having two different case-versions of sirupsen/logrus (vs Sirupsen/logrus)
was really freaking out glide. I could not get it to bring in the new yaml libs
or generally play nice.

## Add JSON tests, as we get it for free with YAML!

As JSON is a subset of YAML, we can read JSON from exec/file. Highlight this is possible in the tests.

## Add 'exec' and 'shell' sources for YAML.

The file-based YAML is only so useful, and requires that you have a secondary process writing to a file (maybe puppet, or a cron job like `factor --yaml` for mCollective). Fullerite is already a pretty good interval-based scheduler, so let's allow it to run arbitrary commands to produce the YAML/JSON. 

Prefix a yamlSource with 'exec:' to cause the command to be run directly.

Prefix a yamlSource with 'shell:' to run it under 'sh -c', so that pipelines
and args are functional. Eg `http JSON_ENDPOINT | jq 'stuff'` or `myscript arg1 arg2`.

Commands must output valid YAML (or JSON), in either Simple or Fullerite format.

## 'Fullerite' format

It's not really possible with the 'read arbitrary YAML/JSON' idea to have per metric dimensions. This is quite limiting for many use-cases, and so it's advantageous to have a format that allows them.

By specifying 'format: "fullerite"' as a top-level key, read metrics.Metrics format metric+dimensions+value structs from an list under 'metrics: []' key.
 
