### PR TITLE
Add nginx nerve collector

### DIFF
--- a/examples/config/NginxNerveStats.conf
+++ b/examples/config/NginxNerveStats.conf
@@ -1,0 +1,4 @@
+{
+    "servicePath.routing": "/_routing/nginx-status",
+    "servicePath.spectre": "/nginx_status"
+}

--- a/src/fullerite/collector/nginx_nerve.go
+++ b/src/fullerite/collector/nginx_nerve.go
@@ -1,0 +1,94 @@
+package collector
+
+import (
+	"fmt"
+	"fullerite/config"
+	"fullerite/metric"
+	"fullerite/util"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strconv"
+
+	l "github.com/Sirupsen/logrus"
+)
+
+type NginxNerveStats struct {
+	baseCollector
+	client            http.Client
+	nerveConfigPath   string
+	serviceNameToPath map[string]string
+}
+
+var (
+	servicePathKeyRE = regexp.MustCompile(`^servicePath\.(.+)$`)
+)
+
+func init() {
+	RegisterCollector("NginxNerveStats", newNginxNerveStats)
+}
+
+func newNginxNerveStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	m := new(NginxNerveStats)
+
+	m.log = log
+	m.channel = channel
+	m.interval = initialInterval
+	m.name = "NginxNerveStats"
+	m.nerveConfigPath = "/etc/nerve/nerve.conf.json"
+	m.client = http.Client{Timeout: nginxGetTimeout}
+
+	return m
+}
+
+func (m *NginxNerveStats) Configure(configMap map[string]interface{}) {
+	m.configureCommonParams(configMap)
+	c := config.GetAsMap(configMap)
+
+	// Convert config keys/values like "servicePath.routing" into a mapping of
+	// service name to nginx status path.
+	m.serviceNameToPath = make(map[string]string)
+	for key, value := range c {
+		if match := servicePathKeyRE.FindStringSubmatch(key); match != nil {
+			m.serviceNameToPath[match[1]] = value
+		}
+	}
+}
+
+func (m *NginxNerveStats) Collect() {
+	rawFileContents, err := ioutil.ReadFile(m.nerveConfigPath)
+	if err != nil {
+		m.log.Warn("Failed to read the contents of file ", m.nerveConfigPath, " because ", err)
+		return
+	}
+	services, err := util.ParseNerveConfig(&rawFileContents, true)
+	if err != nil {
+		m.log.Warn("Failed to parse the nerve config at ", m.nerveConfigPath, ": ", err)
+		return
+	}
+	m.log.Debug("Finished parsing Nerve config into ", services)
+
+	for _, service := range services {
+		if path, exists := m.serviceNameToPath[service.Name]; exists {
+			go m.collectMetricsForService(service, path)
+		}
+	}
+}
+
+func (m *NginxNerveStats) collectMetricsForService(service util.NerveService, path string) {
+	serviceLog := m.log.WithField("service", service.Name)
+	statsURL := fmt.Sprintf("http://localhost:%d%s", service.Port, path)
+
+	serviceLog.Debug("Fetching nginx stats from", statsURL)
+	metrics := getNginxMetrics(m.client, statsURL, serviceLog)
+
+	metric.AddToAll(&metrics, map[string]string{
+		"service_name":      service.Name,
+		"service_namespace": service.Namespace,
+		"port":              strconv.Itoa(service.Port),
+	})
+
+	for _, metric := range metrics {
+		m.Channel() <- metric
+	}
+}

--- a/src/fullerite/collector/nginx_nerve_test.go
+++ b/src/fullerite/collector/nginx_nerve_test.go
@@ -1,0 +1,91 @@
+package collector
+
+import (
+	"fullerite/util"
+	"net/http"
+	"os"
+
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http/httptest"
+	"testing"
+
+	"fullerite/metric"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNginxNerveStatsNewNginxNerveStats(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
+	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+
+	assert.Equal(t, channel, stats.channel)
+	assert.Equal(t, 10, stats.interval)
+	assert.Equal(t, log, stats.log)
+	assert.Equal(t, http.Client{Timeout: getTimeout}, stats.client)
+}
+
+func TestNginxNerveStatsConfigureDefaults(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
+	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+
+	configMap := map[string]interface{}{}
+	stats.Configure(configMap)
+}
+
+func TestNginxNerveStatsConfigure(t *testing.T) {
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
+	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+
+	configMap := map[string]interface{}{
+		"servicePath.routing": "/_routing/nginx-status",
+		"servicePath.spectre": "/nginx_status",
+	}
+	stats.Configure(configMap)
+
+	assert.Equal(t, stats.serviceNameToPath, map[string]string{
+		"routing": "/_routing/nginx-status",
+		"spectre": "/nginx_status",
+	})
+}
+
+func TestNginxNerveStatsCollect(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Active connections: 2")
+	}))
+	defer ts.Close()
+	ip, port := parseURL(ts.URL)
+	minimalNerveConfig := util.CreateMinimalNerveConfig(map[string]util.EndPoint{
+		"routing.main": util.EndPoint{ip, port},
+	})
+
+	tmpFile, err := ioutil.TempFile("", "fullerite_testing")
+	defer os.Remove(tmpFile.Name())
+	assert.Nil(t, err)
+
+	marshalled, err := json.Marshal(minimalNerveConfig)
+	assert.Nil(t, err)
+
+	_, err = tmpFile.Write(marshalled)
+	assert.Nil(t, err)
+
+	cfg := map[string]interface{}{
+		"servicePath.routing": "/_routing/nginx-status",
+	}
+
+	channel := make(chan metric.Metric)
+	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
+	inst := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+	inst.nerveConfigPath = tmpFile.Name()
+	inst.Configure(cfg)
+
+	inst.Collect()
+	metric := <-inst.Channel()
+	assert.Equal(t, metric.Value, 2.0)
+	assert.Equal(t, metric.Dimensions["service_name"], "routing")
+}


### PR DESCRIPTION
This creates a new nerve collector based on the nginx collector added in #376. The configuration looks like this:

```json
{
    "servicePath.routing": "/_routing/nginx-status",
    "servicePath.spectre": "/nginx_status"
}
```

The fullerite collector behaves similarly to the other existing nerve collectors: it looks at the services running on the current box, checks against the whitelist, then collects metrics from any matching services.

I tested this out on a stageg host currently running the routing service with the above config; here are the metrics it found:

```
 msg="{\"name\":\"nginx.active_connections\",\"type\":\"gauge\",\"value\":2,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.conn_accepted\",\"type\":\"cumcounter\",\"value\":265697,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.conn_handled\",\"type\":\"cumcounter\",\"value\":265697,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.req_handled\",\"type\":\"cumcounter\",\"value\":271399,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.req_per_conn\",\"type\":\"gauge\",\"value\":1.0214605358735702,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.act_reads\",\"type\":\"gauge\",\"value\":0,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.act_writes\",\"type\":\"gauge\",\"value\":1,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
 msg="{\"name\":\"nginx.act_waits\",\"type\":\"gauge\",\"value\":1,\"dimensions\":{\"collector\":\"NginxNerveStats\",\"port\":\"31880\",\"service_name\":\"routing\",\"service_namespace\":\"main\"}}" app=fullerite handler=Log pkg=handler
```

These are all of the same metrics as the regular collector, but with a couple extra dimensions (`service_name`, `service_namespace`, `port`).