### PR TITLE
metrics_blacklist is a reserved config option that is an optional regex, not a list.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.25
+VERSION        := 0.6.26
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/diamond/collectors/proxysql/proxysqlstat.py
+++ b/src/diamond/collectors/proxysql/proxysqlstat.py
@@ -67,7 +67,6 @@ class ProxySQLCollector(diamond.collector.Collector):
     def get_default_config_help(self):
         config_help = super(ProxySQLCollector, self).get_default_config_help()
         config_help.update({
-            'metrics_blacklist': "Which metrics you would don't want to publish.",
             'hosts': 'List of hosts to collect from. Format is yourusername:yourpassword@host:port/db',
         })
         return config_help
@@ -79,7 +78,6 @@ class ProxySQLCollector(diamond.collector.Collector):
         config = super(ProxySQLCollector, self).get_default_config()
         config.update({
             'path': 'proxysql',
-            'metrics_blacklist': [],
             'hosts': [],
         })
         return config
@@ -181,9 +179,6 @@ class ProxySQLCollector(diamond.collector.Collector):
 
     def _publish_proxysql_metric(self, metric):
         """Converts from our Metric datastructure into the call format of self.publish"""
-        if (metric.name in self.config['metrics_blacklist']):
-            return
-
         self.dimensions = metric.dimensions
         self.publish(metric.name, metric.value)
 

--- a/src/diamond/collectors/proxysql/test/testproxysql.py
+++ b/src/diamond/collectors/proxysql/test/testproxysql.py
@@ -71,33 +71,12 @@ class TestProxySQLCollector(CollectorTestCase):
                 }
             ]
         ):
-            self.collector.config['metrics_blacklist'] = ['Latency_us']
             self.collector.collect()
             calls = publish_mock.call_args_list
             expected = [
                 ('ConnUsed', 5),
                 ('ConnFree', 6),
-            ]
-            self._verify_calls(calls, expected)
-
-    @mock.patch.object(ProxySQLCollector, 'connect', Mock(return_value=True))
-    @mock.patch.object(ProxySQLCollector, 'disconnect', Mock(return_value=True))
-    @mock.patch.object(ProxySQLCollector, '_execute_connection_pool_stats_query', Mock(return_value=[]))
-    @mock.patch.object(Collector, 'publish')
-    def test_publish_with_blacklist(self, publish_mock):
-        with mock.patch.object(
-            ProxySQLCollector,
-            '_execute_mysql_status_query',
-            return_value=[
-                {'Value': '0', 'Variable_name': 'Active_transactions'},
-                {'Value': '1', 'Variable_name': 'Client_Connections_connected'}
-            ]
-        ):
-            self.collector.config['metrics_blacklist'] = ['Client_Connections_connected']
-            self.collector.collect()
-            calls = publish_mock.call_args_list
-            expected = [
-                ('Active_transactions', 0.0),
+                ('Latency_us', 3000),
             ]
             self._verify_calls(calls, expected)
 

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.25"
+	version = "0.6.26"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.25"
+	version = "0.6.26"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
When I set the metrics_blacklist to be a list of metrics, it caused this error:

```
File "/usr/share/fullerite/diamond/utils/classes.py", line 152, in initialize_collector
  collector = cls(name=name, config=config, handlers=handlers, configfile=configfile)
File "/usr/share/fullerite/diamond/collectors/proxysql/proxysqlstat.py", line 60, in __init__
  super(ProxySQLCollector, self).__init__(*args, **kwargs)
File "/usr/share/fullerite/diamond/collector.py", line 104, in __init__
  self.load_config(config if config else {})
File "/usr/share/fullerite/diamond/collector.py", line 145, in load_config
  self.process_config()
File "/usr/share/fullerite/diamond/collectors/proxysql/proxysqlstat.py", line 63, in process_config
  super(ProxySQLCollector, self).process_config()
File "/usr/share/fullerite/diamond/collector.py", line 178, in process_config
  self.config['metrics_blacklist'])
File "/usr/lib/python2.7/re.py", line 194, in compile
  return _compile(pattern, flags)
File "/usr/lib/python2.7/re.py", line 237, in _compile
  p, loc = _cache[cachekey]
TypeError: unhashable type: 'list'
```