### PR TITLE
Fix wrong metricName variable in HPAMetrics collector

### DIFF
--- a/src/fullerite/collector/hpa_metrics.go
+++ b/src/fullerite/collector/hpa_metrics.go
@@ -266,7 +266,7 @@ func (d *HPAMetrics) CollectMetricsForPod(pod *corev1.Pod) {
 			return
 		}
 		var value float64
-		switch metricName {
+		switch metric.name {
 		case "uwsgi":
 			{
 				tmp, uwsgiErr := parseUWSGIMetrics(raw)
@@ -284,6 +284,11 @@ func (d *HPAMetrics) CollectMetricsForPod(pod *corev1.Pod) {
 					d.log.Error(httpErr)
 					return
 				}
+			}
+		default:
+			{
+				d.log.Error("Unknown metric name ", metric.name)
+				return
 			}
 		}
 		var sanitizedDimensions map[string]string


### PR DESCRIPTION
metricName originally used is in cpu_info.go. I hate that Go does not restrict the scope of variables. This could have been a compilation error. 
Tested in stagef with compute-infra-test-service. 
```
time="Friday, 14-Feb-20 13:00:58 PST" level=debug msg="readFromCollector: m = {Name:uwsgi MetricType:gauge Value:0.25 Dimensions:ma
```