### PR TITLE
[KAFKA-25711] Bumping up version to 0.6.76

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.75
+VERSION        := 0.6.76
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.74"
+	version = "0.6.76"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.74"
+	version = "0.6.76"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
Bumping up version of fullerite to `0.6.76` for changes in https://github.com/Yelp/fullerite/pull/443