### PR TITLE
Added features for nerveUWSGI to do service level whitelist/blacklist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ src/github.com/
 *.pyc
 *.DS_Store
 .project
+.vscode/*
 .vagrant
 src/fullerite/collector/collector.test
 *.pprof

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -828,7 +828,7 @@ func TestNerveJavaCollectWithSchemaCumulativeCountersEnabled(t *testing.T) {
 	cfg := map[string]interface{}{
 		"configFilePath":    tmpFile.Name(),
 		"queryPath":         "",
-		"servicesWhitelist": []string{"test_service"},
+		"cumCounterEnabledServices": []string{"test_service"},
 	}
 
 	inst := getTestNerveUWSGI()


### PR DESCRIPTION
This change will enable the collector to be setup using either a service level blacklist/whitelist. Only one can be passed and if there is none that is passed - operation is status-quo. I replaced some functionality that we already have with one single method called serviceInList because we would be doing that in more than one instance. I need to add test cases for this but other than that existing test cases passes.

Another issue I noticed was that we use `serviceInWhitelist` but it really has no meaning because the thing it does is not what it is named. Using that lets you make the metrics a cumulative counter. I have replaced the config name to be what it should be.
