### PR TITLE
Fix metric.addDimension() panic

### DIFF
--- a/src/fullerite/collector/yaml.go
+++ b/src/fullerite/collector/yaml.go
@@ -149,12 +149,12 @@ func (c *YamlMetrics) yamlKeyMatchesWhitelist(k string) bool {
 // 'advanced' format - YAML representation of metric.Metric objects
 func (c *YamlMetrics) getFulleriteFormatMetrics(yamlData []byte) (metrics []metric.Metric) {
 	var m []interface{}
-	var metric metric.Metric
 	err := yaml.Unmarshal(yamlData, &m)
 	if err != nil {
 		c.log.Error("Invalid YAML for fullerite yamlFormat")
 	}
 	for _, v := range m {
+		var metric metric.Metric
 		j, err := json.Marshal(v)
 		if err != nil {
 			c.log.Error("getFulleriteFormatMetrics: Skipping, could not Marshal '%s': %s", v, err.Error())
@@ -232,7 +232,9 @@ func (c *YamlMetrics) Collect() {
 		c.log.Errorf("Could not get YAML data from source %s:%s ", c.yamlSourceMethod, c.yamlSource)
 		return
 	}
-	go c.sendMetrics(c.GetMetrics(y))
+	if metrics := c.GetMetrics(y); len(metrics) > 0 {
+		go c.sendMetrics(metrics)
+	}
 }
 
 func (c *YamlMetrics) getYamlFromFile(file string) ([]byte, error) {

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -93,6 +93,7 @@ func readFromCollector(collector collector.Collector,
 		var exists bool
 		c := collector.CanonicalName()
 		if _, exists = m.GetDimensionValue("collector"); !exists {
+			log.Debugf("readFromCollector: m = %+v", m)
 			m.AddDimension("collector", collector.Name())
 		}
 		// We allow external collectors to provide us their collector's CanonicalName

--- a/src/fullerite/metric/metric.go
+++ b/src/fullerite/metric/metric.go
@@ -42,6 +42,9 @@ func Sentinel() Metric {
 
 // AddDimension adds a new dimension to the Metric.
 func (m *Metric) AddDimension(name, value string) {
+	if m.Dimensions == nil {
+		m.Dimensions = make(map[string]string)
+	}
 	m.Dimensions[name] = value
 }
 

--- a/src/fullerite/metric/metric_test.go
+++ b/src/fullerite/metric/metric_test.go
@@ -1,6 +1,7 @@
 package metric_test
 
 import (
+	"encoding/json"
 	"fullerite/metric"
 
 	"testing"
@@ -20,6 +21,17 @@ func TestNewMetric(t *testing.T) {
 
 func TestAddDimension(t *testing.T) {
 	m := metric.New("TestMetric")
+	m.AddDimension("TestDimension", "test value")
+
+	assert := assert.New(t)
+	assert.Equal(len(m.Dimensions), 1, "should have 1 dimension")
+	assert.Equal(m.Dimensions["TestDimension"], "test value")
+}
+
+func TestAddDimensionToUnmarshalledMetric(t *testing.T) {
+	j := []byte(`{ "name": "test_add_dimension", "value": 123.45}`)
+	var m metric.Metric
+	_ = json.Unmarshal(j, &m)
 	m.AddDimension("TestDimension", "test value")
 
 	assert := assert.New(t)


### PR DESCRIPTION
Fix panic issue in AddDimension when creating metrics from JSON
Discovered this whilst working on the YamlMetrics collector, but it should
apply to the Adhoc collector too.

When you create a metrics.Metric struct via marshalling from JSON, it is
possible to have a nil Dimesions field. This then causes a panic when trying
to add to it:

```
=== RUN   TestAddDimensionToUnmarshalledMetric
--- FAIL: TestAddDimensionToUnmarshalledMetric (0.00s)
panic: assignment to entry in nil map [recovered]
        panic: assignment to entry in nil map

goroutine 5 [running]:
panic(0x65ad60, 0xc420013600)
        /usr/local/go/src/runtime/panic.go:500 +0x1a1
testing.tRunner.func1(0xc420074180)
        /usr/local/go/src/testing/testing.go:579 +0x25d
panic(0x65ad60, 0xc420013600)
        /usr/local/go/src/runtime/panic.go:458 +0x243
fullerite/metric_test.TestAddDimensionToUnmarshalledMetric(0xc420074180)
        /vagrant/src/fullerite/metric/metric_test.go:35 +0x155
testing.tRunner(0xc420074180, 0x6c59b0)
        /usr/local/go/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:646 +0x2ec
exit status 2
```

Fixed this by testing for the nil case and initialising with make() if it is.

Test now passes, woop!

There are a couple of associated commits: tidying up YamlMetrics and improving collector debugging.
