### PR TITLE
Collecting UWSGI Worker stats in NerveUWSGI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.43
+VERSION        := 0.6.44
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ comma := ,
 GOPATH  := $(shell pwd -L)
 export GOPATH
 
-PATH := $(GOPATH)/bin:$(PATH)
+PATH := $(GOPATH)/bin:$(GOPATH)/go/bin:$(PATH)
 export PATH
 
 all: clean fmt lint $(FULLERITE) $(BEATIT) test
@@ -66,13 +66,7 @@ $(BEATIT): $(BEATIT_SOURCES)
 	@go build -o bin/$(BEATIT) fullerite/beatit
 
 go:
-	curl -s https://dl.google.com/go/go1.9.linux-amd64.tar.gz | tar xz
-	@echo "Please type: eval \`make goenv\`"
-
-goenv: go
-	@echo export GOROOT=`readlink -f go/`
-	@echo export GOPATH=`readlink -f go/bin`
-	@echo export PATH=`readlink -f go/bin`:\$$PATH
+	uname -a |grep -qE '^Linux.*x86_64' && curl -s https://dl.google.com/go/go1.9.linux-amd64.tar.gz | tar xz
 
 test: tests
 tests: deps diamond_test fullerite-tests

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.43"
+	version = "0.6.44"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -6,11 +6,13 @@ import (
 	"fullerite/metric"
 	"fullerite/util"
 
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	l "github.com/Sirupsen/logrus"
@@ -26,16 +28,20 @@ const (
 type nerveUWSGICollector struct {
 	baseCollector
 
-	configFilePath    string
-	queryPath         string
-	timeout           int
-	servicesWhitelist []string
+	configFilePath        string
+	queryPath             string
+	timeout               int
+	servicesWhitelist     []string
+	workersStatsEnabled   bool
+	workersStatsQueryPath string
+	workersStatsBlacklist []string
 }
 
 func init() {
 	RegisterCollector("NerveUWSGI", newNerveUWSGI)
 }
 
+// Default values of configuration fields
 func newNerveUWSGI(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
 	col := new(nerveUWSGICollector)
 
@@ -46,11 +52,13 @@ func newNerveUWSGI(channel chan metric.Metric, initialInterval int, log *l.Entry
 	col.name = "NerveUWSGI"
 	col.configFilePath = "/etc/nerve/nerve.conf.json"
 	col.queryPath = "status/metrics"
+	col.workersStatsQueryPath = "status/uwsgi"
 	col.timeout = 2
 
 	return col
 }
 
+// Rewrites config variables from the global config
 func (n *nerveUWSGICollector) Configure(configMap map[string]interface{}) {
 	if val, exists := configMap["queryPath"]; exists {
 		n.queryPath = val.(string)
@@ -61,7 +69,15 @@ func (n *nerveUWSGICollector) Configure(configMap map[string]interface{}) {
 	if val, exists := configMap["servicesWhitelist"]; exists {
 		n.servicesWhitelist = config.GetAsSlice(val)
 	}
-
+	if val, exists := configMap["workersStatsBlacklist"]; exists {
+		n.workersStatsBlacklist = config.GetAsSlice(val)
+	}
+	if val, exists := configMap["workersStatsEnabled"]; exists {
+		n.workersStatsEnabled = config.GetAsBool(val, false)
+	}
+	if val, exists := configMap["workersStatsQueryPath"]; exists {
+		n.workersStatsQueryPath = val.(string)
+	}
 	if val, exists := configMap["http_timeout"]; exists {
 		n.timeout = config.GetAsInt(val, 2)
 	}
@@ -69,6 +85,7 @@ func (n *nerveUWSGICollector) Configure(configMap map[string]interface{}) {
 	n.configureCommonParams(configMap)
 }
 
+// Parses nerve config from HTTP uWSGI stats endpoints
 func (n *nerveUWSGICollector) Collect() {
 	rawFileContents, err := ioutil.ReadFile(n.configFilePath)
 	if err != nil {
@@ -88,12 +105,13 @@ func (n *nerveUWSGICollector) Collect() {
 	}
 }
 
+// Fetches and computes stats from metrics HTTP endpoint,
+// calls an additional endpoint if UWSGI is detected
 func (n *nerveUWSGICollector) queryService(serviceName string, port int) {
 	serviceLog := n.log.WithField("service", serviceName)
 
 	endpoint := fmt.Sprintf("http://localhost:%d/%s", port, n.queryPath)
 	serviceLog.Debug("making GET request to ", endpoint)
-
 	rawResponse, schemaVer, err := queryEndpoint(endpoint, n.timeout)
 	if err != nil {
 		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", err)
@@ -103,6 +121,26 @@ func (n *nerveUWSGICollector) queryService(serviceName string, port int) {
 	if err != nil {
 		serviceLog.Warn("Failed to parse response into metrics: ", err)
 		return
+	}
+	// If we detect metrics from uwsgi, we try to fetch an additional Workers info
+	// If this was a separate collector, there would be no way to figure that out
+	// without a costly additional HTTP call.
+	// This prevent us from having to maintain a whitelist of services to query
+	// or from flooding all non UWSGI services with these requests.
+	// We still maintain a blacklist (with wildcard support) just in case
+	if strings.Contains(schemaVer, "uwsgi") && n.workersStatsEnabled && !n.serviceInWorkersStatsBlacklist(serviceName) {
+		serviceLog.Debug("Trying to fetch workers stats")
+		uwsgiWorkerStatsEndpoint := fmt.Sprintf("http://localhost:%d/%s", port, n.workersStatsQueryPath)
+		uwsgiWorkerStatsMetrics, err := n.tryFetchUWSGIWorkersStats(serviceName, uwsgiWorkerStatsEndpoint)
+		if err != nil {
+			serviceLog.Info("Could not get additional worker stat metrics")
+		} else {
+			// Add the metrics to our existing ones so we get the post process for free.
+			serviceLog.Debug("Additional workers metrics collected: ", len(uwsgiWorkerStatsMetrics))
+			for _, v := range uwsgiWorkerStatsMetrics {
+				metrics = append(metrics, v)
+			}
+		}
 	}
 
 	metric.AddToAll(&metrics, map[string]string{
@@ -162,4 +200,79 @@ func (n *nerveUWSGICollector) serviceInWhitelist(service string) bool {
 		}
 	}
 	return false
+}
+
+// serviceInWhitelist returns true if the service name passed as argument
+// is found among the ones whitelisted by the user
+func (n *nerveUWSGICollector) serviceInWorkersStatsBlacklist(service string) bool {
+	for _, s := range n.workersStatsBlacklist {
+		if s == service {
+			return true
+		}
+	}
+	return false
+}
+
+// Fetches and computes status stats from an HTTP endpoint
+func (n *nerveUWSGICollector) tryFetchUWSGIWorkersStats(serviceName string, endpoint string) ([]metric.Metric, error) {
+	emptyResult := []metric.Metric{}
+	serviceLog := n.log.WithField("service", serviceName)
+	serviceLog.Debug("making GET request to ", endpoint)
+	rawResponse, _, err := queryEndpoint(endpoint, n.timeout)
+	if err != nil {
+		serviceLog.Info("Failed to query workers stats endpoint ", endpoint, ": ", err)
+		return emptyResult, err
+	}
+	metrics, err := parseUWSGIWorkersStats(rawResponse)
+	if err != nil {
+		serviceLog.Info("No workers stats retreived: ", err)
+		return emptyResult, err
+	}
+	return metrics, nil
+}
+
+// Counts workers status stats from JSON content
+func parseUWSGIWorkersStats(raw []byte) ([]metric.Metric, error) {
+	result := make(map[string]interface{})
+	err := json.Unmarshal(raw, &result)
+	results := []metric.Metric{}
+	if err != nil {
+		return results, err
+	}
+	registry := make(map[string]int)
+	registry["IdleWorkers"] = 0
+	registry["BusyWorkers"] = 0
+
+	// Let's emit these only if they aren't 0
+	// registry["SigWorkers"] = 0
+	// registry["PauseWorkers"] = 0
+	// registry["CheapWorkers"] = 0
+	// registry["UnknownStateWorkers"] = 0
+	workers, ok := result["workers"].([]interface{})
+	if !ok {
+		return results, fmt.Errorf("\"workers\" field not found or not an array")
+	}
+	for _, worker := range workers {
+		workerMap, ok := worker.(map[string]interface{})
+		if !ok {
+			return results, fmt.Errorf("worker record is not a map")
+		}
+		status, ok := workerMap["status"].(string)
+		if !ok {
+			return results, fmt.Errorf("status not found or not a string")
+		}
+		if strings.Index(status, "sig") == 0 {
+			status = "sig"
+		}
+		metricName := strings.Title(status) + "Workers"
+		_, exists := registry[metricName]
+		if !exists {
+			registry[metricName] = 0
+		}
+		registry[metricName]++
+	}
+	for key, value := range registry {
+		results = append(results, metric.WithValue(key, float64(value)))
+	}
+	return results, err
 }

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -470,16 +470,6 @@ func TestNerveUWSGICollectWithSchema(t *testing.T) {
 	testNerveUWSGICollectHelper(t, httpHandler, cfg, expectedMetrics)
 }
 
-/* List of the following test cases:
-CollectWorkersStats	0	1	1	1	1	1	1	1
-UWSGIHeader			0	0	1	1	1	1	1	1
-ServiceDims			0	0	0	1	1	1	1	1
-BadURL				0	0	0	0	1	0	0	0
-SlowStatsEndpoint	0	0	0	0	0	1	0	0
-BlacklistedService	0	0	0	0	0	0	1	0
-AlreadyCollected	0	0	0	0	0	0	0	1
-
-*/
 func TestNerveUWSGICollectWorkersStatsDisabled(t *testing.T) {
 	httpHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/src/fullerite/collector/uwsgi_nerve_worker_stats.go
+++ b/src/fullerite/collector/uwsgi_nerve_worker_stats.go
@@ -5,13 +5,11 @@ import (
 	"fullerite/metric"
 	"fullerite/util"
 
-	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	l "github.com/Sirupsen/logrus"
@@ -103,7 +101,7 @@ func (n *uWSGINerveWorkerStatsCollector) queryService(serviceName string, port i
 		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", err)
 		return
 	}
-	metrics, err := parseJSONData(rawResponse)
+	metrics, err := util.ParseUWSGIWorkersStats(rawResponse)
 	if err != nil {
 		serviceLog.Warn("Failed to parse response into metrics: ", err)
 		return
@@ -128,50 +126,6 @@ func (n *uWSGINerveWorkerStatsCollector) serviceInWhitelist(service util.NerveSe
 		}
 	}
 	return false
-}
-
-// Counts status stats from JSON content
-func parseJSONData(raw []byte) ([]metric.Metric, error) {
-	result := make(map[string]interface{})
-	err := json.Unmarshal(raw, &result)
-	results := []metric.Metric{}
-	if err != nil {
-		return results, err
-	}
-	registry := make(map[string]int)
-	registry["IdleWorkers"] = 0
-	registry["BusyWorkers"] = 0
-	registry["SigWorkers"] = 0
-	registry["PauseWorkers"] = 0
-	registry["CheapWorkers"] = 0
-	registry["UnknownStateWorkers"] = 0
-	workers, ok := result["workers"].([]interface{})
-	if !ok {
-		return results, fmt.Errorf("\"workers\" field not found or not an array")
-	}
-	for _, worker := range workers {
-		workerMap, ok := worker.(map[string]interface{})
-		if !ok {
-			return results, fmt.Errorf("worker record is not a map")
-		}
-		status, ok := workerMap["status"].(string)
-		if !ok {
-			return results, fmt.Errorf("status not found or not a string")
-		}
-		if strings.Index(status, "sig") == 0 {
-			status = "sig"
-		}
-		metricName := strings.Title(status) + "Workers"
-		_, exists := registry[metricName]
-		if !exists {
-			metricName = "UnknownStateWorkers"
-		}
-		registry[metricName]++
-	}
-	for key, value := range registry {
-		results = append(results, metric.WithValue(key, float64(value)))
-	}
-	return results, err
 }
 
 // Fetches the JSON stats content from HTTP endpoint

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -89,6 +89,23 @@ func GetAsFloat(value interface{}, defaultValue float64) (result float64) {
 	return
 }
 
+// GetAsBool uses ParseBool, will match on real bool or strings that looks like booleans
+func GetAsBool(value interface{}, defaultValue bool) (result bool) {
+	result = defaultValue
+	switch value.(type) {
+	case string:
+		fromString, err := strconv.ParseBool(value.(string))
+		if err == nil {
+			result = fromString
+		} else {
+			log.Warn("Failed to read ", value, "as a bool. Falling back to default", defaultValue)
+		}
+	case bool:
+		result = value.(bool)
+	}
+	return
+}
+
 // GetAsInt parses a string/float to an int or returns the int if int is passed in
 func GetAsInt(value interface{}, defaultValue int) (result int) {
 	result = defaultValue

--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -1,6 +1,7 @@
 package dropwizard
 
 import (
+	"encoding/json"
 	"fullerite/metric"
 	"regexp"
 
@@ -189,6 +190,23 @@ func (parser *BaseParser) parseMapOfMap(
 	metricMap map[string]map[string]interface{},
 	metricType string) []metric.Metric {
 	return []metric.Metric{}
+}
+
+// ExtractServiceDims is a lightweight version of extractParsedMetric to make
+// common service dimensions available in the collector
+func ExtractServiceDims(raw []byte) map[string]string {
+	parsed := new(Format)
+	parsed.ServiceDims = map[string]interface{}{}
+	results := map[string]string{}
+	err := json.Unmarshal(raw, parsed)
+
+	if err == nil {
+		for k, v := range parsed.ServiceDims {
+			results[k] = v.(string)
+		}
+	}
+
+	return results
 }
 
 // Parse is just a placehoder function

--- a/src/fullerite/dropwizard/base_parser.go
+++ b/src/fullerite/dropwizard/base_parser.go
@@ -192,11 +192,14 @@ func (parser *BaseParser) parseMapOfMap(
 	return []metric.Metric{}
 }
 
+type serviceDimsOnly struct {
+	ServiceDims map[string]interface{} `json:"service_dims"`
+}
+
 // ExtractServiceDims is a lightweight version of extractParsedMetric to make
 // common service dimensions available in the collector
 func ExtractServiceDims(raw []byte) map[string]string {
-	parsed := new(Format)
-	parsed.ServiceDims = map[string]interface{}{}
+	parsed := new(serviceDimsOnly)
 	results := map[string]string{}
 	err := json.Unmarshal(raw, parsed)
 

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.43"
+	version = "0.6.44"
 	desc    = "Diamond compatible metrics collector"
 )
 

--- a/src/fullerite/util/uwsgi_stats_parser.go
+++ b/src/fullerite/util/uwsgi_stats_parser.go
@@ -1,0 +1,52 @@
+package util
+
+import (
+	"fullerite/metric"
+
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// ParseUWSGIWorkersStats Counts workers status stats from JSON content and returns metrics
+func ParseUWSGIWorkersStats(raw []byte) ([]metric.Metric, error) {
+	result := make(map[string]interface{})
+	err := json.Unmarshal(raw, &result)
+	results := []metric.Metric{}
+	if err != nil {
+		return results, err
+	}
+	registry := make(map[string]int)
+	registry["IdleWorkers"] = 0
+	registry["BusyWorkers"] = 0
+
+	workers, ok := result["workers"].([]interface{})
+	if !ok {
+		return results, fmt.Errorf("\"workers\" field not found or not an array")
+	}
+	for _, worker := range workers {
+		workerMap, ok := worker.(map[string]interface{})
+		if !ok {
+			return results, fmt.Errorf("worker record is not a map")
+		}
+		status, ok := workerMap["status"].(string)
+		if !ok {
+			return results, fmt.Errorf("status not found or not a string")
+		}
+		// Consider all status starting by sig as just "sig"
+		if strings.Index(status, "sig") == 0 {
+			status = "sig"
+		}
+		// Capitalize the metric name (busy => BusyWorkers)
+		metricName := strings.Title(status) + "Workers"
+		_, exists := registry[metricName]
+		if !exists {
+			registry[metricName] = 0
+		}
+		registry[metricName]++
+	}
+	for key, value := range registry {
+		results = append(results, metric.WithValue(key, float64(value)))
+	}
+	return results, err
+}

--- a/src/fullerite/util/uwsgi_stats_parser_test.go
+++ b/src/fullerite/util/uwsgi_stats_parser_test.go
@@ -1,0 +1,74 @@
+package util
+
+import (
+	"fullerite/metric"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func getArtificialUWSGIStatsResponse() []byte {
+	return []byte(`{
+        "workers":[
+		{"status":"idle"},
+		{"status":"pause"},
+		{"status":"cheap"},
+		{"status":"sigsig"},
+		{"status":"sig255"},
+		{"status":"invalid"},
+		{"status":"idle"}
+	]
+	}`)
+}
+
+// Validate Results
+func TestParseUWSGIWorkersStatsShort(t *testing.T) {
+	outMetrics, _ := ParseUWSGIWorkersStats(getArtificialUWSGIStatsResponse())
+	assert.Equal(t, 6, len(outMetrics))
+
+	for _, m := range outMetrics {
+
+		switch m.Name {
+		case "IdleWorkers":
+			assert.Equal(t, 2.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+			// Even if there are no busy workers, we want to emit 0
+		case "BusyWorkers":
+			assert.Equal(t, 0.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+		case "SigWorkers":
+			assert.Equal(t, 2.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+		case "CheapWorkers":
+			assert.Equal(t, 1.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+		case "InvalidWorkers":
+			assert.Equal(t, 1.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+		case "PauseWorkers":
+			assert.Equal(t, 1.0, m.Value)
+			assert.Equal(t, metric.Gauge, m.MetricType)
+		default:
+			t.Fatal("Unexpected metric name: " + m.Name)
+		}
+	}
+}
+
+// Returns nothing if the value of a worker isn't a string
+func TestParseUWSGIWorkersStatsWrongVal(t *testing.T) {
+	outMetrics, _ := ParseUWSGIWorkersStats([]byte(`{
+        "workers":[
+		{"status":1},
+		{"status":"cheap255"}
+	]
+	}`))
+	assert.Equal(t, 0, len(outMetrics))
+}
+
+// Returns nothing if iJSON is unparsable
+func TestParseUWSGIWorkersStatsWeirdJSON(t *testing.T) {
+	outMetrics, _ := ParseUWSGIWorkersStats([]byte(`{
+        foo/*&^%%$bar
+	}`))
+	assert.Equal(t, 0, len(outMetrics))
+}


### PR DESCRIPTION
[UPDATED 2019-05-21]
There are currently at least 2 collectors that are parsing uwsgi related metrics:

- uwsgi_nerve_worker_stats polling workers stats on /uwsgi/workers
- nerve_uwsgi polling all server side metrics on /status/metrics 

uwsgi_nerve_worker_stats collector is works via a whitelist system. This prevents us from flooding non UWSGI services (or UWSGI services that don't have worker stats endpoint) on the /status/uwsgi endpoint and generating lots of 404 in the service logs. However keeping that list up to date is difficult.

The goal of this review is to integrates the collection of additional UWSGI workers stats in the NerveUWSGI collector for every service that is identified as running UWSGI (based on uwsgi in its schema header on the metrics endpoint). 

The code for uwsgi worker stats parsing is mostly from the dedicated collector https://github.com/Yelp/fullerite/blob/master/src/fullerite/collector/uwsgi_nerve_worker_stats.go

but a few adjustments have been made:
* the logic is now in a util package and shared among the two collectors to ensure consistency and better testing
* in NerveUWSGI collector, withelist for worker stats collection has been replaced by a blacklist
* For both workers, we do not emit other metrics than BusyWorkers  or IdleWorkers  if their value is 0 (these are very rare, so doing this will save lots of TS)
* Removes the "Unknown state worker" catchall as the change in the previous bullet point makes this possible

Tests:
Tests have been refactored to assert exactly on the expected output metrics (including their count, type, dimensions...) for a given JSON input and collector config. 

Note that to ease the rollout, the new feature is toggleable in the collector's config file and set to disabled by default. The rollout plan is to deploy this new version with the feature disabled by default and then remove all entries from UWSGI Workers stats collector whitelist (basically deprecating it)