### PR TITLE
Make DockerMemoryUsed report RSS and not the buggy usage_in_bytes

### DIFF
--- a/src/fullerite/collector/docker_stats.go
+++ b/src/fullerite/collector/docker_stats.go
@@ -189,7 +189,8 @@ func (d *DockerStats) extractMetrics(container *docker.Container, stats *docker.
 
 // buildMetrics creates the actual metrics for the given container.
 func (d DockerStats) buildMetrics(container *docker.Container, containerStats *docker.Stats, cpuPercentage float64) []metric.Metric {
-	mem := containerStats.MemoryStats.Usage - containerStats.MemoryStats.Stats.Cache
+	// Report only Rss, not cache.
+	mem := containerStats.MemoryStats.Stats.Rss + containerStats.MemoryStats.Stats.Swap
 	ret := []metric.Metric{
 		buildDockerMetric("DockerMemoryUsed", metric.Gauge, float64(mem)),
 		buildDockerMetric("DockerMemoryLimit", metric.Gauge, float64(containerStats.MemoryStats.Limit)),

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -74,7 +74,7 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	stats := new(docker.Stats)
 	stats.Networks = make(map[string]docker.NetworkStats)
 	stats.Networks["eth0"] = docker.NetworkStats{RxBytes: 10, TxBytes: 20}
-	stats.MemoryStats.Usage = 50
+    stats.MemoryStats.Stats.Rss = 50
 	stats.MemoryStats.Limit = 70
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
 	stats.CPUStats.ThrottlingData.ThrottledTime = 456
@@ -147,7 +147,8 @@ func TestDockerStatsBuildwithEmitImageName(t *testing.T) {
 	stats := new(docker.Stats)
 	stats.Networks = make(map[string]docker.NetworkStats)
 	stats.Networks["eth0"] = docker.NetworkStats{RxBytes: 10, TxBytes: 20}
-	stats.MemoryStats.Usage = 50
+	stats.MemoryStats.Stats.Rss = 50
+	stats.MemoryStats.Stats.Swap = 10
 	stats.MemoryStats.Limit = 70
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
 	stats.CPUStats.ThrottlingData.ThrottledTime = 456
@@ -184,7 +185,7 @@ func TestDockerStatsBuildwithEmitImageName(t *testing.T) {
 		"instance_name": "main",
 	}
 	expectedMetrics := []metric.Metric{
-		metric.Metric{"DockerMemoryUsed", "gauge", 50, baseDims},
+		metric.Metric{"DockerMemoryUsed", "gauge", 60, baseDims},
 		metric.Metric{"DockerMemoryLimit", "gauge", 70, baseDims},
 		metric.Metric{"DockerCpuPercentage", "gauge", 0.5, baseDims},
 		metric.Metric{"DockerCpuThrottledPeriods", "cumcounter", 123, baseDims},
@@ -216,7 +217,7 @@ func TestDockerStatsBuildMetricsWithNameAsEnvVariable(t *testing.T) {
 	config["generatedDimensions"] = val
 
 	stats := new(docker.Stats)
-	stats.MemoryStats.Usage = 50
+	stats.MemoryStats.Stats.Rss = 50
 	stats.MemoryStats.Limit = 70
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
 	stats.CPUStats.ThrottlingData.ThrottledTime = 456

--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -74,7 +74,7 @@ func TestDockerStatsBuildMetrics(t *testing.T) {
 	stats := new(docker.Stats)
 	stats.Networks = make(map[string]docker.NetworkStats)
 	stats.Networks["eth0"] = docker.NetworkStats{RxBytes: 10, TxBytes: 20}
-    stats.MemoryStats.Stats.Rss = 50
+	stats.MemoryStats.Stats.Rss = 50
 	stats.MemoryStats.Limit = 70
 	stats.CPUStats.ThrottlingData.ThrottledPeriods = 123
 	stats.CPUStats.ThrottlingData.ThrottledTime = 456


### PR DESCRIPTION
We've been observing disparities between usage_in_bytes and actual memory usage

This documentation, Section 5.5 says that we should not rely on usage_in_bytes
https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt 

We should instead do RSS + Cache + Swap if we want an accurate idea of the memory usage.
I thought about adding a timeserie but this could be very costly so let's just look at RSS

Because Swap is not exposed here by the API I didn't add it here but maybe we should take this specific use case into account ?