### PR TITLE
replace paasta_yelp_com prefix in pod labels to paasta

### DIFF
--- a/src/fullerite/collector/hpa_metrics_test.go
+++ b/src/fullerite/collector/hpa_metrics_test.go
@@ -28,7 +28,7 @@ func getFakeUWSGIWorkerStatsResponse() []byte {
 
 func getFakeHTTPResponse() []byte {
 	return []byte(`{
-        "utilization": "0.75"
+        "utilization": 0.75
 	}`)
 }
 
@@ -50,7 +50,7 @@ func TestConfigureHPAMetrics(t *testing.T) {
 
 func TestSanitizeDimensions(t *testing.T) {
 	var dimensions = map[string]string{"paasta.yelp.com/instance": "fake-instance"}
-	assert.Equal(t, "fake-instance", sanitizeDimensions(dimensions)["paasta_yelp_com_instance"])
+	assert.Equal(t, "fake-instance", sanitizeDimensions(dimensions)["paasta_instance"])
 }
 
 func TestParseMetrics(t *testing.T) {


### PR DESCRIPTION
* replace paasta_yelp_com with paasta. I changed 
* http metrics should be float instead of string. Fixed it.

I have a [fork](https://github.com/EmanekaT/signalfx-k8s-metrics-adapter/commit/84e063f5cac2b283b3b964a31c9b43e51219cc97) of signalfx-k8s-metrics-adapter. I uploaded it to docker-dev registry, and tested both adapter and this collector with compute-infra-test-service with http metrics. It worked
```
mingqiz@dev54-uswest1adevc:~$ kubectl-kubestage -n paasta get hpa
NAME                                        REFERENCE                                              TARGETS     MINPODS   MAXPODS   REPLICAS   AGE
compute-infra-test-service-autoscaling--2   Deployment/compute-infra-test-service-autoscaling--2   0%/80%      1         10        1          136d
compute-infra-test-service-main--1          Deployment/compute-infra-test-service-main--1          200m/400m   1         2         2          56d
```