### PR TITLE
Add stats_mysql_connection_pool proxysql statistics

### DIFF
--- a/src/diamond/collectors/proxysql/proxysqlstat.py
+++ b/src/diamond/collectors/proxysql/proxysqlstat.py
@@ -64,8 +64,6 @@ class ProxySQLCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(ProxySQLCollector, self).get_default_config_help()
         config_help.update({
-            'publish':
-                "Which metrics you would like to publish. Leave unset to publish all",
             'hosts': 'List of hosts to collect from. Format is ' +
             'yourusername:yourpassword@host:port/db'
         })
@@ -151,9 +149,8 @@ class ProxySQLCollector(diamond.collector.Collector):
 
             if metric_name not in self.MYSQL_STATS_GLOBAL:
                 metric_value = self.derivative(metric_name, metric_value)
-            if (('publish' not in self.config or
-                 metric_name in self.config['publish'])):
-                self.publish(metric_name, metric_value)
+
+            self.publish(metric_name, metric_value)
 
     def collect(self):
         if MySQLdb is None:
@@ -171,13 +168,6 @@ class ProxySQLCollector(diamond.collector.Collector):
                 self.log.error('Collection failed for %s %s', e)
                 continue
 
-            # Warn if publish contains an unknown variable
-            if 'publish' in self.config and metrics['status']:
-                for k in self.config['publish'].split():
-                    if k not in metrics['status']:
-                        self.log.error("No such key '%s' available, issue " +
-                                       "'show global status' for a full " +
-                                       "list", k)
             self._publish_stats(metrics)
 
     def parse_host_config(self, host):

--- a/src/diamond/collectors/proxysql/proxysqlstat.py
+++ b/src/diamond/collectors/proxysql/proxysqlstat.py
@@ -67,7 +67,7 @@ class ProxySQLCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(ProxySQLCollector, self).get_default_config_help()
         config_help.update({
-            'publish': 'Which metrics you would like to publish. Leave unset to publish all',
+            'metrics_blacklist': "Which metrics you would don't want to publish.",
             'hosts': 'List of hosts to collect from. Format is yourusername:yourpassword@host:port/db',
             'mysql_connection_pool_metric_names': 'A list of columns in the stats_mysql_connection_pool '
                 'proxysql table that you would like to track. Example: ["ConnUsed"]',
@@ -81,7 +81,7 @@ class ProxySQLCollector(diamond.collector.Collector):
         config = super(ProxySQLCollector, self).get_default_config()
         config.update({
             'path': 'proxysql',
-            'publish': [],
+            'metrics_blacklist': [],
             'hosts': [],
             'mysql_connection_pool_metric_names': [],
         })
@@ -185,10 +185,7 @@ class ProxySQLCollector(diamond.collector.Collector):
 
     def _publish_proxysql_metric(self, metric):
         """Converts from our Metric datastructure into the call format of self.publish"""
-        if (
-            self.config['publish'] and
-            metric.name not in self.config['publish']
-        ):
+        if (metric.name in self.config['metrics_blacklist']):
             return
 
         self.dimensions = metric.dimensions

--- a/src/diamond/collectors/proxysql/proxysqlstat.py
+++ b/src/diamond/collectors/proxysql/proxysqlstat.py
@@ -69,8 +69,6 @@ class ProxySQLCollector(diamond.collector.Collector):
         config_help.update({
             'metrics_blacklist': "Which metrics you would don't want to publish.",
             'hosts': 'List of hosts to collect from. Format is yourusername:yourpassword@host:port/db',
-            'mysql_connection_pool_metric_names': 'A list of columns in the stats_mysql_connection_pool '
-                'proxysql table that you would like to track. Example: ["ConnUsed"]',
         })
         return config_help
 
@@ -83,7 +81,6 @@ class ProxySQLCollector(diamond.collector.Collector):
             'path': 'proxysql',
             'metrics_blacklist': [],
             'hosts': [],
-            'mysql_connection_pool_metric_names': [],
         })
         return config
 
@@ -173,8 +170,7 @@ class ProxySQLCollector(diamond.collector.Collector):
 
     def _publish_connection_pool_metrics(self, metrics):
         for metric in metrics:
-            if metric.name in self.config['mysql_connection_pool_metric_names']:
-                self._publish_proxysql_metric(metric)
+            self._publish_proxysql_metric(metric)
 
     def _publish_status_metrics(self, metrics):
         for metric in metrics:

--- a/src/diamond/collectors/proxysql/test/testproxysql.py
+++ b/src/diamond/collectors/proxysql/test/testproxysql.py
@@ -7,7 +7,7 @@ from test import get_collector_config
 from test import unittest
 from test import run_only
 from mock import Mock
-from mock import patch
+import mock
 
 from diamond.collector import Collector
 from proxysqlstat import ProxySQLCollector
@@ -32,22 +32,41 @@ class TestProxySQLCollector(CollectorTestCase):
             assert call[0] in expected
             expected.remove(call[0])
 
-    @patch.object(ProxySQLCollector, 'connect', Mock(return_value=True))
-    @patch.object(ProxySQLCollector, 'disconnect', Mock(return_value=True))
-    @patch.object(Collector, 'publish')
+    @mock.patch.object(ProxySQLCollector, 'connect', Mock(return_value=True))
+    @mock.patch.object(ProxySQLCollector, 'disconnect', Mock(return_value=True))
+    @mock.patch.object(Collector, 'publish')
     def test_global_status(self, publish_mock):
-        with patch.object(
+        with mock.patch.object(
             ProxySQLCollector,
-            'get_db_stats',
+            '_execute_mysql_status_query',
             Mock(return_value=[
                 {'Value': '0', 'Variable_name': 'Active_transactions'},
                 {'Value': '1', 'Variable_name': 'Client_Connections_connected'}
             ])
         ):
-            self.collector.collect()
-            calls = publish_mock.call_args_list
-            expected = [('Active_transactions', 0.0), ('Client_Connections_connected', 1.0)]
-            self._verify_calls(calls, expected)
+            with mock.patch.object(
+                ProxySQLCollector,
+                '_execute_connection_pool_stats_query',
+                Mock(return_value=[
+                    {
+                        'hostgroup': 'host',
+                        'srv_host': '127.0.0.1',
+                        'ConnUsed': 5,
+                        'ConnFree': 6,
+                        'Latency_us': 3000,
+                    }
+                ])
+            ):
+                self.collector.collect()
+                calls = publish_mock.call_args_list
+                expected = [
+                    ('Active_transactions', 0.0),
+                    ('Client_Connections_connected', 1.0),
+                    ('ConnUsed', 5),
+                    ('ConnFree', 6),
+                    ('Latency_us', 3000),
+                ]
+                self._verify_calls(calls, expected)
 
     def test_host_parsing_with_port(self):
         assert self.collector.parse_host_config('admin:admin@127.0.0.1:6032/') == {

--- a/src/diamond/collectors/proxysql/test/testproxysql.py
+++ b/src/diamond/collectors/proxysql/test/testproxysql.py
@@ -84,7 +84,7 @@ class TestProxySQLCollector(CollectorTestCase):
     @mock.patch.object(ProxySQLCollector, 'disconnect', Mock(return_value=True))
     @mock.patch.object(ProxySQLCollector, '_execute_connection_pool_stats_query', Mock(return_value=[]))
     @mock.patch.object(Collector, 'publish')
-    def test_publish_whitelist_of_global_stats(self, publish_mock):
+    def test_publish_with_blacklist(self, publish_mock):
         with mock.patch.object(
             ProxySQLCollector,
             '_execute_mysql_status_query',
@@ -93,7 +93,7 @@ class TestProxySQLCollector(CollectorTestCase):
                 {'Value': '1', 'Variable_name': 'Client_Connections_connected'}
             ]
         ):
-            self.collector.config['publish'] = ['Active_transactions']
+            self.collector.config['metrics_blacklist'] = ['Client_Connections_connected']
             self.collector.collect()
             calls = publish_mock.call_args_list
             expected = [

--- a/src/diamond/collectors/proxysql/test/testproxysql.py
+++ b/src/diamond/collectors/proxysql/test/testproxysql.py
@@ -22,7 +22,6 @@ class TestProxySQLCollector(CollectorTestCase):
 
         self.collector = ProxySQLCollector(config, None)
         self.collector.config['hosts'] = ['admin:admin@127.0.0.1:6032/']
-        self.collector.config['mysql_connection_pool_metric_names'] = ['ConnUsed', 'ConnFree']
 
     def test_import(self):
         self.assertTrue(ProxySQLCollector)
@@ -72,6 +71,7 @@ class TestProxySQLCollector(CollectorTestCase):
                 }
             ]
         ):
+            self.collector.config['metrics_blacklist'] = ['Latency_us']
             self.collector.collect()
             calls = publish_mock.call_args_list
             expected = [

--- a/src/diamond/collectors/proxysql/test/testproxysql.py
+++ b/src/diamond/collectors/proxysql/test/testproxysql.py
@@ -49,6 +49,33 @@ class TestProxySQLCollector(CollectorTestCase):
             expected = [('Active_transactions', 0.0), ('Client_Connections_connected', 1.0)]
             self._verify_calls(calls, expected)
 
+    def test_host_parsing_with_port(self):
+        assert self.collector.parse_host_config('admin:admin@127.0.0.1:6032/') == {
+            'user': 'admin',
+            'passwd': 'admin',
+            'host': '127.0.0.1',
+            'port': 6032,
+            'db': '',
+        }
+
+    def test_host_parsing_without_port(self):
+        assert self.collector.parse_host_config('admin:admin@127.0.0.1:/') == {
+            'user': 'admin',
+            'passwd': 'admin',
+            'host': '127.0.0.1',
+            'port': 3306,
+            'db': '',
+        }
+
+    def test_parsing_invalid_host(self):
+        threw_error = False
+        try:
+            self.collector.parse_host_config('not_a_valid_host')
+        except ValueError:
+            threw_error = True
+
+        assert threw_error is True
+
 
 ################################################################################
 if __name__ == "__main__":


### PR DESCRIPTION
Internal ticket: DREIMP-389

I manually tested this on a testopia host by following the internal runbook at y/rb-fullerite. I then confirmed that signalfx was receiving these new metrics.

I removed some of the customizations that we weren't using: whitelisting the metrics to send via a config and giving database hosts a 'nickname'.