### PR TITLE
[KAKFA-25711] Fixes handling of urllib2 in kubelet

### DIFF
--- a/src/diamond/collectors/jolokia/kubernetes.py
+++ b/src/diamond/collectors/jolokia/kubernetes.py
@@ -11,8 +11,10 @@ class Kubelet(object):
         url = "http://{}:{}/pods".format(KUBELET_DEFAULT_HOST, KUBELET_DEFAULT_PORT)
         try:
             response = urllib2.urlopen(url)
-            if response['status'] == 200:
-                json_str = response.read()
-                return json.loads(json_str), None
-        except urllib2.URLError as e:
+        except urllib2.HTTPError as err:
+            return None, err
+
+        try:
+            return json.load(response), None
+        except (TypeError, ValueError) as e:
             return None, e


### PR DESCRIPTION
Fixes the following error 
```python
import kubernetes
kubernetes.Kubelet().list_pods()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "kubernetes.py", line 14, in list_pods
    if response['status'] == 200:
AttributeError: addinfourl instance has no attribute '__getitem__'
```
for changes in https://github.com/Yelp/fullerite/pull/443

**Testing**
```bash
make test
```
Output
```
  py27: commands succeeded
  congratulations :)
```