### PR TITLE
Fix leader check for marathon

### DIFF
--- a/src/fullerite/collector/chronos.go
+++ b/src/fullerite/collector/chronos.go
@@ -73,7 +73,7 @@ func (m *ChronosStats) Configure(configMap map[string]interface{}) {
 // Collect compares the leader against this hosts's hostaname and sends metrics if this is the leader
 func (m *ChronosStats) Collect() {
 	// Non-chronos-leaders forward requests to the leader, so only the leader's metrics matter
-	if leader, err := util.IsLeader(m.chronosHost, "leader", m.client); leader && err == nil {
+	if leader, err := util.IsLeader(m.chronosHost, "leader", m.client, m.log); leader && err == nil {
 		go sendChronosMetrics(m)
 	} else if err != nil {
 		m.log.Error("Error finding leader: ", err)

--- a/src/fullerite/collector/marathon.go
+++ b/src/fullerite/collector/marathon.go
@@ -73,7 +73,7 @@ func (m *MarathonStats) Configure(configMap map[string]interface{}) {
 // Collect compares the leader against this hosts's hostaname and sends metrics if this is the leader
 func (m *MarathonStats) Collect() {
 	// Non-marathon-leaders forward requests to the leader, so only the leader's metrics matter
-	if leader, err := util.IsLeader(m.marathonHost, "v2/leader", m.client); leader && err == nil {
+	if leader, err := util.IsLeader(m.marathonHost, "v2/leader", m.client, m.log); leader && err == nil {
 		go sendMarathonMetrics(m)
 	} else if err != nil {
 		m.log.Error("Error finding leader: ", err)

--- a/src/fullerite/util/marathon_chronos_leader_test.go
+++ b/src/fullerite/util/marathon_chronos_leader_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	l "github.com/Sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,6 +16,7 @@ func TestIsLeader(t *testing.T) {
 
 	oldHostname := hostname
 	defer func() { hostname = oldHostname }()
+	log := l.WithFields(l.Fields{})
 
 	tests := []struct {
 		ourHostname string
@@ -39,7 +41,7 @@ func TestIsLeader(t *testing.T) {
 		getLeaderURL = func(ip string, _ string) string { return ts.URL }
 		hostname = func() (string, error) { return test.ourHostname, nil }
 
-		actual, _ := IsLeader("", "", http.Client{})
+		actual, _ := IsLeader("", "", http.Client{}, log)
 
 		assert.Equal(t, test.expected, actual, test.msg)
 	}


### PR DESCRIPTION
We have reconfigured marathon to use IP address for host identification.
This makes the leader check whether the IP is one of our interfaces