### PR TITLE
Respawn fullerite automatically using upstart

### DIFF
--- a/deb/etc/init/fullerite
+++ b/deb/etc/init/fullerite
@@ -1,7 +1,9 @@
 description "Fullerite Core processing service"
-author "perf-metrics@yelp.com"
+author "darwin@yelp.dog"
 start on runlevel [2345] and net-device-up IFACE!=lo
 stop on runlevel [!2345]
+
+respawn
 
 script
 USER="fuller"

--- a/deb/etc/init/fullerite_diamond_server
+++ b/deb/etc/init/fullerite_diamond_server
@@ -1,5 +1,5 @@
 description "Diamond Server to bridge the connection between the python process to the fullerite core"
-author "squirrely@users.noreply.github.com"
+author "darwin@yelp.dog"
 start on runlevel [2345] and net-device-up IFACE!=lo
 stop on runlevel [!2345]
 


### PR DESCRIPTION
`master`:
```
angelo@stage ~> sudo service fullerite status
fullerite start/running, process 12157
angelo@stage ~> sudo service fullerite_diamond_server status
fullerite_diamond_server start/running, process 12262
angelo@stage ~> ps afux | grep fuller | grep -v grep
root     12159  0.0  0.0  68336  2684 ?        S    14:55   0:00  \_ sudo -u fuller /usr/bin/fullerite --config /etc/fullerite.conf --log_level info
...
angelo@stage ~> sudo kill 12159
angelo@stage ~> sudo service fullerite status
fullerite stop/waiting
```

`systemd_respawn` (edited `/etc/init/fullerite.conf` manually):
```
angelo@stage ~> sudo service fullerite status
fullerite start/running, process 20285
angelo@stage ~> sudo service fullerite_diamond_server status
fullerite_diamond_server start/running, process 22541
angelo@stage ~> ps afux | grep fuller | grep -v grep
root     20290  0.0  0.0  68336  2680 ?        S    14:44   0:00  \_ sudo -u fuller /usr/bin/fullerite --config /etc/fullerite.conf --log_level info
...
angelo@stage ~> sudo kill 20290
angelo@stage ~> sudo service fullerite status
fullerite start/running, process 32487
```

Edit: The branch is named `systemd_respawn` despite targeting upstart