### PR TITLE
fix prometheus collector white/balck lists

### DIFF
--- a/src/fullerite/collector/prometheus.go
+++ b/src/fullerite/collector/prometheus.go
@@ -30,8 +30,8 @@ type Endpoint struct {
 	headers             map[string]string
 	httpGetter          util.HTTPGetter
 	generatedDimensions map[string]string
-	metricsBlacklist    *map[string]bool
-	metricsWhitelist    *map[string]bool
+	metricsBlacklist    map[string]bool
+	metricsWhitelist    map[string]bool
 }
 
 // Prometheus collector type.
@@ -93,7 +93,13 @@ func (p *Prometheus) Configure(configMap map[string]interface{}) {
 		if v, exists := endpoint["timeout"]; exists {
 			timeout = config.GetAsInt(v, timeout)
 		}
-
+		var metricsWhitelist, metricsBlacklist map[string]bool = nil, nil
+		if v, exists := endpoint["metrics_whitelist"]; exists {
+			metricsWhitelist = config.GetAsSet(v)
+		}
+		if v, exists := endpoint["metrics_blacklist"]; exists {
+			metricsBlacklist = config.GetAsSet(v)
+		}
 		httpGetter, err := util.NewHTTPGetter(
 			p.getString(endpoint, "serverCaFile"),
 			p.getString(endpoint, "clientCertFile"),
@@ -112,8 +118,8 @@ func (p *Prometheus) Configure(configMap map[string]interface{}) {
 				"X-Prometheus-Scrape-Timeout-Seconds": fmt.Sprintf("%d", timeout),
 			},
 			httpGetter:          httpGetter,
-			metricsWhitelist:    p.getSet(endpoint, "metrics_whitelist"),
-			metricsBlacklist:    p.getSet(endpoint, "metrics_blacklist"),
+			metricsWhitelist:    metricsWhitelist,
+			metricsBlacklist:    metricsBlacklist,
 			generatedDimensions: generatedDimensions,
 		})
 	}

--- a/src/fullerite/config/config.go
+++ b/src/fullerite/config/config.go
@@ -159,6 +159,15 @@ func GetAsMap(value interface{}) (result map[string]string) {
 	return
 }
 
+// GetAsSet parses a string to a map[string]string
+func GetAsSet(value interface{}) (result map[string]bool) {
+	result = make(map[string]bool)
+	for _, v := range GetAsSlice(value) {
+		result[v] = true
+	}
+	return
+}
+
 // GetAsSlice : Parses a json array string to []string
 func GetAsSlice(value interface{}) []string {
 	result := []string{}

--- a/src/fullerite/config/config_test.go
+++ b/src/fullerite/config/config_test.go
@@ -172,3 +172,15 @@ func TestParseBadConfig(t *testing.T) {
 	_, err := config.ReadConfig(tmpTestBadFile)
 	assert.NotNil(t, err, "should fail")
 }
+
+func TestGetAsSet(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test if string array can be converted to map[string]bool
+	stringToParse := "[\"runtimeenv\", \"region\"]"
+	expectedValue := map[string]bool{
+		"runtimeenv": true,
+		"region":     true,
+	}
+	assert.Equal(config.GetAsSet(stringToParse), expectedValue)
+}

--- a/src/fullerite/util/prometheus.go
+++ b/src/fullerite/util/prometheus.go
@@ -25,8 +25,8 @@ func trimSuffix(name string, suffix string) (string, bool) {
 func ExtractPrometheusMetrics(
 	body []byte,
 	contentType string,
-	metricsWhitelist *map[string]bool,
-	metricsBlacklist *map[string]bool,
+	metricsWhitelist map[string]bool,
+	metricsBlacklist map[string]bool,
 	prefix string,
 	generatedDimensions map[string]string,
 	log *l.Entry,
@@ -76,11 +76,11 @@ func ExtractPrometheusMetrics(
 		}
 
 		if metricsWhitelist != nil {
-			if _, ok := (*metricsWhitelist)[metricName]; !ok {
+			if _, ok := metricsWhitelist[metricName]; !ok {
 				continue
 			}
 		} else if metricsBlacklist != nil {
-			if _, ok := (*metricsBlacklist)[metricName]; ok {
+			if _, ok := metricsBlacklist[metricName]; ok {
 				continue
 			}
 		}

--- a/src/fullerite/util/prometheus_test.go
+++ b/src/fullerite/util/prometheus_test.go
@@ -324,7 +324,7 @@ func TestExtractPrometheusMetricsWithPrefixAndWhitelist(t *testing.T) {
 	actualMetrics, err := ExtractPrometheusMetrics(
 		body,
 		contentType,
-		&map[string]bool{
+		map[string]bool{
 			"process_virtual_memory_bytes":     true,
 			"go_memstats_last_gc_time_seconds": true,
 		},
@@ -366,7 +366,7 @@ func TestPrometheusExtractMetricsWithBlacklist(t *testing.T) {
 		body,
 		contentType,
 		nil,
-		&map[string]bool{
+		map[string]bool{
 			"process_virtual_memory_bytes":                   true,
 			"kubelet_docker_operations_latency_microseconds": true,
 			"kubelet_cgroup_manager_duration_seconds":        true,


### PR DESCRIPTION
* I noticed that metrics_whitelist is not parsed when testing my changes with a d branch. The cause is that endpoint["metric_whitelist"] is parsed as string instead of []string. I fixed this issue.
* I changed metricsBlacklist from pointer to map. The map object itself is a pointer. https://stackoverflow.com/questions/2809543/pointer-to-a-map  