### PR TITLE
Support parsing service_dims in legacy metrics.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.57
+VERSION        := 0.6.58
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/fullerite/dropwizard/legacy_metric.go
+++ b/src/fullerite/dropwizard/legacy_metric.go
@@ -90,6 +90,8 @@ func (parser *LegacyMetric) parseNestedMetricMaps(
 
 	unvisitedMetricMaps = append(unvisitedMetricMaps, startMetricMap)
 
+	var serviceDims interface{}
+
 	for len(unvisitedMetricMaps) > 0 {
 		nodeToVisit := unvisitedMetricMaps[0]
 		unvisitedMetricMaps = unvisitedMetricMaps[1:]
@@ -100,6 +102,9 @@ func (parser *LegacyMetric) parseNestedMetricMaps(
 		for k, v := range nodeToVisit.metricMap {
 			switch t := v.(type) {
 			case map[string]interface{}:
+				if k == "service_dims" {
+					serviceDims = v
+				}
 				unvistedNode := nestedMetricMap{
 					metricSegments: append(currentMetricSegment, k),
 					metricMap:      t,
@@ -117,6 +122,12 @@ func (parser *LegacyMetric) parseNestedMetricMaps(
 					results = append(results, m)
 				}
 			}
+		}
+	}
+
+	if serviceDims != nil {
+		for k, v := range serviceDims.(map[string]interface{}) {
+			metric.AddToAll(&results, map[string]string{k: v.(string)})
 		}
 	}
 

--- a/src/fullerite/dropwizard/legacy_metric_test.go
+++ b/src/fullerite/dropwizard/legacy_metric_test.go
@@ -221,3 +221,27 @@ func TestDropwizardHistogram(t *testing.T) {
 
 	assert.Equal(t, 100.0, counterMetric.Value)
 }
+
+func TestServiceDimsWithLegacyMetric(t *testing.T) {
+	var rawData = []byte(`{
+  "service_dims": {
+    "git_sha": "aabbcc",
+    "deploy_group": "canary"
+  },
+  "jvm.classloader.loaded": {
+	"value": 123
+  }
+}`)
+
+	parser := NewLegacyMetric(rawData, "", false)
+	metrics, err := parser.Parse()
+
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(metrics))
+
+	for _, m := range metrics {
+		assert.Equal(t, 3, len(m.Dimensions))
+		assert.Equal(t, m.Dimensions["git_sha"], "aabbcc")
+		assert.Equal(t, m.Dimensions["deploy_group"], "canary")
+	}
+}


### PR DESCRIPTION
The legacy metric collector doesn't parse service_dims for hystrix metrics. This PR adds the support for that.

### Testing
make test works.

