### PR TITLE
Adding a java_metric dimension with ts name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ src/github.com/
 src/fullerite/collector/collector.test
 *.pprof
 .tox
+go

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.40
+VERSION        := 0.6.41
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,15 @@ $(BEATIT): $(BEATIT_SOURCES)
 	@echo Building $(BEATIT)...
 	@go build -o bin/$(BEATIT) fullerite/beatit
 
+go:
+	curl -s https://dl.google.com/go/go1.9.linux-amd64.tar.gz | tar xz
+	@echo "Please type: eval \`make goenv\`"
+
+goenv: go
+	@echo export GOROOT=`readlink -f go/`
+	@echo export GOPATH=`readlink -f go/bin`
+	@echo export PATH=`readlink -f go/bin`:\$$PATH
+
 test: tests
 tests: deps diamond_test fullerite-tests
 

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.40"
+	version = "0.6.41"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/dropwizard/java_metric.go
+++ b/src/fullerite/dropwizard/java_metric.go
@@ -37,6 +37,7 @@ func (parser *JavaMetric) Parse() ([]metric.Metric, error) {
 func (parser *JavaMetric) parseMapOfMap(
 	metricMap map[string]map[string]interface{},
 	metricType string) []metric.Metric {
+
 	results := []metric.Metric{}
 	var values []string
 
@@ -44,6 +45,7 @@ func (parser *JavaMetric) parseMapOfMap(
 		values = strings.Split(metricName, ",")
 		for rollup, value := range metricData {
 			mName := values[0]
+			mNameWithSuffix := mName
 			mType := metricType
 			matched, _ := regexp.MatchString("m[0-9]+_rate", rollup)
 
@@ -53,14 +55,18 @@ func (parser *JavaMetric) parseMapOfMap(
 			if parser.ccEnabled && matched {
 				continue
 			}
+
 			if parser.ccEnabled && rollup != "value" {
-				mName = mName + "." + rollup
+			// For legacy reasons we append the rollup to the metric name
+				mNameWithSuffix = mName + "." + rollup
 				if rollup == "count" {
 					mType = metric.CumulativeCounter
 				}
 			}
-			tmpMetric, ok := parser.createMetricFromDatam(rollup, value, mName, mType)
+
+			tmpMetric, ok := parser.createMetricFromDatam(rollup, value, mNameWithSuffix, mType)
 			if ok {
+				addNameDimension(&tmpMetric, mName)
 				addDimensionsFromName(&tmpMetric, values)
 				results = append(results, tmpMetric)
 			}
@@ -68,6 +74,15 @@ func (parser *JavaMetric) parseMapOfMap(
 	}
 
 	return results
+}
+
+// If we want to be able to do operations the same metric but different rollup (eg. mean * count)
+// we need to have a common dimension to link them. Name isn't because we happened a suffix to it
+// It would be better to use only one metric name with many values for rollup dimensions
+// but that involve updating all our dashbords. Hence the gross hack of adding the metric name as
+// a dimension.
+func addNameDimension(m *metric.Metric, mName string) {
+	m.AddDimension("java_metric", mName)
 }
 
 func addDimensionsFromName(m *metric.Metric, dimensions []string) {

--- a/src/fullerite/dropwizard/java_metric_test.go
+++ b/src/fullerite/dropwizard/java_metric_test.go
@@ -1,0 +1,34 @@
+package dropwizard
+
+import (
+    "testing"
+    "github.com/stretchr/testify/assert"
+)
+
+func TestJavaMetric(t *testing.T) {
+    testMeters := make(map[string]map[string]interface{})
+    testMeters["com.yelp.service.endpoint"] = map[string]interface{}{
+        "count":    957,
+        "p50":      0.5,
+        "m1_rate":  0.1,
+        "units":    "events/second",
+    }
+    parser := NewJavaMetric([]byte(``), "", true)
+    actual := parser.parseMapOfMap(testMeters, "metricType")
+
+    for _, m := range actual {
+        switch m.Name {
+        case "com.yelp.service.endpoint.count":
+            assert.Equal(t, 957.0, m.Value)
+        case "com.yelp.service.endpoint.p50":
+            assert.Equal(t, 0.5, m.Value)
+            assert.Equal(t, "p50", m.Dimensions["rollup"])
+            assert.Equal(t, "com.yelp.service.endpoint", m.Dimensions["java_metric"])
+            assert.Equal(t, 2, len(m.Dimensions))
+        case "com.yelp.service.endpoint.m1_rate":
+            t.Fatalf("m*_rate metrics should be discarded, found: %s", m.Name)
+        default:
+            t.Fatalf("unknown metric name %s", m.Name)
+        }
+    }
+}

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.40"
+	version = "0.6.41"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
For legacy reasons we append the rollup to the metric name

If we want to be able to do operations the same metric but different rollup (eg. mean * count) we need to have a common dimension to link them. Name isn't because we happened a suffix to it. It would be better to use only one metric name with many values for rollup dimensions but that involve updating all our dashbords. Hence the gross hack of adding the metric name as a dimension.


+ adding make target to setup go 1.9 on linux