### PR TITLE
Add java common service_dims support for java

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.42
+VERSION        := 0.6.43
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/diamond/collectors/nginx/nginx.py
+++ b/src/diamond/collectors/nginx/nginx.py
@@ -72,11 +72,11 @@ class NginxCollector(diamond.collector.Collector):
                         int(activeConnectionsRE.match(l).group('conn')))
                 elif totalConnectionsRE.match(l):
                     m = totalConnectionsRE.match(l)
-                    reqPerConn = float(m.group('req')) / float(m.group('acc'))
+                    req_per_conn = float(m.group('req')) / float(m.group('acc'))
                     self.publish_cumulative_counter('nginx.conn_accepted', int(m.group('conn')))
                     self.publish_cumulative_counter('nginx.conn_handled', int(m.group('acc')))
                     self.publish_cumulative_counter('nginx.req_handled', int(m.group('req')))
-                    self.publish_gauge('nginx.req_per_conn', float(reqPerConn))
+                    self.publish_gauge('nginx.req_per_conn', float(req_per_conn))
                 elif connectionStatusRE.match(l):
                     m = connectionStatusRE.match(l)
                     self.publish_gauge('nginx.act_reads', int(m.group('reading')))

--- a/src/diamond/collectors/nginx/nginx.py
+++ b/src/diamond/collectors/nginx/nginx.py
@@ -72,11 +72,11 @@ class NginxCollector(diamond.collector.Collector):
                         int(activeConnectionsRE.match(l).group('conn')))
                 elif totalConnectionsRE.match(l):
                     m = totalConnectionsRE.match(l)
-                    req_per_conn = float(m.group('req')) / float(m.group('acc'))
+                    reqPerConn = float(m.group('req')) / float(m.group('acc'))
                     self.publish_cumulative_counter('nginx.conn_accepted', int(m.group('conn')))
                     self.publish_cumulative_counter('nginx.conn_handled', int(m.group('acc')))
                     self.publish_cumulative_counter('nginx.req_handled', int(m.group('req')))
-                    self.publish_gauge('nginx.req_per_conn', float(req_per_conn))
+                    self.publish_gauge('nginx.req_per_conn', float(reqPerConn))
                 elif connectionStatusRE.match(l):
                     m = connectionStatusRE.match(l)
                     self.publish_gauge('nginx.act_reads', int(m.group('reading')))

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.42"
+	version = "0.6.43"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/collector/net_udp.go
+++ b/src/fullerite/collector/net_udp.go
@@ -40,8 +40,7 @@ type procNetUpdLine struct {
 	drops         string
 }
 
-// ProcNetUDPStats Collector to record udp stats
-type ProcNetUDPStats struct {
+type procNetUDPStats struct {
 	baseCollector
 	localAddressWhitelist  *regexp.Regexp
 	remoteAddressWhitelist *regexp.Regexp
@@ -52,7 +51,7 @@ func init() {
 }
 
 func newProcNetUDPStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
-	s := new(ProcNetUDPStats)
+	s := new(procNetUDPStats)
 	s.log = log
 	s.channel = channel
 	s.interval = initialInterval
@@ -62,7 +61,7 @@ func newProcNetUDPStats(channel chan metric.Metric, initialInterval int, log *l.
 }
 
 // Configure Override *baseCollector.Configure()
-func (s *ProcNetUDPStats) Configure(configMap map[string]interface{}) {
+func (s *procNetUDPStats) Configure(configMap map[string]interface{}) {
 	s.configureCommonParams(configMap)
 
 	if whitelist, exists := configMap["localAddressWhitelist"]; exists {
@@ -88,7 +87,7 @@ func (s *ProcNetUDPStats) Configure(configMap map[string]interface{}) {
 	}
 }
 
-func (s *ProcNetUDPStats) Collect() {
+func (s *procNetUDPStats) Collect() {
 	if s.localAddressWhitelist == nil && s.remoteAddressWhitelist == nil {
 		return
 	}
@@ -111,7 +110,7 @@ func (s *ProcNetUDPStats) Collect() {
 	}
 }
 
-func (s *ProcNetUDPStats) createMetric(name string, value float64, dims map[string]string) metric.Metric {
+func (s *procNetUDPStats) createMetric(name string, value float64, dims map[string]string) metric.Metric {
 	m := metric.New("udp.drops")
 	m.Value = value
 	m.MetricType = metric.CumulativeCounter
@@ -119,7 +118,7 @@ func (s *ProcNetUDPStats) createMetric(name string, value float64, dims map[stri
 	return m
 }
 
-func (s *ProcNetUDPStats) getProcNetUDPStats() []procNetUpdLine {
+func (s *procNetUDPStats) getProcNetUDPStats() []procNetUpdLine {
 	cmdLine := []string{
 		"cat",
 		"/proc/net/udp",
@@ -134,7 +133,7 @@ func (s *ProcNetUDPStats) getProcNetUDPStats() []procNetUpdLine {
 	return s.parseProcNetUDPLines(string(out))
 }
 
-func (s *ProcNetUDPStats) runCommand(cmdLine []string) []byte {
+func (s *procNetUDPStats) runCommand(cmdLine []string) []byte {
 	var out []byte
 	var err error
 
@@ -148,7 +147,7 @@ func (s *ProcNetUDPStats) runCommand(cmdLine []string) []byte {
 	return out
 }
 
-func (s *ProcNetUDPStats) parseProcNetUDPLines(out string) []procNetUpdLine {
+func (s *procNetUDPStats) parseProcNetUDPLines(out string) []procNetUpdLine {
 	raw := strings.Trim(out, "\n")
 	lines := strings.Split(raw, "\n")
 	stats := []procNetUpdLine{}

--- a/src/fullerite/collector/net_udp_test.go
+++ b/src/fullerite/collector/net_udp_test.go
@@ -13,7 +13,7 @@ func TestNewProcNetUDPStats(t *testing.T) {
 	i := 10
 	l := defaultLog.WithFields(l.Fields{"collector": "Mesos"})
 
-	actual := newProcNetUDPStats(c, i, l).(*ProcNetUDPStats)
+	actual := newProcNetUDPStats(c, i, l).(*procNetUDPStats)
 
 	assert.Equal(t, "ProcNetUDPStats", actual.Name())
 	assert.Equal(t, c, actual.Channel())
@@ -24,47 +24,47 @@ func TestNewProcNetUDPStats(t *testing.T) {
 func TestProcNetUDPStatsConfigureMissingRemote(t *testing.T) {
 	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
 
-	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
-	fake_collector.Configure(map[string]interface{}{
+	fakeCollector := newProcNetUDPStats(nil, 0, l).(*procNetUDPStats)
+	fakeCollector.Configure(map[string]interface{}{
 		"localAddressWhitelist": "7F000001:613",
 	})
 
-	assert.NotNil(t, fake_collector.localAddressWhitelist)
-	assert.Nil(t, fake_collector.remoteAddressWhitelist)
+	assert.NotNil(t, fakeCollector.localAddressWhitelist)
+	assert.Nil(t, fakeCollector.remoteAddressWhitelist)
 }
 
 func TestProcNetUDPStatsConfigureMissingLocal(t *testing.T) {
 	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
 
-	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
-	fake_collector.Configure(map[string]interface{}{
+	fakeCollector := newProcNetUDPStats(nil, 0, l).(*procNetUDPStats)
+	fakeCollector.Configure(map[string]interface{}{
 		"remoteAddressWhitelist": "7F000001:613",
 	})
 
-	assert.Nil(t, fake_collector.localAddressWhitelist)
-	assert.NotNil(t, fake_collector.remoteAddressWhitelist)
+	assert.Nil(t, fakeCollector.localAddressWhitelist)
+	assert.NotNil(t, fakeCollector.remoteAddressWhitelist)
 }
 
 func TestProcNetUDPStatsConfigure(t *testing.T) {
 	l := defaultLog.WithFields(l.Fields{"collector": "ProcNetUDPStats"})
 
-	fake_collector := newProcNetUDPStats(nil, 0, l).(*ProcNetUDPStats)
-	fake_collector.Configure(map[string]interface{}{
+	fakeCollector := newProcNetUDPStats(nil, 0, l).(*procNetUDPStats)
+	fakeCollector.Configure(map[string]interface{}{
 		"localAddressWhitelist":  "7F000001:613",
 		"remoteAddressWhitelist": "7F000001:613",
 	})
 
-	assert.NotNil(t, fake_collector.localAddressWhitelist)
-	assert.NotNil(t, fake_collector.remoteAddressWhitelist)
+	assert.NotNil(t, fakeCollector.localAddressWhitelist)
+	assert.NotNil(t, fakeCollector.remoteAddressWhitelist)
 }
 
 func TestParse(t *testing.T) {
 	out := `sl  local_address rem_address   st tx_queue rx_queue tr tm->when retrnsmt   uid  timeout inode ref pointer drops
  3152: FEFFFEA9:4ED6 00000000:0000 07 00000000:00000000 00:00000000 00000000 65534        0 3841266873 2 ffff88021734b480 0
 15747: FEFFFEA9:8009 FEFFFEA9:1FBD 01 00000000:00000000 00:00000000 00000000  4404        0 1989081677 2 ffff8806859712c0 100`
-	fake_collector := &ProcNetUDPStats{}
+	fakeCollector := &procNetUDPStats{}
 
-	lines := fake_collector.parseProcNetUDPLines(out)
+	lines := fakeCollector.parseProcNetUDPLines(out)
 	assert.Equal(t, 2, len(lines))
 
 	assert.Equal(t, "FEFFFEA9:4ED6", lines[0].localAddress)

--- a/src/fullerite/collector/nginx.go
+++ b/src/fullerite/collector/nginx.go
@@ -15,7 +15,7 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
-type NginxStats struct {
+type nginxStats struct {
 	baseCollector
 	client   http.Client
 	statsURL string
@@ -43,7 +43,7 @@ func init() {
 }
 
 func newNginxStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
-	m := new(NginxStats)
+	m := new(nginxStats)
 
 	m.log = log
 	m.channel = channel
@@ -54,7 +54,7 @@ func newNginxStats(channel chan metric.Metric, initialInterval int, log *l.Entry
 	return m
 }
 
-func (m *NginxStats) Configure(configMap map[string]interface{}) {
+func (m *nginxStats) Configure(configMap map[string]interface{}) {
 	m.configureCommonParams(configMap)
 
 	c := config.GetAsMap(configMap)
@@ -76,7 +76,7 @@ func (m *NginxStats) Configure(configMap map[string]interface{}) {
 	m.statsURL = fmt.Sprintf("http://%s:%s%s", host, port, path)
 }
 
-func (m *NginxStats) Collect() {
+func (m *nginxStats) Collect() {
 	for _, metric := range getNginxMetrics(m.client, m.statsURL, m.log) {
 		m.Channel() <- metric
 	}
@@ -136,14 +136,14 @@ func getNginxMetrics(client http.Client, statsURL string, log *l.Entry) []metric
 			conn, _ := strconv.ParseFloat(match[1], 64)
 			acc, _ := strconv.ParseFloat(match[2], 64)
 			req, _ := strconv.ParseFloat(match[3], 64)
-			req_per_conn := req / acc
+			reqPerConn := req / acc
 
 			metrics = append(
 				metrics,
 				buildNginxMetric("nginx.conn_accepted", metric.CumulativeCounter, conn),
 				buildNginxMetric("nginx.conn_handled", metric.CumulativeCounter, acc),
 				buildNginxMetric("nginx.req_handled", metric.CumulativeCounter, req),
-				buildNginxMetric("nginx.req_per_conn", metric.Gauge, req_per_conn),
+				buildNginxMetric("nginx.req_per_conn", metric.Gauge, reqPerConn),
 			)
 		} else if match := connectionStatusRE.FindStringSubmatch(line); match != nil {
 			reading, _ := strconv.ParseFloat(match[1], 64)

--- a/src/fullerite/collector/nginx_nerve.go
+++ b/src/fullerite/collector/nginx_nerve.go
@@ -13,7 +13,7 @@ import (
 	l "github.com/Sirupsen/logrus"
 )
 
-type NginxNerveStats struct {
+type nginxNerveStats struct {
 	baseCollector
 	client            http.Client
 	nerveConfigPath   string
@@ -29,7 +29,7 @@ func init() {
 }
 
 func newNginxNerveStats(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
-	m := new(NginxNerveStats)
+	m := new(nginxNerveStats)
 
 	m.log = log
 	m.channel = channel
@@ -41,7 +41,7 @@ func newNginxNerveStats(channel chan metric.Metric, initialInterval int, log *l.
 	return m
 }
 
-func (m *NginxNerveStats) Configure(configMap map[string]interface{}) {
+func (m *nginxNerveStats) Configure(configMap map[string]interface{}) {
 	m.configureCommonParams(configMap)
 	c := config.GetAsMap(configMap)
 
@@ -55,7 +55,7 @@ func (m *NginxNerveStats) Configure(configMap map[string]interface{}) {
 	}
 }
 
-func (m *NginxNerveStats) Collect() {
+func (m *nginxNerveStats) Collect() {
 	rawFileContents, err := ioutil.ReadFile(m.nerveConfigPath)
 	if err != nil {
 		m.log.Warn("Failed to read the contents of file ", m.nerveConfigPath, " because ", err)
@@ -75,7 +75,7 @@ func (m *NginxNerveStats) Collect() {
 	}
 }
 
-func (m *NginxNerveStats) collectMetricsForService(service util.NerveService, path string) {
+func (m *nginxNerveStats) collectMetricsForService(service util.NerveService, path string) {
 	serviceLog := m.log.WithField("service", service.Name)
 	statsURL := fmt.Sprintf("http://localhost:%d%s", service.Port, path)
 

--- a/src/fullerite/collector/nginx_nerve_test.go
+++ b/src/fullerite/collector/nginx_nerve_test.go
@@ -20,7 +20,7 @@ import (
 func TestNginxNerveStatsNewNginxNerveStats(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
-	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+	stats := newNginxNerveStats(channel, 10, log).(*nginxNerveStats)
 
 	assert.Equal(t, channel, stats.channel)
 	assert.Equal(t, 10, stats.interval)
@@ -31,7 +31,7 @@ func TestNginxNerveStatsNewNginxNerveStats(t *testing.T) {
 func TestNginxNerveStatsConfigureDefaults(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
-	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+	stats := newNginxNerveStats(channel, 10, log).(*nginxNerveStats)
 
 	configMap := map[string]interface{}{}
 	stats.Configure(configMap)
@@ -40,7 +40,7 @@ func TestNginxNerveStatsConfigureDefaults(t *testing.T) {
 func TestNginxNerveStatsConfigure(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
-	stats := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+	stats := newNginxNerveStats(channel, 10, log).(*nginxNerveStats)
 
 	configMap := map[string]interface{}{
 		"servicePath.routing": "/_routing/nginx-status",
@@ -80,7 +80,7 @@ func TestNginxNerveStatsCollect(t *testing.T) {
 
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "NginxNerveStats"})
-	inst := newNginxNerveStats(channel, 10, log).(*NginxNerveStats)
+	inst := newNginxNerveStats(channel, 10, log).(*nginxNerveStats)
 	inst.nerveConfigPath = tmpFile.Name()
 	inst.Configure(cfg)
 

--- a/src/fullerite/collector/nginx_test.go
+++ b/src/fullerite/collector/nginx_test.go
@@ -15,7 +15,7 @@ import (
 func TestNginxStatsNewNginxStats(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	assert.Equal(t, channel, stats.channel)
 	assert.Equal(t, 10, stats.interval)
@@ -26,7 +26,7 @@ func TestNginxStatsNewNginxStats(t *testing.T) {
 func TestNginxStatsConfigureDefaults(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	configMap := map[string]interface{}{}
 	stats.Configure(configMap)
@@ -36,7 +36,7 @@ func TestNginxStatsConfigureDefaults(t *testing.T) {
 func TestNginxStatsConfigureCustomStatsLocation(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	configMap := map[string]interface{}{
 		"reqHost": "yelp.com",
@@ -50,7 +50,7 @@ func TestNginxStatsConfigureCustomStatsLocation(t *testing.T) {
 func TestNginxStatsQueryNginxStatsSuccess(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "some response here")
@@ -66,7 +66,7 @@ func TestNginxStatsQueryNginxStatsSuccess(t *testing.T) {
 func TestNginxStatsQueryNginxStatsFailure(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	stats.statsURL = "invalid-url"
 	contents, err := queryNginxStats(stats.client, stats.statsURL)
@@ -83,7 +83,7 @@ func TestBuildNginxMetric(t *testing.T) {
 func TestGetNginxMetrics(t *testing.T) {
 	channel := make(chan metric.Metric)
 	log := defaultLog.WithFields(l.Fields{"collector": "Nginx"})
-	stats := newNginxStats(channel, 10, log).(*NginxStats)
+	stats := newNginxStats(channel, 10, log).(*nginxStats)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Response copied verbatim from an nginx status page from the routing service.

--- a/src/fullerite/collector_hook.go
+++ b/src/fullerite/collector_hook.go
@@ -47,13 +47,13 @@ func (hook *LogErrorHook) Levels() []logrus.Level {
 }
 
 func (hook *LogErrorHook) reportErrors(entry *logrus.Entry) {
-	new_metric := metric.New("fullerite.collector_errors")
-	new_metric.MetricType = metric.Counter
-	new_metric.Value = 1
+	newMetric := metric.New("fullerite.collector_errors")
+	newMetric.MetricType = metric.Counter
+	newMetric.Value = 1
 	if val, exists := entry.Data["collector"]; exists {
-		new_metric.AddDimension("collector", val.(string))
+		newMetric.AddDimension("collector", val.(string))
 	}
 
-	writeToHandlers(hook.handlers, new_metric)
+	writeToHandlers(hook.handlers, newMetric)
 	return
 }

--- a/src/fullerite/collectors.go
+++ b/src/fullerite/collectors.go
@@ -146,11 +146,11 @@ func emitCollectorStats(data map[string]uint64,
 
 func reportCollector(collector collector.Collector) {
 	log.Warn(fmt.Sprintf("%s collector took too long to run, reporting incident!", collector.Name()))
-	new_metric := metric.New("fullerite.collection_time_exceeded")
-	new_metric.MetricType = metric.Counter
-	new_metric.Value = 1
-	new_metric.AddDimension("interval", fmt.Sprintf("%d", collector.Interval()))
-	collector.Channel() <- new_metric
+	newMetric := metric.New("fullerite.collection_time_exceeded")
+	newMetric.MetricType = metric.Counter
+	newMetric.Value = 1
+	newMetric.AddDimension("interval", fmt.Sprintf("%d", collector.Interval()))
+	collector.Channel() <- newMetric
 }
 
 func stringInSlice(metricName string, list []string) bool {

--- a/src/fullerite/dropwizard/java_metric.go
+++ b/src/fullerite/dropwizard/java_metric.go
@@ -57,7 +57,7 @@ func (parser *JavaMetric) parseMapOfMap(
 			}
 
 			if parser.ccEnabled && rollup != "value" {
-			// For legacy reasons we append the rollup to the metric name
+				// For legacy reasons we append the rollup to the metric name
 				mNameWithSuffix = mName + "." + rollup
 				if rollup == "count" {
 					mType = metric.CumulativeCounter

--- a/src/fullerite/dropwizard/java_metric.go
+++ b/src/fullerite/dropwizard/java_metric.go
@@ -24,6 +24,7 @@ func NewJavaMetric(data []byte, schemaVer string, ccEnabled bool) *JavaMetric {
 // Parse returns dimensionalized parsed metrics
 func (parser *JavaMetric) Parse() ([]metric.Metric, error) {
 	parsed := new(Format)
+	parsed.ServiceDims = map[string]interface{}{}
 	err := json.Unmarshal(parser.data, parsed)
 
 	if err != nil {
@@ -31,6 +32,9 @@ func (parser *JavaMetric) Parse() ([]metric.Metric, error) {
 	}
 
 	results := extractParsedMetric(parser, parsed)
+	for k, v := range parsed.ServiceDims {
+		metric.AddToAll(&results, map[string]string{k: v.(string)})
+	}
 	return results, nil
 }
 

--- a/src/fullerite/dropwizard/java_metric_test.go
+++ b/src/fullerite/dropwizard/java_metric_test.go
@@ -1,34 +1,34 @@
 package dropwizard
 
 import (
-    "testing"
-    "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 func TestJavaMetric(t *testing.T) {
-    testMeters := make(map[string]map[string]interface{})
-    testMeters["com.yelp.service.endpoint"] = map[string]interface{}{
-        "count":    957,
-        "p50":      0.5,
-        "m1_rate":  0.1,
-        "units":    "events/second",
-    }
-    parser := NewJavaMetric([]byte(``), "", true)
-    actual := parser.parseMapOfMap(testMeters, "metricType")
+	testMeters := make(map[string]map[string]interface{})
+	testMeters["com.yelp.service.endpoint"] = map[string]interface{}{
+		"count":   957,
+		"p50":     0.5,
+		"m1_rate": 0.1,
+		"units":   "events/second",
+	}
+	parser := NewJavaMetric([]byte(``), "", true)
+	actual := parser.parseMapOfMap(testMeters, "metricType")
 
-    for _, m := range actual {
-        switch m.Name {
-        case "com.yelp.service.endpoint.count":
-            assert.Equal(t, 957.0, m.Value)
-        case "com.yelp.service.endpoint.p50":
-            assert.Equal(t, 0.5, m.Value)
-            assert.Equal(t, "p50", m.Dimensions["rollup"])
-            assert.Equal(t, "com.yelp.service.endpoint", m.Dimensions["java_metric"])
-            assert.Equal(t, 2, len(m.Dimensions))
-        case "com.yelp.service.endpoint.m1_rate":
-            t.Fatalf("m*_rate metrics should be discarded, found: %s", m.Name)
-        default:
-            t.Fatalf("unknown metric name %s", m.Name)
-        }
-    }
+	for _, m := range actual {
+		switch m.Name {
+		case "com.yelp.service.endpoint.count":
+			assert.Equal(t, 957.0, m.Value)
+		case "com.yelp.service.endpoint.p50":
+			assert.Equal(t, 0.5, m.Value)
+			assert.Equal(t, "p50", m.Dimensions["rollup"])
+			assert.Equal(t, "com.yelp.service.endpoint", m.Dimensions["java_metric"])
+			assert.Equal(t, 2, len(m.Dimensions))
+		case "com.yelp.service.endpoint.m1_rate":
+			t.Fatalf("m*_rate metrics should be discarded, found: %s", m.Name)
+		default:
+			t.Fatalf("unknown metric name %s", m.Name)
+		}
+	}
 }

--- a/src/fullerite/dropwizard/uwsgi_metric_test.go
+++ b/src/fullerite/dropwizard/uwsgi_metric_test.go
@@ -188,6 +188,41 @@ func TestUWSGIMetricConversionNewDataFormat(t *testing.T) {
 	}
 }
 
+func TestServiceDims(t *testing.T) {
+	var jsonBlob = []byte(`{
+		"version": "3.0.0",
+		"format": 2,
+		"gauges": [],
+		"histograms": [],
+		"meters": [],
+		"timers": [],
+        "service_dims": {
+              "git_sha": "aabbcc"
+        },
+		"counters": [
+			{
+				"name": "tests.my_counter",
+				"count": 17.0,
+				"dimensions": {
+					"test": "counter",
+					"two": "four"
+				}
+			}
+		]
+	}`)
+
+	parser := NewUWSGIMetric(jsonBlob, "uwsgi.1.0", false)
+
+	actual, err := parser.Parse()
+	if err != nil {
+		t.Fatalf("Failed to parse input json: %s", err)
+	}
+
+	for _, m := range actual {
+		assert.True(t, m.Dimensions["git_sha"] == "aabbcc")
+	}
+}
+
 func TestUWSGIMetricConversionCumulativeCountersEnabled(t *testing.T) {
 	testMeters := make(map[string]map[string]interface{})
 	testMeters["pyramid_uwsgi_metrics.tweens.5xx-responses"] = map[string]interface{}{

--- a/src/fullerite/handler/wavefront_test.go
+++ b/src/fullerite/handler/wavefront_test.go
@@ -1,69 +1,69 @@
 package handler
 
 import (
-        "fullerite/metric"
+	"fullerite/metric"
 
-        "testing"
-        "time"
+	"testing"
+	"time"
 
-        l "github.com/Sirupsen/logrus"
-        "github.com/stretchr/testify/assert"
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
 func getTestWavefrontHandler(interval, buffsize, timeoutsec int) *Wavefront {
-        testChannel := make(chan metric.Metric)
-        testLog := l.WithField("testing", "wavefront_handler")
-        timeout := time.Duration(timeoutsec) * time.Second
-        w :=  newWavefront(testChannel, interval, buffsize, timeout, testLog).(*Wavefront)
-        w.proxyFlag = false
-        return w
+	testChannel := make(chan metric.Metric)
+	testLog := l.WithField("testing", "wavefront_handler")
+	timeout := time.Duration(timeoutsec) * time.Second
+	w := newWavefront(testChannel, interval, buffsize, timeout, testLog).(*Wavefront)
+	w.proxyFlag = false
+	return w
 }
 
 func TestWavefrontConfigureEmptyConfig(t *testing.T) {
-        config := make(map[string]interface{})
+	config := make(map[string]interface{})
 
-        w := getTestWavefrontHandler(12, 13, 14)
-        w.Configure(config)
+	w := getTestWavefrontHandler(12, 13, 14)
+	w.Configure(config)
 
-        assert.Equal(t, 12, w.Interval())
-        assert.Equal(t, 13, w.MaxBufferSize())
+	assert.Equal(t, 12, w.Interval())
+	assert.Equal(t, 13, w.MaxBufferSize())
 }
 
 func TestWavefrontConfigure(t *testing.T) {
-        config := map[string]interface{}{
-                "interval":        "10",
-                "timeout":         "10",
-                "max_buffer_size": "100",
-                "endpoint":        "wavefront.server",
-                "proxyFlag":       "true",
-                "port":            "2878",
-                "proxyServer":	   "wavefront.proxy",
-        }
+	config := map[string]interface{}{
+		"interval":        "10",
+		"timeout":         "10",
+		"max_buffer_size": "100",
+		"endpoint":        "wavefront.server",
+		"proxyFlag":       "true",
+		"port":            "2878",
+		"proxyServer":     "wavefront.proxy",
+	}
 
-        w := getTestWavefrontHandler(40, 50, 60)
-        w.Configure(config)
+	w := getTestWavefrontHandler(40, 50, 60)
+	w.Configure(config)
 
-        assert.Equal(t, 10, w.Interval())
-        assert.Equal(t, 100, w.MaxBufferSize())
-        assert.Equal(t, true, w.proxyFlag)
-        assert.Equal(t, "wavefront.proxy", w.proxyServer)
-        assert.Equal(t, "2878", w.port)
+	assert.Equal(t, 10, w.Interval())
+	assert.Equal(t, 100, w.MaxBufferSize())
+	assert.Equal(t, true, w.proxyFlag)
+	assert.Equal(t, "wavefront.proxy", w.proxyServer)
+	assert.Equal(t, "2878", w.port)
 }
 
 func TestWavefrontSanitation(t *testing.T) {
-        w := getTestWavefrontHandler(12, 12, 12)
+	w := getTestWavefrontHandler(12, 12, 12)
 
-        m1 := metric.New(" Test= .me$tric ")
-        var host = []byte{260: 'x'}
-        m1.AddDimension("host",string(host))
-        m1.AddDimension("With_quotes", "_Value_with-\"quotes++\"_")
-        datapoint1 := w.convertToWavefront(m1)
+	m1 := metric.New(" Test= .me$tric ")
+	var host = []byte{260: 'x'}
+	m1.AddDimension("host", string(host))
+	m1.AddDimension("With_quotes", "_Value_with-\"quotes++\"_")
+	datapoint1 := w.convertToWavefront(m1)
 
-        m2 := metric.New("Test-_.metric")
-        var tag = []byte{1030: 'x'}
-        m2.AddDimension("long_tag", string(tag))
-        datapoint2 := w.convertToWavefront(m2)
+	m2 := metric.New("Test-_.metric")
+	var tag = []byte{1030: 'x'}
+	m2.AddDimension("long_tag", string(tag))
+	datapoint2 := w.convertToWavefront(m2)
 
-        assert.Equal(t, datapoint1.Name, datapoint2.Name, "the metric name should be the same")
-        assert.Equal(t, len(datapoint1.PointTags), len(datapoint2.PointTags))
+	assert.Equal(t, datapoint1.Name, datapoint2.Name, "the metric name should be the same")
+	assert.Equal(t, len(datapoint1.PointTags), len(datapoint2.PointTags))
 }

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.42"
+	version = "0.6.43"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
[EDIT : In order to faciliate this review, please look at both commits individually]
Real changes: 
* Add dimensions under the service_dims json block to all parsed metrics.
* Bump fullerite version to 0.6.43

Tests: (java_metric, uswsgi_metric)
* Add more end to end tests to JavaMetric
* Add tests to ensure that the presence of absence of the service_dims block doesn't break anything

This is the commit with those changes:
https://github.com/Yelp/fullerite/pull/395/commits/4b90ae309b9079836eb61e055ad928342c1f5d06
Internal ticket: PEOBS-840


Cosmetic changes to make the linter happy: (nginx, udp)
* Do not export the types used locally
* Do not use _ in var names

This is commit with these changes:
https://github.com/Yelp/fullerite/pull/395/commits/fa07218a370ef19f6d2759a818e83ff938abdf5c