### PR TITLE
Fixed/Enabled ElasticSearchCollector tests + Added alias support.

### DIFF
--- a/src/diamond/blacklist_test.txt
+++ b/src/diamond/blacklist_test.txt
@@ -28,7 +28,6 @@ TestNagiosPerfdataCollector
 TestConnTrackCollector
 TestNetworkCollector
 TestHttpCollector
-TestElasticSearchCollector
 TestNginxCollector
 TestVMStatCollector
 TestNfsdCollector

--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -139,7 +139,7 @@ class ElasticSearchCollector(diamond.collector.Collector):
         for key1, d1 in data.iteritems():
             self._copy_one_level(metrics, '%s.%s' % (prefix, key1), d1, filter)
 
-    def _index_metrics(self, metrics, prefix, index):
+    def _index_metrics(self, metrics, prefix, index, index_to_aliases_map=None):
         if self.config['logstash_mode']:
             """Remove the YYYY.MM.DD bit from logstash indices.
             This way we keep using the same metric naming and not polute
@@ -152,17 +152,20 @@ class ElasticSearchCollector(diamond.collector.Collector):
                 self._set_or_sum_metric(metrics,
                                         '%s.indexes_in_group' % prefix, 1)
 
-        self._add_metric(metrics, '%s.docs.count' % prefix, index,
-                         ['docs', 'count'])
-        self._add_metric(metrics, '%s.docs.deleted' % prefix, index,
-                         ['docs', 'deleted'])
-        self._add_metric(metrics, '%s.datastore.size' % prefix, index,
-                         ['store', 'size_in_bytes'])
+        index_names_to_publish = index_to_aliases_map.get(prefix, []) if index_to_aliases_map else []
+        index_names_to_publish.append(prefix)
+        for prefix in index_names_to_publish:
+            self._add_metric(metrics, '%s.docs.count' % prefix, index,
+                             ['docs', 'count'])
+            self._add_metric(metrics, '%s.docs.deleted' % prefix, index,
+                             ['docs', 'deleted'])
+            self._add_metric(metrics, '%s.datastore.size' % prefix, index,
+                             ['store', 'size_in_bytes'])
 
-        # publish all 'total' and 'time_in_millis' stats
-        self._copy_two_level(
-            metrics, prefix, index,
-            lambda key: key.endswith('total') or key.endswith('time_in_millis'))
+            # publish all 'total' and 'time_in_millis' stats
+            self._copy_two_level(
+                metrics, prefix, index,
+                lambda key: key.endswith('total') or key.endswith('time_in_millis'))
 
     def _add_metric(self, metrics, metric_path, data, data_path):
         """If the path specified by data_path (a list) exists in data,
@@ -227,10 +230,29 @@ class ElasticSearchCollector(diamond.collector.Collector):
             indices = result['indices']
         else:
             return
+        
+        # Collect index aliases
+        result = self._get(host, port, "_alias")
+        index_to_aliases_map = self._build_index_to_aliases_map(result)
+
 
         for name, index in indices.iteritems():
-            self._index_metrics(metrics, 'indices.%s' % name,
-                                index['primaries'])
+            self._index_metrics(
+                metrics,
+                'indices.%s' % name,
+                index['primaries'],
+                index_to_aliases_map=index_to_aliases_map
+            )
+
+    def _build_index_to_aliases_map(self, result):
+        mapping = {}
+        for index, aliases_dict in result.items():
+            prefix = 'indices.%s' % index
+            indexes = list(aliases_dict.get('aliases', {}).keys())
+            prefixes = ['indices.%s' % i for i in indexes]    
+            mapping[prefix] = prefixes
+        return mapping
+
 
     def collect_instance(self, alias, host, port):
         es_version = self._get(host, port, '/', 'version')['version']['number']
@@ -240,7 +262,6 @@ class ElasticSearchCollector(diamond.collector.Collector):
             # All stats are fetched by default
             result = self._get(host, port, '_nodes/_local/stats', 'nodes')
 
-        result = self._get(host, port, '_nodes/_local/stats', 'nodes')
         if not result:
             return
 

--- a/src/diamond/collectors/elasticsearch/elasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/elasticsearch.py
@@ -233,7 +233,10 @@ class ElasticSearchCollector(diamond.collector.Collector):
         
         # Collect index aliases
         result = self._get(host, port, "_alias")
-        index_to_aliases_map = self._build_index_to_aliases_map(result)
+        if result:
+            index_to_aliases_map = self._build_index_to_aliases_map(result)
+        else:
+            index_to_aliases_map = None
 
 
         for name, index in indices.iteritems():

--- a/src/diamond/collectors/elasticsearch/test/fixtures/alias
+++ b/src/diamond/collectors/elasticsearch/test/fixtures/alias
@@ -1,0 +1,12 @@
+{
+  "logstash-adm-syslog-2014.01.02": {
+    "aliases": {
+    }
+  },
+  "test": {
+    "aliases": {
+      "test_alias": {
+      }
+    }
+  }
+}

--- a/src/diamond/collectors/elasticsearch/test/fixtures/version
+++ b/src/diamond/collectors/elasticsearch/test/fixtures/version
@@ -1,0 +1,1 @@
+{"version":{"number": "6.3.1"},"tagline":"Testing Is Hard. Have A Donut."}

--- a/src/diamond/collectors/elasticsearch/test/fixtures/version0.90
+++ b/src/diamond/collectors/elasticsearch/test/fixtures/version0.90
@@ -1,0 +1,1 @@
+{"version":{"number": "0.90"},"tagline":"Testing Is Hard. Have A Donut."}

--- a/src/diamond/collectors/elasticsearch/test/testelasticsearch.py
+++ b/src/diamond/collectors/elasticsearch/test/testelasticsearch.py
@@ -18,7 +18,6 @@ from elasticsearch import ElasticSearchCollector
 class TestElasticSearchCollector(CollectorTestCase):
     def setUp(self):
         config = get_collector_config('ElasticSearchCollector', {})
-
         self.collector = ElasticSearchCollector(config, None)
 
     def test_import(self):
@@ -26,13 +25,13 @@ class TestElasticSearchCollector(CollectorTestCase):
 
     def test_new__instances_default(self):
         config = get_collector_config('ElasticSearchCollector', {})
-        self.collector = ElasticSearchCollector(config, None)
+        self.collector = ElasticSearchCollector(config, configfile=config['collectors']['ElasticSearchCollector'])
         self.assertEqual(self.collector.instances, {'': ('127.0.0.1', 9200)})
 
     def test_new__instances_single(self):
         config = get_collector_config('ElasticSearchCollector', {
             'instances': 'bla'})
-        self.collector = ElasticSearchCollector(config, None)
+        self.collector = ElasticSearchCollector(config, configfile=config['collectors']['ElasticSearchCollector'])
         self.assertEqual(self.collector.instances, {'default': ('bla', 9200)})
 
     def test_new__instances_multi(self):
@@ -42,7 +41,7 @@ class TestElasticSearchCollector(CollectorTestCase):
                 'foo@1234',
                 'bar@bla:1234',
             ]})
-        self.collector = ElasticSearchCollector(config, None)
+        self.collector = ElasticSearchCollector(config, configfile=config['collectors']['ElasticSearchCollector'])
         self.assertEqual(self.collector.instances, {
             'default': ('something', 9200),
             'foo': ('1234', 9200),
@@ -52,21 +51,22 @@ class TestElasticSearchCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_data(self, publish_mock):
         returns = [
+            self.getFixture('version'),
             self.getFixture('stats'),
             self.getFixture('cluster_stats'),
             self.getFixture('indices_stats'),
+            self.getFixture('alias'),
         ]
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-            side_effect=lambda *args: returns.pop(0)))
+        with patch(
+            'elasticsearch.urllib2.urlopen',
+            side_effect=lambda *args: returns.pop(0)
+        ) as urlopen_mock:
 
-        self.collector.config['cluster'] = True
+            self.collector.config['cluster'] = True
+            self.collector.collect()
 
-        urlopen_mock.start()
-        self.collector.collect()
-        urlopen_mock.stop()
-
-        # check how many fixtures were consumed
-        self.assertEqual(urlopen_mock.new.call_count, 3)
+            # check how many fixtures were consumed
+            self.assertEqual(urlopen_mock.call_count, 5)
 
         metrics = {
             'http.current': 1,
@@ -82,6 +82,10 @@ class TestElasticSearchCollector(CollectorTestCase):
             'indices.test.docs.count': 4,
             'indices.test.docs.deleted': 0,
             'indices.test.datastore.size': 2674,
+            
+            'indices.test_alias.docs.count': 4,
+            'indices.test_alias.docs.deleted': 0,
+            'indices.test_alias.datastore.size': 2674,
 
             'process.cpu.percent': 58,
 
@@ -109,20 +113,20 @@ class TestElasticSearchCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_data_logstash_mode(self, publish_mock):
         returns = [
+            self.getFixture('version'),
             self.getFixture('stats'),
             self.getFixture('logstash_indices_stats'),
+            self.getFixture('alias'),
         ]
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-            side_effect=lambda *args: returns.pop(0)))
+        with patch('elasticsearch.urllib2.urlopen',
+            side_effect=lambda *args: returns.pop(0)
+        ) as urlopen_mock:
 
-        self.collector.config['logstash_mode'] = True
+            self.collector.config['logstash_mode'] = True
+            self.collector.collect()
 
-        urlopen_mock.start()
-        self.collector.collect()
-        urlopen_mock.stop()
-
-        # check how many fixtures were consumed
-        self.assertEqual(urlopen_mock.new.call_count, 2)
+            # check how many fixtures were consumed
+            self.assertEqual(urlopen_mock.call_count, 4)
 
         # Omit all non-indices metrics, since those were already
         # checked in previous test.
@@ -181,18 +185,18 @@ class TestElasticSearchCollector(CollectorTestCase):
     @patch.object(Collector, 'publish')
     def test_should_work_with_real_0_90_data(self, publish_mock):
         returns = [
+            self.getFixture('version0.90'),
             self.getFixture('stats0.90'),
             self.getFixture('indices_stats'),
+            self.getFixture('alias'),
         ]
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-            side_effect=lambda *args: returns.pop(0)))
+        with patch('elasticsearch.urllib2.urlopen',
+            side_effect=lambda *args: returns.pop(0)
+        ) as urlopen_mock:
+            self.collector.collect()
 
-        urlopen_mock.start()
-        self.collector.collect()
-        urlopen_mock.stop()
-
-        # check how many fixtures were consumed
-        self.assertEqual(urlopen_mock.new.call_count, 2)
+            # check how many fixtures were consumed
+            self.assertEqual(urlopen_mock.call_count, 4)
 
         # test some 0.90 specific stats
         metrics = {
@@ -210,12 +214,14 @@ class TestElasticSearchCollector(CollectorTestCase):
 
     @patch.object(Collector, 'publish')
     def test_should_fail_gracefully(self, publish_mock):
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-                             return_value=self.getFixture('stats_blank')))
-
-        urlopen_mock.start()
-        self.collector.collect()
-        urlopen_mock.stop()
+        returns = [
+            self.getFixture('version'),
+            self.getFixture('stats_blank'),
+        ]
+        with patch('elasticsearch.urllib2.urlopen',
+            side_effect=lambda *args: returns.pop(0)
+        ) as urlopen_mock:
+            self.collector.collect()
 
         self.assertPublishedMany(publish_mock, {})
 
@@ -226,24 +232,26 @@ class TestElasticSearchCollector(CollectorTestCase):
                 'esprodata01@10.10.10.201:9200',
                 'esprodata02@10.10.10.202:9200',
             ]})
-        self.collector = ElasticSearchCollector(config, None)
+        self.collector = ElasticSearchCollector(config, configfile=config['collectors']['ElasticSearchCollector'])
         self.assertEqual(len(self.collector.instances), 2)
 
         returns = [
+            self.getFixture('version'),
             self.getFixture('stats'),
             self.getFixture('indices_stats'),
+            self.getFixture('alias'),
+            self.getFixture('version'),
             self.getFixture('stats2'),
             self.getFixture('indices_stats2'),
+            self.getFixture('alias'),
         ]
-        urlopen_mock = patch('urllib2.urlopen', Mock(
-            side_effect=lambda *args: returns.pop(0)))
+        with patch('urllib2.urlopen',
+            side_effect=lambda *args: returns.pop(0)
+        ) as urlopen_mock:
+            self.collector.collect()
 
-        urlopen_mock.start()
-        self.collector.collect()
-        urlopen_mock.stop()
-
-        # check how many fixtures were consumed
-        self.assertEqual(urlopen_mock.new.call_count, 4)
+            # check how many fixtures were consumed
+            self.assertEqual(urlopen_mock.call_count, 8)
 
         metrics = {
             'esprodata01.http.current': 1,


### PR DESCRIPTION
### Description
Fixed ElasticSearchCollector tests
Re-enabled ElasticSearchCollector tests
Added support for pushing index metrics by alias.
Update tests

### Test Results:
```tox ``` **passes**
``` tox -- -c elasticsearch``` **passes**