### PR TITLE
send http headers in the Get request 

### DIFF
--- a/src/fullerite/collector/http_dropwizard.go
+++ b/src/fullerite/collector/http_dropwizard.go
@@ -81,8 +81,7 @@ func (h *httpDropwizardCollector) queryService(s ServiceEndpoint) {
 	endpoint := fmt.Sprintf("http://localhost:%s/%s", s.Port, s.Path)
 	serviceLog.Debug("making GET request to ", endpoint)
 
-	headers := make(map[string]string)
-	rawResponse, schemaVer, err := queryEndpoint(endpoint, headers, h.timeout)
+	rawResponse, schemaVer, err := queryEndpoint(endpoint, map[string]string{}, h.timeout)
 	if err != nil {
 		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", err)
 		return

--- a/src/fullerite/collector/http_dropwizard.go
+++ b/src/fullerite/collector/http_dropwizard.go
@@ -81,7 +81,8 @@ func (h *httpDropwizardCollector) queryService(s ServiceEndpoint) {
 	endpoint := fmt.Sprintf("http://localhost:%s/%s", s.Port, s.Path)
 	serviceLog.Debug("making GET request to ", endpoint)
 
-	rawResponse, schemaVer, err := queryEndpoint(endpoint, h.timeout)
+	headers := make(map[string]string)
+	rawResponse, schemaVer, err := queryEndpoint(endpoint, headers, h.timeout)
 	if err != nil {
 		serviceLog.Warn("Failed to query endpoint ", endpoint, ": ", err)
 		return

--- a/src/fullerite/collector/nerve_uwsgi.go
+++ b/src/fullerite/collector/nerve_uwsgi.go
@@ -52,7 +52,6 @@ func newNerveUWSGI(channel chan metric.Metric, initialInterval int, log *l.Entry
 	col.name = "NerveUWSGI"
 	col.configFilePath = "/etc/nerve/nerve.conf.json"
 	col.queryPath = "status/metrics"
-	//col.serviceHeadersMap = make(map[string]map[string]string)
 	col.workersStatsQueryPath = "status/uwsgi"
 	col.timeout = 2
 
@@ -118,7 +117,10 @@ func (n *nerveUWSGICollector) queryService(serviceName string, host string, port
 	serviceLog := n.log.WithField("service", serviceName)
 	endpoint := fmt.Sprintf("http://%s:%d/%s", host, port, n.queryPath)
 	serviceLog.Debug("making GET request to ", endpoint)
-	headers := n.serviceHeadersMap[serviceName]
+	headers := make(map[string]string)
+	if val, exists := n.serviceHeadersMap[serviceName]; exists {
+		headers = val
+	}
 	serviceLog.Debug("GET request headers ", headers)
 	rawResponse, schemaVer, err := queryEndpoint(endpoint, headers, n.timeout)
 	if err != nil {
@@ -240,7 +242,10 @@ func (n *nerveUWSGICollector) tryFetchUWSGIWorkersStats(serviceName string, endp
 	emptyResult := []metric.Metric{}
 	serviceLog := n.log.WithField("service", serviceName)
 	serviceLog.Debug("making GET request to ", endpoint)
-	headers := n.serviceHeadersMap[serviceName]
+	headers := make(map[string]string)
+	if val, exists := n.serviceHeadersMap[serviceName]; exists {
+		headers = val
+	}
 	serviceLog.Debug("GET request headers ", headers)
 	rawResponse, _, err := queryEndpoint(endpoint, headers, n.timeout)
 	if err != nil {

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -393,7 +393,8 @@ func TestErrorQueryEndpointResponse(t *testing.T) {
 	endpoint := ts.URL + "/status/metrics"
 	ts.Close()
 
-	_, _, queryEndpointError := queryEndpoint(endpoint, 10)
+    headers := make(map[string]string)
+	_, _, queryEndpointError := queryEndpoint(endpoint, headers, 10)
 	assert.NotNil(t, queryEndpointError)
 
 	//Socket closed test
@@ -402,7 +403,7 @@ func TestErrorQueryEndpointResponse(t *testing.T) {
 	}))
 	tsClosed.Close()
 	closedEndpoint := tsClosed.URL + "/status/metrics"
-	_, queryClosedEndpointResponse, queryClosedEndpointError := queryEndpoint(closedEndpoint, 10)
+	_, queryClosedEndpointResponse, queryClosedEndpointError := queryEndpoint(closedEndpoint, headers, 10)
 	assert.NotNil(t, queryClosedEndpointError)
 	assert.Equal(t, "", queryClosedEndpointResponse)
 

--- a/src/fullerite/collector/nerve_uwsgi_test.go
+++ b/src/fullerite/collector/nerve_uwsgi_test.go
@@ -393,7 +393,7 @@ func TestErrorQueryEndpointResponse(t *testing.T) {
 	endpoint := ts.URL + "/status/metrics"
 	ts.Close()
 
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 	_, _, queryEndpointError := queryEndpoint(endpoint, headers, 10)
 	assert.NotNil(t, queryEndpointError)
 

--- a/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
+++ b/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
@@ -386,7 +386,7 @@ func TestErrorQueryStatsEndpointResponse(t *testing.T) {
 	endpoint := ts.URL + "/status/uwsgi"
 	ts.Close()
 
-    headers := make(map[string]string)
+	headers := make(map[string]string)
 	_, _, queryEndpointError := queryEndpoint(endpoint, headers, 10)
 	assert.NotNil(t, queryEndpointError)
 

--- a/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
+++ b/src/fullerite/collector/uwsgi_nerve_worker_stats_test.go
@@ -386,7 +386,8 @@ func TestErrorQueryStatsEndpointResponse(t *testing.T) {
 	endpoint := ts.URL + "/status/uwsgi"
 	ts.Close()
 
-	_, _, queryEndpointError := queryEndpoint(endpoint, 10)
+    headers := make(map[string]string)
+	_, _, queryEndpointError := queryEndpoint(endpoint, headers, 10)
 	assert.NotNil(t, queryEndpointError)
 
 	//Socket closed test
@@ -395,7 +396,7 @@ func TestErrorQueryStatsEndpointResponse(t *testing.T) {
 	}))
 	tsClosed.Close()
 	closedEndpoint := tsClosed.URL + "/status/uwsgi"
-	_, queryClosedEndpointResponse, queryClosedEndpointError := queryEndpoint(closedEndpoint, 10)
+	_, queryClosedEndpointResponse, queryClosedEndpointError := queryEndpoint(closedEndpoint, headers, 10)
 	assert.NotNil(t, queryClosedEndpointError)
 	assert.Equal(t, "", queryClosedEndpointResponse)
 }


### PR DESCRIPTION
Need help with these 2 errors:

Building fullerite...
# fullerite/collector
src/fullerite/collector/nerve_uwsgi.go:74:23: cannot use serviceHeadersMap (type interface {}) as type map[string]map[string]string in assignment: need type assertion
src/fullerite/collector/nerve_uwsgi.go:170:24: too many arguments in call to client.Get
	have (string, map[string]string)
	want (string)