### PR TITLE
Bump go-thrift version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,6 @@ deps:
 
 $(FULLERITE): $(SOURCES) deps
 	@echo Building $(FULLERITE)...
-	@# The following is a workaround for `src/fullerite/vendor/github.com/samuel/go-thrift/examples/scribe/thrift.go:63:9: e declared and not used`
-	@# I know.  Please feel free to do it better.
-	@sed -i -e '63,64d' src/fullerite/vendor/github.com/samuel/go-thrift/examples/scribe/thrift.go
 	@go build -o bin/$(FULLERITE) $@
 
 $(BEATIT): $(BEATIT_SOURCES)

--- a/src/fullerite/glide.lock
+++ b/src/fullerite/glide.lock
@@ -113,7 +113,7 @@ imports:
   subpackages:
   - xfs
 - name: github.com/samuel/go-thrift
-  version: e9042807f4f5bf47563df6992d3ea0857313e2be
+  version: 5165175b40afa0d250de9a330d47c1ea2051589f
   subpackages:
   - examples/scribe
   - thrift

--- a/src/fullerite/glide.yaml
+++ b/src/fullerite/glide.yaml
@@ -18,7 +18,7 @@ import:
   version: 7b053ad66e2a49baca9cc97b982dcea0e182bda4
 - package: github.com/prometheus/procfs
 - package: github.com/samuel/go-thrift
-  version: e9042807f4f5bf47563df6992d3ea0857313e2be
+  version: 5165175b40afa0d250de9a330d47c1ea2051589f
   subpackages:
   - examples/scribe
   - thrift


### PR DESCRIPTION
Bump `go-thrift` version to the one where the `e declared and not used`
error is fixed.