### PR TITLE
Add collector for kube-scheduler and controller-manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,7 @@ tests: deps diamond_test fullerite-tests
 
 fullerite-tests:
 	@echo Testing $(FULLERITE)
-	@for pkg in $(PKGS); do \
-		go test -race -cover $$pkg || exit 1;\
-	done
+	go test -race -cover fullerite/... || exit 1;\
 
 qbt:
 	@echo Fast testing $(FULLERITE)

--- a/src/fullerite/collector/kube_core_component.go
+++ b/src/fullerite/collector/kube_core_component.go
@@ -1,0 +1,157 @@
+package collector
+
+import (
+	"fmt"
+	l "github.com/Sirupsen/logrus"
+
+	"fullerite/config"
+	"fullerite/metric"
+	"fullerite/util"
+	p "fullerite/util/kubernetes/pod_info"
+)
+
+const (
+	defaultPrometheusEndpointTimeoutSecs = 5
+	defaultKubeletTimeoutSecs            = 3
+	kubernetesCoreComponentCollectorName = "KubeCoreComponentMetrics"
+)
+
+type kubernetesCoreComponentMetric struct {
+	endpointSuffix string
+	selectors      []p.Selector
+}
+
+// KubeCoreComponentMetrics For example,
+// {
+//		"kubeletTimeoutSecs": 3,
+//		"prometheusEndpointTimeoutSecs": 5,
+// 		"metricsBlacklist": ["hello", "world"],
+// 		"metricsWhitelist": ["syoy"],
+// 		"kubernetesCoreComponentMetric": {
+// 			"kube-scheduler": "10251/metrics",
+// 			"controller-manager": "10255/metrics"
+// 		},
+// 		"additionalDimensions": {
+// 			"kubernetes_cluster": "norcal-stagef"
+// 		}
+// 	}
+// Note that metrics is a map where the keys are
+// kuberentes components as specified in Label "component" in pod spec
+// The suffix appended after pod ip of prometheus endpoints.
+type KubeCoreComponentMetrics struct {
+	baseCollector
+	podInfoParser                 *p.PodInfoParser
+	metrics                       map[string]*kubernetesCoreComponentMetric
+	prometheusEndpointTimeoutSecs int
+	kubeletTimeoutSecs            int
+	metricsBlacklist              map[string]bool
+	metricsWhitelist              map[string]bool
+	additionalDimensions          map[string]string
+	headers                       map[string]string
+}
+
+func init() {
+	RegisterCollector(kubernetesCoreComponentCollectorName, newKubeCoreComponentMetrics)
+}
+
+func newKubeCoreComponentMetrics(channel chan metric.Metric, initialInterval int, log *l.Entry) Collector {
+	k := new(KubeCoreComponentMetrics)
+	k.log = log
+	k.channel = channel
+	k.interval = initialInterval
+	k.name = kubernetesCoreComponentCollectorName
+	k.additionalDimensions = make(map[string]string)
+	k.headers = map[string]string{
+		"Accept":                              acceptHeader,
+		"User-Agent":                          userAgentHeader,
+		"X-Prometheus-Scrape-Timeout-Seconds": fmt.Sprintf("%d", defaultPrometheusEndpointTimeoutSecs),
+	}
+	return k
+}
+
+// Configure configure KubeCoreComponentMetrics
+func (k *KubeCoreComponentMetrics) Configure(configMap map[string]interface{}) {
+	if prometheusEndpointTimeoutSecs, exists := configMap["prometheusEndpointTimeoutSecs"]; exists {
+		k.prometheusEndpointTimeoutSecs = config.GetAsInt(prometheusEndpointTimeoutSecs, defaultPrometheusEndpointTimeoutSecs)
+	}
+	if kubeletTimeoutSecs, exists := configMap["kubeletTimeoutSecs"]; exists {
+		k.kubeletTimeoutSecs = config.GetAsInt(kubeletTimeoutSecs, defaultKubeletTimeoutSecs)
+	}
+	if metricsWhitelist, exists := configMap["metricsWhitelist"]; exists {
+		k.metricsWhitelist = config.GetAsSet(metricsWhitelist)
+	}
+	if metricsBlacklist, exists := configMap["metricsBlacklist"]; exists {
+		k.metricsBlacklist = config.GetAsSet(metricsBlacklist)
+	}
+	if additionalDimensions, exists := configMap["additionalDimensions"]; exists {
+		k.additionalDimensions = config.GetAsMap(additionalDimensions)
+	}
+	if metric, exists := configMap["kubernetesCoreComponentMetric"]; exists {
+		k.metrics = make(map[string]*kubernetesCoreComponentMetric)
+		metricsMap := config.GetAsMap(metric)
+		for name, endpoint := range metricsMap {
+			k.metrics[name] = &kubernetesCoreComponentMetric{
+				endpointSuffix: endpoint,
+				selectors:      make([]p.Selector, 0),
+			}
+			k.metrics[name].selectors = append(k.metrics[name].selectors, p.NewLabelSelector(
+				map[string]string{
+					"component": name,
+				},
+			))
+		}
+	}
+	k.podInfoParser = p.NewPodInfoParser(
+		k.kubeletTimeoutSecs,
+		p.NewAllContainersReadySelector(),
+	)
+	k.configureCommonParams(configMap)
+}
+
+// Collect collect metrics
+func (k *KubeCoreComponentMetrics) Collect() {
+	for _, metric := range k.metrics {
+		pods, err := k.podInfoParser.Pods(metric.selectors...)
+		if err != nil {
+			k.log.Fatalf("Something went wrong while parsing extracting pod information: %v", err)
+		}
+		for _, pod := range pods {
+			go k.collectForPod(fmt.Sprintf("http://%s:%s", pod.Status.PodIP, metric.endpointSuffix))
+		}
+	}
+}
+
+func (k *KubeCoreComponentMetrics) collectForPod(endpoint string) {
+	body, contentType, scrapeErr := util.HTTPGet(
+		endpoint,
+		k.headers,
+		defaultPrometheusEndpointTimeoutSecs,
+		"",
+		"",
+		"",
+	)
+	if scrapeErr != nil {
+		k.log.Errorf("Error while scraping %s: %s", endpoint, scrapeErr)
+		return
+	}
+	metrics, parseErr := util.ExtractPrometheusMetrics(
+		body,
+		contentType,
+		&k.metricsWhitelist,
+		&k.metricsBlacklist,
+		"",
+		k.additionalDimensions,
+		k.log,
+	)
+	if parseErr != nil {
+		k.log.Errorf("Error while parsing response: %s", parseErr)
+		return
+	}
+	k.sendMetrics(metrics)
+}
+
+func (k *KubeCoreComponentMetrics) sendMetrics(metrics []metric.Metric) {
+	for _, m := range metrics {
+		k.Channel() <- m
+	}
+}

--- a/src/fullerite/collector/kube_core_component_test.go
+++ b/src/fullerite/collector/kube_core_component_test.go
@@ -1,0 +1,50 @@
+package collector
+
+import (
+	"encoding/json"
+	"fullerite/metric"
+	p "fullerite/util/kubernetes/pod_info"
+	l "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestConfigure(t *testing.T) {
+	expectedChan := make(chan metric.Metric)
+	var expectedLogger = defaultLog.WithFields(l.Fields{"collector": "KubeCoreComponent"})
+	k := newKubeCoreComponentMetrics(expectedChan, 10, expectedLogger).(*KubeCoreComponentMetrics)
+	testConfig := []byte(`
+	{
+		"kubeletTimeoutSecs": 3,
+		"prometheusEndpointTimeoutSecs": 5,
+		"metricsBlacklist": ["hello", "world"],
+		"metricsWhitelist": ["syoy"],
+		"kubernetesCoreComponentMetric": {
+			"kube-scheduler": "10251/metrics",
+			"controller-manager": "10255/metrics"
+		},
+		"additionalDimensions": {
+			"kubernetes_cluster": "norcal-stagef"
+		}
+	}`)
+	testConfigMap := make(map[string]interface{})
+	json.Unmarshal(testConfig, &testConfigMap)
+	k.Configure(testConfigMap)
+	assert.Equal(t, k.log, expectedLogger)
+	assert.Equal(t, k.channel, expectedChan)
+	assert.Equal(t, 3, k.kubeletTimeoutSecs)
+	assert.Equal(t, 5, k.prometheusEndpointTimeoutSecs)
+	_, exists1 := k.metricsBlacklist["hello"]
+	assert.True(t, exists1)
+	_, exists2 := k.metricsBlacklist["world"]
+	assert.True(t, exists2)
+	_, exists3 := k.metricsWhitelist["syoy"]
+	assert.True(t, exists3)
+	assert.Equal(t, 2, len(k.metricsBlacklist))
+	assert.Equal(t, 1, len(k.metricsWhitelist))
+	LabelSelector1, _ := k.metrics["kube-scheduler"]
+	assert.Equal(t, "10251/metrics", LabelSelector1.endpointSuffix)
+	assert.Equal(t, map[string]string{"component": "kube-scheduler"}, LabelSelector1.selectors[0].(*p.LabelSelector).Labels)
+	assert.Equal(t, map[string]string{"kubernetes_cluster": "norcal-stagef"}, k.additionalDimensions)
+
+}

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -159,6 +159,15 @@ func GetAsMap(value interface{}) (result map[string]string) {
 	return
 }
 
+// GetAsSet parses a string to a map[string]string
+func GetAsSet(value interface{}) (result map[string]bool) {
+	result = make(map[string]bool)
+	for _, v := range GetAsSlice(value) {
+		result[v] = true
+	}
+	return
+}
+
 // GetAsSlice : Parses a json array string to []string
 func GetAsSlice(value interface{}) []string {
 	result := []string{}

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -131,6 +131,18 @@ func TestGetAsMap(t *testing.T) {
 	assert.Equal(config.GetAsMap(interfaceMapToParse), expectedValue)
 }
 
+func TestGetAsSet(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test if string array can be converted to map[string]bool
+	stringToParse := "[\"runtimeenv\", \"region\"]"
+	expectedValue := map[string]bool{
+		"runtimeenv": true,
+		"region":     true,
+	}
+	assert.Equal(config.GetAsSet(stringToParse), expectedValue)
+}
+
 func TestGetAsSlice(t *testing.T) {
 	assert := assert.New(t)
 

--- a/src/fullerite/util/kubernetes/pod_info/parser.go
+++ b/src/fullerite/util/kubernetes/pod_info/parser.go
@@ -1,0 +1,92 @@
+package podinfo
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	"net/http"
+	"time"
+)
+
+const podSpecURL = "http://localhost:10255/pods"
+
+// PodInfoParser Used to retrieve selected corev1.Pod objects 
+type PodInfoParser struct {
+	kubeletTimeout int
+	selectors      []Selector
+}
+
+// NewPodInfoParser Return a new PodInfoParser
+func NewPodInfoParser(kubeletTimeout int, selectors ...Selector) *PodInfoParser {
+	podInfoParser := &PodInfoParser{
+		kubeletTimeout: 5,
+		selectors:      make([]Selector, 0),
+	}
+	for _, selector := range selectors {
+		podInfoParser.selectors = append(podInfoParser.selectors, selector)
+	}
+	return podInfoParser
+}
+
+// AllPods Return all unfiltered pods on this host. This information is 
+// retrieved from podSpecURL 
+func (p *PodInfoParser) AllPods() ([]corev1.Pod, error) {
+	client := http.Client{
+		Timeout: time.Second * time.Duration(p.kubeletTimeout),
+	}
+
+	res, getErr := client.Get(podSpecURL)
+	if getErr != nil {
+		return nil, getErr
+	}
+	defer res.Body.Close()
+	body, readErr := ioutil.ReadAll(res.Body)
+	if readErr != nil {
+		return nil, readErr
+	}
+	podList := corev1.PodList{}
+	jsonErr := json.Unmarshal(body, &podList)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+	return podList.Items, nil
+}
+
+// Pods Return pods filterd by provided selector argument, and selectors 
+// in this PodInfoParser object
+func (p *PodInfoParser) Pods(selectors ...Selector) ([]corev1.Pod, error) {
+	pods, err := p.AllPods()
+	if err != nil {
+		return nil, err
+	}
+	return p.SelectPodsFrom(pods, selectors...)
+}
+
+// Pods Return pods filterd by provided selector argument, and selectors 
+// in this PodInfoParser object
+func (p *PodInfoParser) SelectPodsFrom(pods []corev1.Pod, selectors ...Selector) ([]corev1.Pod, error) {
+	ret := make([]corev1.Pod, 0)
+	for _, pod := range pods {
+		isPodLegit := true
+		for _, s := range p.selectors {
+			if !isPodLegit {
+				break
+			}
+			if !s.Filter(&pod) {
+				isPodLegit = false
+			}
+		}
+		for _, s := range selectors {
+			if !isPodLegit {
+				break
+			}
+			if !s.Filter(&pod) {
+				isPodLegit = false
+			}
+		}
+		if isPodLegit {
+			ret = append(ret, pod)
+		}
+	}
+	return ret, nil
+}

--- a/src/fullerite/util/kubernetes/pod_info/parser_test.go
+++ b/src/fullerite/util/kubernetes/pod_info/parser_test.go
@@ -1,0 +1,57 @@
+package podinfo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"encoding/json"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func mockPods() ([]corev1.Pod) {
+	podJSON1 := []byte(`
+	{
+		"status": {
+			"containerStatuses": [
+				{
+					"ready": true
+				}, {
+					"ready": true
+				}
+			]
+		}
+	}`)
+	podJSON2 := []byte(`
+	{
+		"status": {
+			"containerStatuses": [
+				{
+					"ready": true
+				}, {
+					"ready": true
+				}
+			]
+		}
+	}`)
+	var pod1, pod2 corev1.Pod
+	json.Unmarshal(podJSON1, &pod1)
+	json.Unmarshal(podJSON2, &pod2)
+    pod1.SetLabels(map[string]string{
+		"component": "kube-scheduler",
+	})
+	pod2.SetLabels(map[string]string{
+		"noop": "noop",
+	})
+	return []corev1.Pod{pod1, pod2}
+}
+
+func TestSelectPodsFrom(t *testing.T) {
+	p := NewPodInfoParser(5, NewAllContainersReadySelector())
+	pods := mockPods()
+	l := NewLabelSelector(map[string]string{
+		"component": "kube-scheduler",
+	})	
+	
+	actual, _ := p.SelectPodsFrom(pods, l)
+	assert.Equal(t, 1, len(actual)) 
+	assert.Equal(t, l.Labels["component"], actual[0].GetLabels()["component"]) 
+}

--- a/src/fullerite/util/kubernetes/pod_info/selectors.go
+++ b/src/fullerite/util/kubernetes/pod_info/selectors.go
@@ -1,0 +1,51 @@
+package podinfo
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Selector "Filter" function takes in a pod and tell if it is selected. 
+type Selector interface {
+	Filter(*corev1.Pod) bool
+}
+
+// LabelSelector Implements Selector interface. Select pods by pod Labels provided. 
+type LabelSelector struct {
+	Labels map[string]string
+}
+
+// AllContainersReadySelector Implements Selector interface. Select a pod if all of its containers are ready
+type AllContainersReadySelector struct{}
+
+// NewLabelSelector Return a LabelSecltor
+func NewLabelSelector(l map[string]string) *LabelSelector {
+	return &LabelSelector{
+		Labels: l,
+	}
+}
+
+// NewLabelSelector Return an AllContainersReadySelector
+func NewAllContainersReadySelector() *AllContainersReadySelector {
+	return &AllContainersReadySelector{}
+}
+
+// Filter Return true if pod labels match labels in the filter
+func (l *LabelSelector) Filter(pod *corev1.Pod) bool {
+	for k, v := range l.Labels {
+		v2, exists := pod.GetLabels()[k]
+		if !exists || v2 != v {
+			return false
+		}
+	}
+	return true
+}
+
+// Filter Returns True if all containers in this pod are ready
+func (a *AllContainersReadySelector) Filter(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.ContainerStatuses {
+		if !status.Ready {
+			return false
+		}
+	}
+	return true
+}

--- a/src/fullerite/util/kubernetes/pod_info/selectorss_test.go
+++ b/src/fullerite/util/kubernetes/pod_info/selectorss_test.go
@@ -1,0 +1,53 @@
+package podinfo
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+	"encoding/json"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestLabelSelector(t *testing.T) {
+	l := NewLabelSelector(map[string]string{
+		"component": "kube-scheduler",
+	})
+	podJSON := []byte(`{}`)
+	var pod1 *corev1.Pod
+	json.Unmarshal(podJSON, &pod1)
+	pod1.SetLabels(l.Labels)
+	assert.True(t, l.Filter(pod1))
+}
+
+func TestAllContainersReadySelector(t *testing.T) {
+	a := NewAllContainersReadySelector()
+	podJSON := []byte(`
+	{
+		"status": {
+			"containerStatuses": [
+				{
+					"ready": true
+				}, {
+					"ready": false
+				}
+			]
+		}
+	}`)
+	var pod1 *corev1.Pod
+	json.Unmarshal(podJSON, &pod1)
+	assert.False(t, a.Filter(pod1))
+	podJSON = []byte(`
+	{
+		"status": {
+			"containerStatuses": [
+				{
+					"ready": true
+				}, {
+					"ready": true
+				}
+			]
+		}
+	}`)
+	var pod2 *corev1.Pod
+	json.Unmarshal(podJSON, &pod2)
+	assert.True(t, a.Filter(pod2))
+}

--- a/src/fullerite/util/prometheus.go
+++ b/src/fullerite/util/prometheus.go
@@ -74,12 +74,11 @@ func ExtractPrometheusMetrics(
 				}
 			}
 		}
-
-		if metricsWhitelist != nil {
+		if metricsWhitelist != nil && len(*metricsWhitelist) != 0 {
 			if _, ok := (*metricsWhitelist)[metricName]; !ok {
 				continue
 			}
-		} else if metricsBlacklist != nil {
+		} else if metricsBlacklist != nil && len(*metricsBlacklist) != 0 {
 			if _, ok := (*metricsBlacklist)[metricName]; ok {
 				continue
 			}
@@ -130,6 +129,8 @@ func ExtractPrometheusMetrics(
 		for dimensionName, dimensionValue := range generatedDimensions {
 			metric.AddDimension(dimensionName, dimensionValue)
 		}
+
+		log.Info("Appending metric: ", metric)
 		metrics = append(metrics, metric)
 	}
 


### PR DESCRIPTION
### Summary 
* Added a collector that filters pod on host by component label, find pod ip, and retrieve metrics * from specified endpoints. 
* Changed makefile `fullerite-tests` command to recursively test all packages. It doesn't right now. 
### What is missing
It cannot detect which scheduler is leader due to missing endpoints for components created by kubeadm. And it's expensive to parse log to find the leaders. 
### Tests Done
* Make test 
* Manually tested. 
```
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:0.128]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:0.256]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:0.064]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:0.128]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:0.256]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:0.512]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:0.512]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:1.024]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:2.048]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:4.096]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:1.024]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:2.048]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:4.096]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:8.192]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:8.192]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:16.384]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef le:+Inf]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:16.384]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_bucket cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef le:+Inf]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_scheduling_algorithm_priority_evaluation_seconds_count MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_scheduling_algorithm_priority_evaluation_seconds_count cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="readFromCollector: m = {Name:scheduler_total_preemption_attempts MetricType:cumcounter Value:0 Dimensions:map[kubernetes_cluster:norcal-stagef]}" app=fullerite
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="SignalFx metric: {scheduler_total_preemption_attempts cumcounter 0 map[collector:KubeCoreComponentMetrics kubernetes_cluster:norcal-stagef]}" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=info msg="Successfully sent 346 datapoints to SignalFx" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=info msg="POST of 346 metrics to SignalFx took 0.640128 seconds" app=fullerite handler=SignalFx pkg=handler
time="Thursday, 30-Jan-20 16:30:35 PST" level=debug msg="We removed 0 entries and now have 1" app=fullerite handler=SignalFx pkg=handler
```