### PR TITLE
Port nginx diamond collector to native fullerite

### DIFF
--- a/examples/config/NginxStats.conf
+++ b/examples/config/NginxStats.conf
@@ -1,0 +1,5 @@
+{
+    "reqHost": "127.0.0.1",
+    "reqPort": "44765",
+    "reqPath" :"/_routing/nginx-status"
+}

--- a/src/fullerite/collector/nginx.go
+++ b/src/fullerite/collector/nginx.go
@@ -1,0 +1,162 @@
+package collector
+
+import (
+	"fmt"
+	"fullerite/config"
+	"fullerite/metric"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+type NginxStats struct {
+	baseCollector
+	client   http.Client
+	statsUrl string
+}
+
+const (
+	nginxGetTimeout = 10 * time.Second
+)
+
+var (
+	activeConnectionsRE = regexp.MustCompile(`^Active connections: (?P<conn>\d+)`)
+	totalConnectionsRE  = regexp.MustCompile(
+		`^\s+(?P<conn>\d+)\s+` +
+			`(?P<acc>\d+)\s+(?P<req>\d+)`,
+	)
+	connectionStatusRE = regexp.MustCompile(
+		`^Reading: (?P<reading>\d+) ` +
+			`Writing: (?P<writing>\d+) ` +
+			`Waiting: (?P<waiting>\d+)`,
+	)
+)
+
+func init() {
+	RegisterCollector("NginxStats", newNginxStats)
+}
+
+func newNginxStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	m := new(NginxStats)
+
+	m.log = log
+	m.channel = channel
+	m.interval = initialInterval
+	m.name = "NginxStats"
+	m.client = http.Client{Timeout: nginxGetTimeout}
+
+	return m
+}
+
+func (m *NginxStats) Configure(configMap map[string]interface{}) {
+	m.configureCommonParams(configMap)
+
+	c := config.GetAsMap(configMap)
+
+	host := "localhost"
+	port := "8080"
+	path := "/nginx_status"
+
+	if val, exists := c["reqHost"]; exists {
+		host = val
+	}
+	if val, exists := c["reqPort"]; exists {
+		port = val
+	}
+	if val, exists := c["reqPath"]; exists {
+		path = val
+	}
+
+	m.statsUrl = fmt.Sprintf("http://%s:%s%s", host, port, path)
+}
+
+func (m *NginxStats) Collect() {
+	for _, metric := range m.getNginxMetrics() {
+		m.Channel() <- metric
+	}
+}
+
+func (m *NginxStats) queryNginxStats() (string, error) {
+	rsp, err := m.client.Get(m.statsUrl)
+
+	if rsp != nil {
+		defer func() {
+			io.Copy(ioutil.Discard, rsp.Body)
+			rsp.Body.Close()
+		}()
+	}
+
+	if err != nil {
+		return "", err
+	}
+
+	if rsp != nil && rsp.StatusCode != 200 {
+		err := fmt.Errorf("%s returned %d error code", m.statsUrl, rsp.StatusCode)
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(rsp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+func buildNginxMetric(name string, metricType string, value float64) (m metric.Metric) {
+	m = metric.New(name)
+	m.MetricType = metricType
+	m.Value = value
+	return m
+}
+
+func (m *NginxStats) getNginxMetrics() []metric.Metric {
+	contents, err := m.queryNginxStats()
+	if err != nil {
+		m.log.Error("Could not load stats from nginx: ", err.Error())
+		return nil
+	}
+
+	metrics := []metric.Metric{}
+
+	for _, line := range strings.Split(contents, "\n") {
+		if match := activeConnectionsRE.FindStringSubmatch(line); match != nil {
+			conn, _ := strconv.ParseFloat(match[1], 64)
+			metrics = append(
+				metrics,
+				buildNginxMetric("nginx.active_connections", metric.Gauge, conn),
+			)
+		} else if match := totalConnectionsRE.FindStringSubmatch(line); match != nil {
+			conn, _ := strconv.ParseFloat(match[1], 64)
+			acc, _ := strconv.ParseFloat(match[2], 64)
+			req, _ := strconv.ParseFloat(match[3], 64)
+			req_per_conn := req / acc
+
+			metrics = append(
+				metrics,
+				buildNginxMetric("nginx.conn_accepted", metric.CumulativeCounter, conn),
+				buildNginxMetric("nginx.conn_handled", metric.CumulativeCounter, acc),
+				buildNginxMetric("nginx.req_handled", metric.CumulativeCounter, req),
+				buildNginxMetric("nginx.req_per_conn", metric.Gauge, req_per_conn),
+			)
+		} else if match := connectionStatusRE.FindStringSubmatch(line); match != nil {
+			reading, _ := strconv.ParseFloat(match[1], 64)
+			writing, _ := strconv.ParseFloat(match[2], 64)
+			waiting, _ := strconv.ParseFloat(match[3], 64)
+			metrics = append(
+				metrics,
+				buildNginxMetric("nginx.act_reads", metric.Gauge, reading),
+				buildNginxMetric("nginx.act_writes", metric.Gauge, writing),
+				buildNginxMetric("nginx.act_waits", metric.Gauge, waiting),
+			)
+		}
+	}
+
+	return metrics
+}

--- a/src/fullerite/collector/nginx_test.go
+++ b/src/fullerite/collector/nginx_test.go
@@ -1,0 +1,109 @@
+package collector
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"fullerite/metric"
+	"net/http/httptest"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNginxStatsNewNginxStats(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	assert.Equal(t, channel, stats.channel)
+	assert.Equal(t, 10, stats.interval)
+	assert.Equal(t, log, stats.log)
+	assert.Equal(t, http.Client{Timeout: getTimeout}, stats.client)
+}
+
+func TestNginxStatsConfigureDefaults(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	configMap := map[string]interface{}{}
+	stats.Configure(configMap)
+	assert.Equal(t, stats.statsUrl, "http://localhost:8080/nginx_status")
+}
+
+func TestNginxStatsConfigureCustomStatsLocation(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	configMap := map[string]interface{}{
+		"reqHost": "yelp.com",
+		"reqPort": "1234",
+		"reqPath": "/my-cool-status",
+	}
+	stats.Configure(configMap)
+	assert.Equal(t, stats.statsUrl, "http://yelp.com:1234/my-cool-status")
+}
+
+func TestNginxStatsQueryNginxStatsSuccess(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "some response here")
+	}))
+	defer ts.Close()
+
+	stats.statsUrl = ts.URL
+	contents, err := stats.queryNginxStats()
+	assert.Equal(t, err, nil)
+	assert.Equal(t, contents, "some response here\n")
+}
+
+func TestNginxStatsQueryNginxStatsFailure(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	stats.statsUrl = "invalid-url"
+	contents, err := stats.queryNginxStats()
+	assert.NotEqual(t, err, nil)
+	assert.Equal(t, contents, "")
+}
+
+func TestBuildNginxMetric(t *testing.T) {
+	expected := metric.Metric{"nginx.test", "gauge", 0.1, map[string]string{}}
+	actual := buildNginxMetric("nginx.test", metric.Gauge, 0.1)
+	assert.Equal(t, expected, actual)
+}
+
+func TestGetNginxMetrics(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
+	stats := newNginxStats(channel, 10, log).(*NginxStats)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Response copied verbatim from an nginx status page from the routing service.
+		fmt.Fprintln(w, "Active connections: 2")
+		fmt.Fprintln(w, "server accepts handled requests")
+		fmt.Fprintln(w, " 82130 82130 84211")
+		fmt.Fprintln(w, "Reading: 0 Writing: 1 Waiting: 1")
+	}))
+	defer ts.Close()
+
+	stats.statsUrl = ts.URL
+	metrics := stats.getNginxMetrics()
+	assert.Equal(t, metrics, []metric.Metric{
+		buildNginxMetric("nginx.active_connections", metric.Gauge, 2),
+		buildNginxMetric("nginx.conn_accepted", metric.CumulativeCounter, 82130),
+		buildNginxMetric("nginx.conn_handled", metric.CumulativeCounter, 82130),
+		buildNginxMetric("nginx.req_handled", metric.CumulativeCounter, 84211),
+		buildNginxMetric("nginx.req_per_conn", metric.Gauge, 84211.0/82130.0),
+		buildNginxMetric("nginx.act_reads", metric.Gauge, 0),
+		buildNginxMetric("nginx.act_writes", metric.Gauge, 1),
+		buildNginxMetric("nginx.act_waits", metric.Gauge, 1),
+	})
+}


### PR DESCRIPTION
My goal is to create a nerve collector variant of the nginx stats collector, as we have a couple nginx services advertising in nerve which we'd like to collect stats from (similar to what we do for the uWSGI nerve collectors).

This first step ports the existing nginx diamond collector pretty much verbatim to a "native" fullerite collector and adds unit tests. The next step will be to add nerve support (should be pretty easy since we already have lots of prior art for this for native fullerite collectors).

Once merged, I'll convert existing uses of the diamond collector to this new fullerite collector inside of Yelp and we should be able to remove the diamond one (I think? Or do we want to keep it around for others?).

Internal ticket is WEBCORE-6654