### PR TITLE
Fix bug with some metric names only revealed when running a 'real' set of collectors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.71
+VERSION        := 0.6.72
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/fullerite/internalserver/internal_metrics_server.go
+++ b/src/fullerite/internalserver/internal_metrics_server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"runtime"
+	"strings"
 
 	l "github.com/Sirupsen/logrus"
 )
@@ -132,16 +133,18 @@ func prometheusInternalMetricsCollectorStats(writer http.ResponseWriter, stats m
 
 func prometheusInternalMetricsEmit(namePrefix string, dimString string, writer http.ResponseWriter, im *metric.InternalMetrics, emitTypes bool) {
 	for k, v := range im.Counters {
+		metricName := strings.Replace(k, ".", "_", -1)
 		if emitTypes {
-			io.WriteString(writer, fmt.Sprintf("# TYPE fullerite_internal_%s_%s_count counter\n", namePrefix, k))
+			io.WriteString(writer, fmt.Sprintf("# TYPE fullerite_internal_%s_%s_count counter\n", namePrefix, metricName))
 		}
-		io.WriteString(writer, fmt.Sprintf("fullerite_internal_%s_%s_count{%s} %f\n", namePrefix, k, dimString, v))
+		io.WriteString(writer, fmt.Sprintf("fullerite_internal_%s_%s_count{%s} %f\n", namePrefix, metricName, dimString, v))
 	}
 	for k, v := range im.Gauges {
+		metricName := strings.Replace(k, ".", "_", -1)
 		if emitTypes {
-			io.WriteString(writer, fmt.Sprintf("# TYPE fullerite_internal_%s_%s gauge\n", namePrefix, k))
+			io.WriteString(writer, fmt.Sprintf("# TYPE fullerite_internal_%s_%s gauge\n", namePrefix, metricName))
 		}
-		io.WriteString(writer, fmt.Sprintf("fullerite_internal_%s_%s{%s} %f\n", namePrefix, k, dimString, v))
+		io.WriteString(writer, fmt.Sprintf("fullerite_internal_%s_%s{%s} %f\n", namePrefix, metricName, dimString, v))
 	}
 }
 


### PR DESCRIPTION
I've manually built and installed this package on one host and it starts working (comes up in prometheus)

https://prometheus-peres-norcal-stagef.yelpcorp.com/graph?g0.range_input=1h&g0.expr=up%7Bjob%3D%22fullerite%22%2Cinstance%3D%2210.112.63.92%22%7D&g0.tab=0