### PR TITLE
Add multiple hosts mode for jolokia collector

### DIFF
--- a/src/diamond/collectors/jolokia/test/testkafka_jolokia.py
+++ b/src/diamond/collectors/jolokia/test/testkafka_jolokia.py
@@ -17,7 +17,7 @@ def find_metric(metric_list, metric_name):
 def find_by_dimension(metric_list, key, val):
     return filter(lambda metric:metric["dimensions"][key] == val, metric_list)[0]
 
-def list_request():
+def list_request(host, port):
     return {'value': {'kafka.server':'bla'}, 'status':200}
 
 class TestKafkaJolokiaCollector(CollectorTestCase):


### PR DESCRIPTION
- This mode enables collecting metrics from multiple hosts, which is useful, for example, when a collector runs in a k8s node, and collects metrics from containers
- Hosts discovery is delegated to a JSON file, of which the path is specified in the config

Note that the hosts discovery file, in our specific use case, can be generated from the nerve config file by a cron job deployed on the k8s nodes.