### PR TITLE
Add /proc/net/udp collector

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,9 @@ $(BEATIT): $(BEATIT_SOURCES)
 	@go build -o bin/$(BEATIT) fullerite/beatit
 
 test: tests
-tests: deps diamond_core_test diamond_collector_test
+tests: deps diamond_core_test diamond_collector_test fullerite-tests
+
+fullerite-tests:
 	@echo Testing $(FULLERITE)
 	@for pkg in $(PKGS); do \
 		go test -race -cover $$pkg || exit 1;\

--- a/src/fullerite/collector/net_udp.go
+++ b/src/fullerite/collector/net_udp.go
@@ -17,20 +17,26 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
-// Most of these fields are internal kernel values and we don't care about them
+// The full /proc/net/udp struct contains all the following fields,
+// however we only load the ones we care about for now
+//
+// sl            kernel hash slot for the socket
+// localAddress  local address and port number pair -- hex encoded
+// remoteAddress remote address and port number pair (if connected) -- hex encoded
+// st            internal status of the socket
+// queues        outgoing and incoming data queue in terms of kernel memory usage
+// trRexmits     not used by UDP
+// tmWhen        not used by UDP
+// uid           effective UID of the creator of the socket
+// timeout       socket timeout
+// inode         inode
+// ref           internal kernel field
+// pointer       internal kernel field
+// drops         packets dropped since the socket was created
+
 type procNetUpdLine struct {
-	sl            string
 	localAddress  string // hex encoded
 	remoteAddress string // hex encoded
-	st            string
-	queues        string // "tx_queue:rx_queue": outgoing and incoming data queue in terms of kernel memory usage
-	trRexmits     string // not used by UDP
-	tmWhen        string // not used by UDP
-	uid           string
-	timeout       string
-	inode         string
-	ref           string
-	pointer       string
 	drops         string
 }
 
@@ -152,18 +158,8 @@ func (s *ProcNetUDPStats) parseProcNetUDPLines(out string) []procNetUpdLine {
 		if idx > 0 {
 			parts := strings.Fields(line)
 			stats = append(stats, procNetUpdLine{
-				sl:            parts[0],
 				localAddress:  parts[1],
 				remoteAddress: parts[2],
-				st:            parts[3],
-				queues:        parts[4],
-				trRexmits:     parts[5],
-				tmWhen:        parts[6],
-				uid:           parts[7],
-				timeout:       parts[8],
-				inode:         parts[9],
-				ref:           parts[10],
-				pointer:       parts[11],
 				drops:         parts[12],
 			})
 		}

--- a/src/fullerite/collector/net_udp.go
+++ b/src/fullerite/collector/net_udp.go
@@ -1,0 +1,173 @@
+// Config file: ProcNetUDPStats.conf
+// Example: {
+//	 "localAddressWhitelist": "7F000001:613|*:4ED6",
+//	 "remoteAddressWhitelist": "0A000005:50"
+// }
+
+package collector
+
+import (
+	"fmt"
+	"fullerite/metric"
+	"fullerite/util"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+// Most of these fields are internal kernel values and we don't care about them
+type procNetUpdLine struct {
+	sl            string
+	localAddress  string // hex encoded
+	remoteAddress string // hex encoded
+	st            string
+	queues        string // "tx_queue:rx_queue": outgoing and incoming data queue in terms of kernel memory usage
+	trRexmits     string // not used by UDP
+	tmWhen        string // not used by UDP
+	uid           string
+	timeout       string
+	inode         string
+	ref           string
+	pointer       string
+	drops         string
+}
+
+// ProcNetUDPStats Collector to record udp stats
+type ProcNetUDPStats struct {
+	baseCollector
+	localAddressWhitelist  *regexp.Regexp
+	remoteAddressWhitelist *regexp.Regexp
+}
+
+func init() {
+	RegisterCollector("ProcNetUDPStats", newProcNetUDPStats)
+}
+
+func newProcNetUDPStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	s := new(ProcNetUDPStats)
+	s.log = log
+	s.channel = channel
+	s.interval = initialInterval
+	s.name = "ProcNetUDPStats"
+
+	return s
+}
+
+// Configure Override *baseCollector.Configure()
+func (s *ProcNetUDPStats) Configure(configMap map[string]interface{}) {
+	s.configureCommonParams(configMap)
+
+	if whitelist, exists := configMap["localAddressWhitelist"]; exists {
+		localRex, err := regexp.Compile(whitelist.(string))
+		if err == nil {
+			s.localAddressWhitelist = localRex
+		} else {
+			s.log.Warn(fmt.Sprintf("Failed to compile regex %s. Error: ", whitelist.(string), err))
+		}
+	}
+
+	if whitelist, exists := configMap["remoteAddressWhitelist"]; exists {
+		remoteRex, err := regexp.Compile(whitelist.(string))
+		if err == nil {
+			s.remoteAddressWhitelist = remoteRex
+		} else {
+			s.log.Warn(fmt.Sprintf("Failed to compile regex %s. Error: ", whitelist.(string), err))
+		}
+	}
+
+	if s.localAddressWhitelist == nil && s.remoteAddressWhitelist == nil {
+		s.log.Warn("No whitelist provided, no metric will be emitted.")
+	}
+}
+
+func (s *ProcNetUDPStats) Collect() {
+	if s.localAddressWhitelist == nil && s.remoteAddressWhitelist == nil {
+		return
+	}
+
+	for _, stat := range s.getProcNetUDPStats() {
+		if s.localAddressWhitelist != nil && s.localAddressWhitelist.MatchString(stat.localAddress) {
+			s.Channel() <- s.createMetric(
+				"upd.drops",
+				util.StrToFloat(stat.drops),
+				map[string]string{"local_address": stat.localAddress},
+			)
+		}
+		if s.remoteAddressWhitelist != nil && s.remoteAddressWhitelist.MatchString(stat.remoteAddress) {
+			s.Channel() <- s.createMetric(
+				"upd.drops",
+				util.StrToFloat(stat.drops),
+				map[string]string{"remote_address": stat.remoteAddress},
+			)
+		}
+	}
+}
+
+func (s *ProcNetUDPStats) createMetric(name string, value float64, dims map[string]string) metric.Metric {
+	m := metric.New("udp.drops")
+	m.Value = value
+	m.MetricType = metric.CumulativeCounter
+	m.AddDimensions(dims)
+	return m
+}
+
+func (s *ProcNetUDPStats) getProcNetUDPStats() []procNetUpdLine {
+	cmdLine := []string{
+		"cat",
+		"/proc/net/udp",
+	}
+
+	out := s.runCommand(cmdLine)
+
+	if out == nil {
+		return nil
+	}
+
+	return s.parseProcNetUDPLines(string(out))
+}
+
+func (s *ProcNetUDPStats) runCommand(cmdLine []string) []byte {
+	var out []byte
+	var err error
+
+	cmd := exec.Command(cmdLine[0], cmdLine[1:]...)
+
+	if out, err = (*exec.Cmd).Output(cmd); err != nil {
+		s.log.Error(err.Error())
+		return nil
+	}
+
+	return out
+}
+
+func (s *ProcNetUDPStats) parseProcNetUDPLines(out string) []procNetUpdLine {
+	raw := strings.Trim(out, "\n")
+	lines := strings.Split(raw, "\n")
+	stats := []procNetUpdLine{}
+
+	for idx, line := range lines {
+		// The first line contains the column titles
+		if idx > 0 {
+			parts := strings.Fields(line)
+			stats = append(stats, procNetUpdLine{
+				sl:            parts[0],
+				localAddress:  parts[1],
+				remoteAddress: parts[2],
+				st:            parts[3],
+				queues:        parts[4],
+				trRexmits:     parts[5],
+				tmWhen:        parts[6],
+				uid:           parts[7],
+				timeout:       parts[8],
+				inode:         parts[9],
+				ref:           parts[10],
+				pointer:       parts[11],
+				drops:         parts[12],
+			})
+		}
+	}
+
+	return stats
+}

--- a/src/fullerite/collector/net_udp_test.go
+++ b/src/fullerite/collector/net_udp_test.go
@@ -1,0 +1,69 @@
+package collector
+
+import (
+	"fullerite/metric"
+	"testing"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewProcNetUDPStats(t *testing.T) {
+	c := make(chan metric.Metric)
+	i := 10
+	l := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+
+	actual := newProcNetUDPStats(c, i, l).(*ProcNetUDPStats)
+
+	assert.Equal(t, "ProcNetUDPStats", actual.Name())
+	assert.Equal(t, c, actual.Channel())
+	assert.Equal(t, i, actual.Interval())
+	assert.Equal(t, l, actual.log)
+}
+
+func TestProcNetUDPStatsConfigureMissingRemote(t *testing.T) {
+	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
+
+	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
+	fake_collector.Configure(map[string]interface{}{
+		"localAddressWhitelist": "7F000001:613",
+	})
+
+	assert.NotNil(t, fake_collector.localAddressWhitelist)
+	assert.Nil(t, fake_collector.remoteAddressWhitelist)
+}
+
+func TestProcNetUDPStatsConfigureMissingLocal(t *testing.T) {
+	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
+
+	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
+	fake_collector.Configure(map[string]interface{}{
+		"remoteAddressWhitelist": "7F000001:613",
+	})
+
+	assert.Nil(t, fake_collector.localAddressWhitelist)
+	assert.NotNil(t, fake_collector.remoteAddressWhitelist)
+}
+
+func TestProcNetUDPStatsConfigure(t *testing.T) {
+	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
+
+	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
+	fake_collector.Configure(map[string]interface{}{
+		"localAddressWhitelist":  "7F000001:613",
+		"remoteAddressWhitelist": "7F000001:613",
+	})
+
+	assert.NotNil(t, fake_collector.localAddressWhitelist)
+	assert.NotNil(t, fake_collector.remoteAddressWhitelist)
+}
+
+func TestParse(t *testing.T) {
+	out := `sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
+ 3152: FEFFFEA9:4ED6 00000000:0000 07 00000000:00000000 00:00000000 00000000 65534        0 3841266873 2 ffff88021734b480 0
+15747: FEFFFEA9:8009 FEFFFEA9:1FBD 01 00000000:00000000 00:00000000 00000000  4404        0 1989081677 2 ffff8806859712c0 0`
+	fake_collector := &ProcNetUDPStats{}
+
+	lines := fake_collector.parseProcNetUDPLines(out)
+	assert.Equal(t, 2, len(lines))
+}

--- a/src/fullerite/collector/net_udp_test.go
+++ b/src/fullerite/collector/net_udp_test.go
@@ -61,9 +61,16 @@ func TestProcNetUDPStatsConfigure(t *testing.T) {
 func TestParse(t *testing.T) {
 	out := `sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
  3152: FEFFFEA9:4ED6 00000000:0000 07 00000000:00000000 00:00000000 00000000 65534        0 3841266873 2 ffff88021734b480 0
-15747: FEFFFEA9:8009 FEFFFEA9:1FBD 01 00000000:00000000 00:00000000 00000000  4404        0 1989081677 2 ffff8806859712c0 0`
+15747: FEFFFEA9:8009 FEFFFEA9:1FBD 01 00000000:00000000 00:00000000 00000000  4404        0 1989081677 2 ffff8806859712c0 100`
 	fake_collector := &ProcNetUDPStats{}
 
 	lines := fake_collector.parseProcNetUDPLines(out)
 	assert.Equal(t, 2, len(lines))
+
+	assert.Equal(t, "FEFFFEA9:4ED6", lines[0].localAddress)
+	assert.Equal(t, "00000000:0000", lines[0].remoteAddress)
+	assert.Equal(t, "0", lines[0].drops)
+	assert.Equal(t, "FEFFFEA9:8009", lines[1].localAddress)
+	assert.Equal(t, "FEFFFEA9:1FBD", lines[1].remoteAddress)
+	assert.Equal(t, "100", lines[1].drops)
 }


### PR DESCRIPTION
This collector will emit the cumulative count of packets dropped for the
whitelisted addresses. It supports whilesting both local and server
addresses, however you'll need to use their HEX representation since
that's how they show up in /proc/net/udp

Run it locally and it worked fine: my metric showed up in SignalFx.