### PR TITLE
Internal metrics prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.70
+VERSION        := 0.6.71
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.70"
+	version = "0.6.71"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.70"
+	version = "0.6.71"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
Add an endpoint to fullerite to serve up the internal metrics in prometheus format.

I want to experiment with getting fullerite metrics into prometheus, and there are a number of possible architectural approaches to doing so that I can think of - but the key question about any changes is going to be 'what effect does this have on the CPU/memory requirements of fullerite'.

The best way to answer that question is with data from actual running instances, however given our current SignalFX quota, starting to spray all the fullerite metrics (for every host in the fleet) into SignalFX is probably not a smart move.

We *know* that we can cheaply ingest these metrics into Prometheus, so i just added a prometheus endpoint to the internal metrics server so that we can start scraping the fullerite metrics which will allow us to capture any change in resource requirements that is caused by any future changes.