### PR TITLE
Create units for systemd so logging works

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,8 @@ ifeq ($(OS),Ubuntu)
 		--deb-default "deb/etc/fullerite" \
 		--deb-upstart "deb/etc/init/fullerite" \
 		--deb-upstart "deb/etc/init/fullerite_diamond_server" \
+		--deb-systemd "deb/etc/systemd/fullerite" \
+		--deb-systemd "deb/etc/systemd/fullerite_diamond_server" \
 		--before-install "deb/before_install.sh" \
 		--before-remove "deb/before_rm.sh" \
 		--after-remove "deb/post_rm.sh" \

--- a/deb/etc/systemd/fullerite
+++ b/deb/etc/systemd/fullerite
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fullerite
+After=network.target
+
+[Service]
+TimeoutStartSec=5
+ExecStart=/usr/bin/fullerite --config /etc/fullerite.conf --log_level info 2>&1 >> /var/log/fullerite/fullerite.log | tee --append /var/log/fullerite/fullerite.err
+PIDFile=/var/run/fullerite.pid
+User=fuller
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/deb/etc/systemd/fullerite_diamond_server
+++ b/deb/etc/systemd/fullerite_diamond_server
@@ -1,0 +1,12 @@
+[Unit]
+Description=Fullerite Diamond Collector
+After=network.target
+
+[Service]
+TimeoutStartSec=5
+ExecStart=/usr/bin/run-diamond-collectors.sh -c /etc/fullerite.conf -l INFO 2>&1 | tee --append /var/log/fullerite/diamond_server.log
+User=fuller
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The autogenerated systemd service units don't contain all the logging redirections present in the upstart files to write to /var/log/fullerite/[fullerite.log|fullerite.err|diamond_server.log].  

This just updates fpm to use newly created systemd unit files which contain the logging redirections.

See internal ticket CASCADE-263

Can't say that I understand how the /etc/defaults thingy is supposed to work in systemd, so I left that out.

TODO: Bit more testing