### PR TITLE
Add KubeletPods collector

### DIFF
--- a/src/fullerite/collector/kubelet_pods.go
+++ b/src/fullerite/collector/kubelet_pods.go
@@ -1,0 +1,171 @@
+package collector
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	l "github.com/Sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+
+	"fullerite/config"
+	"fullerite/metric"
+)
+
+const (
+	defaultPort = 10255
+)
+
+// KubeletPods collector type.
+type KubeletPods struct {
+	baseCollector
+	timeout       int
+	compiledRegex map[string]*Regex
+	url           string
+}
+
+func init() {
+	RegisterCollector("KubeletPods", newKubeletPods)
+}
+
+// newKubeletPods creates a new collector for pods returned by kubelet.
+func newKubeletPods(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	d := new(KubeletPods)
+
+	d.log = log
+	d.channel = channel
+	d.interval = initialInterval
+
+	d.name = "KubeletPods"
+	d.compiledRegex = make(map[string]*Regex)
+	return d
+}
+
+// GetURL Returns URL of KubeletPods instance
+func (d *KubeletPods) GetURL() string {
+	return d.url
+}
+
+// Configure takes a dictionary of values with which the handler can configure itself.
+func (d *KubeletPods) Configure(configMap map[string]interface{}) {
+	if timeout, exists := configMap["kubeletTimeout"]; exists {
+		d.timeout = min(config.GetAsInt(timeout, d.interval), d.interval)
+	} else {
+		d.timeout = d.interval
+	}
+
+	var port int
+	if kubeletPort, exists := configMap["kubeletPort"]; exists {
+		port = config.GetAsInt(kubeletPort, defaultPort)
+	} else {
+		port = defaultPort
+	}
+	d.url = fmt.Sprintf("http://localhost:%d/pods", port)
+
+	if generatedDimensions, exists := configMap["generatedDimensions"]; exists {
+		for dimension, generator := range generatedDimensions.(map[string]interface{}) {
+			for key, regx := range config.GetAsMap(generator) {
+				re, err := regexp.Compile(regx)
+				if err != nil {
+					d.log.Warn("Failed to compile regex: ", regx, err)
+				} else {
+					d.compiledRegex[dimension] = &Regex{regex: re, tag: key}
+				}
+			}
+		}
+	}
+
+	d.configureCommonParams(configMap)
+}
+
+// Collect iterates on all the pods and, if possible, collects the
+// correspondent statistics.
+func (d *KubeletPods) Collect() {
+	client := http.Client{
+		Timeout: time.Second * time.Duration(d.timeout),
+	}
+
+	res, getErr := client.Get(d.url)
+	if getErr != nil {
+		d.log.Error("Error sending request to kubelet: ", getErr)
+		return
+	}
+	defer res.Body.Close()
+
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		d.log.Error("Error reading response: ", readErr)
+		return
+	}
+
+	podList := corev1.PodList{}
+	jsonErr := json.Unmarshal(body, &podList)
+	if jsonErr != nil {
+		d.log.Error("Error parsing response: ", jsonErr)
+		return
+	}
+
+	metrics := []metric.Metric{}
+	for i := range podList.Items {
+		metrics = append(metrics, d.getPodInfo(&podList.Items[i])...)
+	}
+	d.sendMetrics(metrics)
+}
+
+// getPodInfo gets pod info for the given pod.
+func (d *KubeletPods) getPodInfo(pod *corev1.Pod) []metric.Metric {
+	metrics := []metric.Metric{}
+	for i := range pod.Spec.Containers {
+		metrics = append(metrics, d.getContainerInfo(&pod.Spec.Containers[i])...)
+	}
+	metric.AddToAll(&metrics, d.extractDimensions(pod))
+	return metrics
+}
+
+// getContainerInfo gets container info for the given container.
+func (d *KubeletPods) getContainerInfo(container *corev1.Container) []metric.Metric {
+	metrics := []metric.Metric{}
+	if ephemeralStorageLimit, ok := container.Resources.Limits[corev1.ResourceEphemeralStorage]; ok {
+		metrics = append(metrics, buildKubeletMetric("KubernetesContainerEphemeralStorageLimit", metric.Gauge, float64(ephemeralStorageLimit.Value())))
+	}
+	additionalDimensions := map[string]string{
+		"container_name": container.Name,
+	}
+	metric.AddToAll(&metrics, additionalDimensions)
+	return metrics
+}
+
+func buildKubeletMetric(name string, metricType string, value float64) (m metric.Metric) {
+	m = metric.New(name)
+	m.MetricType = metricType
+	m.Value = value
+	return m
+}
+
+// Function that extracts additional dimensions from the Kubernetes pod labels
+// set up by the user in the configuration file.
+func (d KubeletPods) extractDimensions(pod *corev1.Pod) map[string]string {
+	ret := map[string]string{}
+
+	for dimension, r := range d.compiledRegex {
+		if value, ok := pod.Labels[r.tag]; ok {
+			subMatch := r.regex.FindStringSubmatch(value)
+			if len(subMatch) > 0 {
+				ret[dimension] = strings.Replace(subMatch[len(subMatch)-1], "--", "_", -1)
+			}
+		}
+	}
+	d.log.Debug(ret)
+	return ret
+}
+
+// sendMetrics writes all the metrics received to the collector channel.
+func (d KubeletPods) sendMetrics(metrics []metric.Metric) {
+	for _, m := range metrics {
+		d.Channel() <- m
+	}
+}

--- a/src/fullerite/collector/kubelet_pods_test.go
+++ b/src/fullerite/collector/kubelet_pods_test.go
@@ -1,0 +1,186 @@
+package collector
+
+import (
+	"encoding/json"
+	"testing"
+
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+
+	"fullerite/metric"
+)
+
+func getSUT2() *KubeletPods {
+	expectedChan := make(chan metric.Metric)
+	var expectedLogger = defaultLog.WithFields(l.Fields{"collector": "fullerite"})
+
+	return newKubeletPods(expectedChan, 10, expectedLogger).(*KubeletPods)
+}
+
+func TestKubeletPodsNewKubeletPods(t *testing.T) {
+	expectedChan := make(chan metric.Metric)
+	var expectedLogger = defaultLog.WithFields(l.Fields{"collector": "fullerite"})
+
+	d := newKubeletPods(expectedChan, 10, expectedLogger).(*KubeletPods)
+
+	assert.Equal(t, d.log, expectedLogger)
+	assert.Equal(t, d.channel, expectedChan)
+	assert.Equal(t, d.interval, 10)
+	assert.Equal(t, d.name, "KubeletPods")
+	d.Configure(make(map[string]interface{}))
+	assert.Equal(t, d.GetURL(), "http://localhost:10255/pods")
+}
+
+func TestKubeletPodsConfigureEmptyConfig(t *testing.T) {
+	config := make(map[string]interface{})
+
+	d := newKubeletPods(nil, 123, nil).(*KubeletPods)
+	d.Configure(config)
+
+	assert.Equal(t, 123, d.Interval())
+}
+
+func TestKubeletPodsConfigure(t *testing.T) {
+	config := make(map[string]interface{})
+	config["interval"] = 9999
+
+	d := newKubeletPods(nil, 123, nil).(*KubeletPods)
+	d.Configure(config)
+
+	assert.Equal(t, 9999, d.Interval())
+}
+
+func TestKubeletPodsGetPodInfo(t *testing.T) {
+	config := make(map[string]interface{})
+	dims := []byte(`
+	{
+		"service_name":  {
+			"acme.com/service": ".*"
+		},
+		"instance_name": {
+			"acme.com/instance": ".*"}
+	}`)
+	var val map[string]interface{}
+
+	err := json.Unmarshal(dims, &val)
+	assert.Equal(t, err, nil)
+	config["generatedDimensions"] = val
+
+	podJSON := []byte(`
+		{
+			"metadata": {
+				"name": "foo-bar-56dbf584cf-c5pd9",
+				"namespace": "somewhere",
+				"labels": {
+					"acme.com/instance": "bar",
+					"acme.com/service": "foo",
+					"acme.com/cluster": "baz"
+				}
+			},
+			"spec": {
+				"containers": [
+					{
+						"name": "main",
+						"resources": {
+							"limits": {
+								"cpu": "1100m",
+								"ephemeral-storage": "50Gi",
+								"memory": "256Mi"
+							},
+							"requests": {
+								"cpu": "100m",
+								"ephemeral-storage": "45Gi",
+								"memory": "256Mi"
+							}
+						}
+					},
+					{
+						"name": "aux",
+						"resources": {
+							"limits": {
+								"ephemeral-storage": "33Gi"
+							}
+						}
+					}
+				]
+			},
+			"status": {
+				"phase": "Running"
+			}
+		}`)
+	var pod *corev1.Pod
+	err = json.Unmarshal(podJSON, &pod)
+	assert.Equal(t, err, nil)
+
+	container1Dims := map[string]string{
+		"container_name": "main",
+		"service_name":   "foo",
+		"instance_name":  "bar",
+	}
+	container2Dims := map[string]string{
+		"container_name": "aux",
+		"service_name":   "foo",
+		"instance_name":  "bar",
+	}
+
+	expectedMetrics := []metric.Metric{
+		metric.Metric{"KubernetesContainerEphemeralStorageLimit", "gauge", 53687091200, container1Dims},
+		metric.Metric{"KubernetesContainerEphemeralStorageLimit", "gauge", 35433480192, container2Dims},
+	}
+
+	d := getSUT2()
+	d.Configure(config)
+	ret := d.getPodInfo(pod)
+	assert.Equal(t, ret, expectedMetrics)
+}
+
+func TestKubeletPodsGetPodInfoWithoutLimit(t *testing.T) {
+	config := make(map[string]interface{})
+	dims := []byte(`
+	{
+		"service_name":  {
+			"acme.com/service": ".*"
+		},
+		"instance_name": {
+			"acme.com/instance": ".*"}
+	}`)
+	var val map[string]interface{}
+
+	err := json.Unmarshal(dims, &val)
+	assert.Equal(t, err, nil)
+	config["generatedDimensions"] = val
+
+	podJSON := []byte(`
+		{
+			"metadata": {
+				"name": "foo-bar-56dbf584cf-c5pd9",
+				"namespace": "somewhere",
+				"labels": {
+					"acme.com/instance": "bar",
+					"acme.com/service": "foo",
+					"acme.com/cluster": "baz"
+				}
+			},
+			"spec": {
+				"containers": [
+					{
+						"name": "main"
+					}
+				]
+			},
+			"status": {
+				"phase": "Running"
+			}
+		}`)
+	var pod *corev1.Pod
+	err = json.Unmarshal(podJSON, &pod)
+	assert.Equal(t, err, nil)
+
+	expectedMetrics := []metric.Metric{}
+
+	d := getSUT2()
+	d.Configure(config)
+	ret := d.getPodInfo(pod)
+	assert.Equal(t, ret, expectedMetrics)
+}

--- a/src/fullerite/glide.lock
+++ b/src/fullerite/glide.lock
@@ -1,5 +1,5 @@
-hash: e5f05d7126820ab18015e9bc61b72086ecd8946fee6345cf17c818d5358b4190
-updated: 2019-11-11T11:59:54.46264413-08:00
+hash: be0317ad91e2ae97eb0fd19f2b1a541706ade865043913d726514ec3b855a5bb
+updated: 2019-11-25T09:06:04.478486684-08:00
 imports:
 - name: github.com/alyu/configparser
   version: 26b2fe18bee125de2a3090d6fadb7e280e63eba6
@@ -65,9 +65,10 @@ imports:
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
 - name: github.com/gogo/protobuf
-  version: 5628607bb4c51c3157aacc3a50f0ab707582b805
+  version: 65acae22fc9d1fe290b33faa2bd64cdc20a463a0
   subpackages:
   - proto
+  - sortkeys
 - name: github.com/golang/lint
   version: 8f348af5e29faa4262efdc14302797f23774e477
   subpackages:
@@ -80,6 +81,8 @@ imports:
   - ptypes/any
   - ptypes/duration
   - ptypes/timestamp
+- name: github.com/google/gofuzz
+  version: f140a6486e521aad38f5917de355cbf147cc0496
 - name: github.com/konsorten/go-windows-terminal-sequences
   version: f55edac94c9bbba5d6182a4be46d86a2c9b5b50e
 - name: github.com/Microsoft/go-winio
@@ -123,15 +126,29 @@ imports:
   version: d26492970760ca5d33129d2d799e34be5c4782eb
   subpackages:
   - hooks/test
+- name: golang.org/x/net
+  version: cdfb69ac37fc6fa907650654115ebebb3aae2087
+  subpackages:
+  - http/httpguts
+  - http2
+  - http2/hpack
+  - idna
 - name: golang.org/x/sync
-  version: cd5d95a43a6e21273425c7ae415d3df9ea832eeb
+  version: 42b317875d0fa942474b76e1b46a6060d720ae6e
   subpackages:
   - errgroup
 - name: golang.org/x/sys
-  version: b90f89a1e7a9c1f6b918820b3daa7f08488c8594
+  version: 3b5209105503162ded1863c307ac66fec31120dd
   subpackages:
   - unix
   - windows
+- name: golang.org/x/text
+  version: e6919f6577db79269a6443b9dc46d18f2238fb5d
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
 - name: golang.org/x/tools
   version: 92d42b9ff15f625347a13b6aeafd04a33537ce91
 - name: google.golang.org/genproto
@@ -146,17 +163,49 @@ imports:
   - grpclog
   - internal
   - status
+- name: gopkg.in/inf.v0
+  version: 3887ee99ecf07df5b447e9b00d9c0b2adaa9f3e4
 - name: gopkg.in/yaml.v2
   version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+- name: k8s.io/api
+  version: 16d7abae0d2a8ab2a6a7ad1bf3300eaacd541f56
+  subpackages:
+  - core/v1
+- name: k8s.io/apimachinery
+  version: 72ed19daf4bb788ae595ae4103c404cb0fa09c84
+  subpackages:
+  - pkg/api/resource
+  - pkg/apis/meta/v1
+  - pkg/conversion
+  - pkg/conversion/queryparams
+  - pkg/fields
+  - pkg/labels
+  - pkg/runtime
+  - pkg/runtime/schema
+  - pkg/selection
+  - pkg/types
+  - pkg/util/errors
+  - pkg/util/intstr
+  - pkg/util/json
+  - pkg/util/naming
+  - pkg/util/net
+  - pkg/util/runtime
+  - pkg/util/sets
+  - pkg/util/validation
+  - pkg/util/validation/field
+  - pkg/watch
+  - third_party/forked/golang/reflect
+- name: k8s.io/klog
+  version: 3ca30a56d8a775276f9cdae009ba326fdc05af7f
 testImports:
 - name: github.com/davecgh/go-spew
-  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
+  version: 8991bc29aa16c548c550c7ff78260e27b9ab7c73
   subpackages:
   - spew
 - name: github.com/MakeNowJust/heredoc
   version: bb23615498cded5e105af4ce27de75b089cbe851
 - name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  version: 792786c7400a136282c1664665ae0a8db921c6c2
   subpackages:
   - difflib
 - name: github.com/stretchr/testify

--- a/src/fullerite/glide.yaml
+++ b/src/fullerite/glide.yaml
@@ -31,6 +31,10 @@ import:
 - package: gopkg.in/yaml.v2
 - package: github.com/ghodss/yaml
   version: ~1.0.0
+- package: k8s.io/api
+  version: kubernetes-1.16.3
+  subpackages:
+  - core/v1
 testImport:
 - package: github.com/stretchr/testify
   subpackages:


### PR DESCRIPTION
Add `KubeletPods` collector which collects information about Kubernetes
pods running on the current host by reading the corresponding
information from the read-only port of `kubelet`.

The only metric collected at the moment is
`KubernetesContainerEphemeralStorageLimit`, which contains the limit in
bytes for the ephemeral disk storage.

Supported configuration options are:
* `kubeletTimeout` - timeout in seconds to read pods information from
  `kubelet`
* `kubeletPort` - the read/only `kubelet` port number, the default
  value is `10255`.
* `generatedDimensions` - map of dimension name to map of Kubernetes
  label name to regexp to extract the dimension value from the label
  value.  Example:
```yaml
instance:
  acme.co.uk/instance:
    .*
```