### PR TITLE
Improve Jolokia Diamond collector error handling

### DIFF
--- a/src/diamond/collectors/jolokia/jolokia.py
+++ b/src/diamond/collectors/jolokia/jolokia.py
@@ -267,7 +267,8 @@ class JolokiaCollector(diamond.collector.Collector):
                                          url_path)
             response = urllib2.urlopen(url)
             return self.read_json(response)
-        except (urllib2.HTTPError, ValueError):
+        except Exception as e:
+            self.log.error(e)
             self.log.error('Unable to read JSON response from %s:%s' % (host, port))
             return {}
 
@@ -285,7 +286,8 @@ class JolokiaCollector(diamond.collector.Collector):
                                          url_path)
             response = urllib2.urlopen(url)
             return self.read_json(response)
-        except (urllib2.HTTPError, ValueError):
+        except Exception as e:
+            self.log.error(e)
             self.log.error('Unable to read JSON response from %s:%s' % (host, port))
             return {}
 


### PR DESCRIPTION
- Any exception of jolokia requests needs to be captured for multiple hosts mode to work properly

Also it should log the exact exception, an example log line when trying connecting to a dead host is
`diamond.CassandraJolokiaCollector - ERROR - <urlopen error [Errno 111] Connection refused>`