### PR TITLE
Fix _stats metrics for elasticsearch

### DIFF
--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -206,9 +206,8 @@ class ElasticSearchCollector(diamond.collector.Collector):
                          result, ['initializing_shards'])
 
     def collect_instance_index_stats(self, host, port, metrics):
-        result = self._get(host, port,
-                           '_stats?clear=true&docs=true&store=true&'
-                           + 'indexing=true&get=true&search=true', '_all')
+        result = self._get(host, port,'_stats', '_all')
+
         if not result:
             return
 

--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -206,7 +206,14 @@ class ElasticSearchCollector(diamond.collector.Collector):
                          result, ['initializing_shards'])
 
     def collect_instance_index_stats(self, host, port, metrics):
-        result = self._get(host, port,'_stats', '_all')
+        result = self._get(host, port,
+                           '_stats/docs,store,indexing,get,search' +
+                           + 'merge,flush,refresh', '_all')
+        if not result: 
+            # elasticsearch < 0.90RC2
+            result = self._get(host, port,
+                               '_stats?clear=true&docs=true&store=true&'
+                               + 'indexing=true&get=true&search=true', '_all')
 
         if not result:
             return

--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -207,7 +207,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
     def collect_instance_index_stats(self, host, port, metrics):
         result = self._get(host, port,
-                           '_stats/docs,store,indexing,get,search' +
+                           '_stats/docs,store,indexing,get,search'
                            + 'merge,flush,refresh', '_all')
         if not result: 
             # elasticsearch < 0.90RC2

--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -207,7 +207,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
 
     def collect_instance_index_stats(self, host, port, metrics):
         result = self._get(host, port,
-                           '_stats/docs,store,indexing,get,search'
+                           '_stats/docs,store,indexing,get,search,'
                            + 'merge,flush,refresh', '_all')
         if not result: 
             # elasticsearch < 0.90RC2


### PR DESCRIPTION
This was broken for versions 5 and above.