### PR TITLE
Adding jvm.uptime to Elasticsearch diamond collector

### DIFF
--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -346,6 +346,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
         # jvm
         if 'jvm' in self.config['stats']:
             jvm = data['jvm']
+            metrics['jvm.uptime_in_days'] = jvm['uptime_in_millis'] / 1000.0 / 60 / 60 / 24
             mem = jvm['mem']
             for k in ('heap_used', 'heap_committed', 'non_heap_used',
                       'non_heap_committed'):


### PR DESCRIPTION
Verified by running fullerite locally #383

This elasticsearch node has an uptime of about one hour which is about 0.0417 days/
![image](https://user-images.githubusercontent.com/8527001/53515611-44bceb00-3a7f-11e9-84d8-de079888215d.png)
