### PR TITLE
K8s pod support on NerveUWSGI / NerveHTTPD collectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ export GOPATH
 PATH := $(GOPATH)/bin:$(GOPATH)/go/bin:$(PATH)
 export PATH
 
+# Use yelp-internal pypi if building at Yelp.
+ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
+    export PIP_INDEX_URL ?= https://pypi.yelpcorp.com/simple
+else
+    export PIP_INDEX_URL ?= https://pypi.python.org/simple
+endif
+
 all: clean fmt lint $(FULLERITE) $(BEATIT) test
 
 .PHONY: clean

--- a/src/fullerite/collector/nerve_httpd.go
+++ b/src/fullerite/collector/nerve_httpd.go
@@ -49,7 +49,6 @@ type NerveHTTPD struct {
 
 	configFilePath    string
 	queryPath         string
-	host              string
 	timeout           int
 	statusTTL         time.Duration
 	servicesWhitelist []string
@@ -74,7 +73,6 @@ func newNerveHTTPD(channel chan metric.Metric, initialInterval int, log *l.Entry
 	c.name = "NerveHTTPD"
 	c.configFilePath = "/etc/nerve/nerve.conf.json"
 	c.queryPath = "server-status?auto"
-	c.host = "localhost"
 	c.timeout = 2
 	c.statusTTL = time.Duration(60) * time.Minute
 	return c
@@ -88,10 +86,6 @@ func (c *NerveHTTPD) Configure(configMap map[string]interface{}) {
 
 	if val, exists := configMap["configFilePath"]; exists {
 		c.configFilePath = val.(string)
-	}
-
-	if val, exists := configMap["host"]; exists {
-		c.host = val.(string)
 	}
 
 	if val, exists := configMap["status_ttl"]; exists {
@@ -148,7 +142,7 @@ func (c *NerveHTTPD) getMetrics(service util.NerveService) []metric.Metric {
 	results := []metric.Metric{}
 	serviceLog := c.log.WithField("service", service.Name)
 
-	endpoint := fmt.Sprintf("http://%s:%d/%s", c.host, service.Port, c.queryPath)
+	endpoint := fmt.Sprintf("http://%s:%d/%s", service.Host, service.Port, c.queryPath)
 	serviceLog.Debug("making GET request to ", endpoint)
 
 	httpResponse := fetchApacheMetrics(endpoint, service.Port)

--- a/src/fullerite/collector/nerve_httpd_test.go
+++ b/src/fullerite/collector/nerve_httpd_test.go
@@ -44,7 +44,6 @@ func TestDefaultConfigNerveHTTPD(t *testing.T) {
 	assert.Equal(t, "/etc/nerve/nerve.conf.json", collector.configFilePath)
 	assert.Equal(t, "server-status?auto", collector.queryPath)
 	assert.Equal(t, time.Duration(1)*time.Hour, collector.statusTTL)
-	assert.Equal(t, "localhost", collector.host)
 	assert.Equal(t, "NerveHTTPD", collector.Name())
 	assert.Nil(t, collector.servicesWhitelist)
 }
@@ -54,7 +53,6 @@ func TestCustomConfigNerveHTTPD(t *testing.T) {
 	configMap := map[string]interface{}{
 		"status_ttl":        120,
 		"configFilePath":    "/tmp/foobar",
-		"host":              "169.0.0.1",
 		"servicesWhitelist": []string{"serv1.ns1", "serv2.ns2"},
 	}
 	collector.Configure(configMap)
@@ -63,7 +61,6 @@ func TestCustomConfigNerveHTTPD(t *testing.T) {
 	assert.Equal(t, "/tmp/foobar", collector.configFilePath)
 	assert.Equal(t, "server-status?auto", collector.queryPath)
 	assert.Equal(t, time.Duration(120)*time.Second, collector.statusTTL)
-	assert.Equal(t, "169.0.0.1", collector.host)
 	assert.Equal(t, []string{"serv1.ns1", "serv2.ns2"}, collector.servicesWhitelist)
 }
 

--- a/src/fullerite/collector/nginx_nerve.go
+++ b/src/fullerite/collector/nginx_nerve.go
@@ -77,7 +77,7 @@ func (m *nginxNerveStats) Collect() {
 
 func (m *nginxNerveStats) collectMetricsForService(service util.NerveService, path string) {
 	serviceLog := m.log.WithField("service", service.Name)
-	statsURL := fmt.Sprintf("http://localhost:%d%s", service.Port, path)
+	statsURL := fmt.Sprintf("http://%s:%d%s", service.Host, service.Port, path)
 
 	serviceLog.Debug("Fetching nginx stats from", statsURL)
 	metrics := getNginxMetrics(m.client, statsURL, serviceLog)

--- a/src/fullerite/util/nerve_config_test.go
+++ b/src/fullerite/util/nerve_config_test.go
@@ -148,9 +148,9 @@ func badURINerveConfig() []byte {
 
 func TestNerveConfigParsing(t *testing.T) {
 	expected := map[NerveService]bool{
-		NerveService{Name: "example_service", Namespace: "mesosstage_main", Port: 22224}: true,
-		NerveService{Name: "example_service", Namespace: "main", Port: 13752}:            true,
-		NerveService{Name: "example_service", Namespace: "another", Port: 13752}:         true,
+		NerveService{Name: "example_service", Namespace: "mesosstage_main", Port: 22224, Host: "10.56.5.21"}: true,
+		NerveService{Name: "example_service", Namespace: "main", Port: 13752, Host: "10.56.5.21"}:            true,
+		NerveService{Name: "example_service", Namespace: "another", Port: 13752, Host: "10.56.5.21"}:         true,
 	}
 
 	cfgString := getTestNerveConfig()
@@ -178,15 +178,6 @@ func TestNerveConfigParsingiNoNamespace(t *testing.T) {
 		m[r.Port] = true
 	}
 	assert.Equal(t, expected, m)
-}
-
-func TestNerveFilterOnIP(t *testing.T) {
-	cfgString := getTestNerveConfig()
-	ipGetter = func() ([]string, error) { return []string{"10.56.2.3"}, nil }
-	results, err := ParseNerveConfig(&cfgString, true)
-	assert.Nil(t, err)
-	assert.NotNil(t, results)
-	assert.Equal(t, 0, len(results))
 }
 
 func TestHandleBadNerveConfig(t *testing.T) {


### PR DESCRIPTION
Currently, these collectors only look at nerve services running on a "local IP", even though I can't think of any cases where we would have nerve register a remote IP. (From digging through the git logs, it looks like it's been that way since the introduction of this collector and wasn't added in response to some issue.)

This drops that filtering, and also makes the collector use the host written in the nerve config, instead of using the same host (defaults to `localhost`) for every service.

In order to get the tests running on my dev box (where we don't have the right packages installed to get the python `mysqlclient` package built), I added logic to the Makefile to use wheels from internal pypi; this is adapted from [Paasta's makefile](https://github.com/Yelp/paasta/blob/35fd718f655e1eae229dbc8f1a4072f5ded73a5d/Makefile#L17-L23)

cc @avadhutp 