### PR TITLE
Don't ignore TCP URIs when finding ports.

### DIFF
--- a/src/fullerite/util/nerve_config.go
+++ b/src/fullerite/util/nerve_config.go
@@ -13,6 +13,7 @@ import (
 var (
 	ipGetter   = getIps
 	httpRegexp = regexp.MustCompile(`http`)
+	tcpRegexp  = regexp.MustCompile(`tcp`)
 )
 
 // example configuration::
@@ -106,7 +107,7 @@ func extractPort(serviceConfig map[string]interface{}) int {
 	if len(uriArray) > 3 {
 		protocol := strings.TrimSpace(uriArray[1])
 		port := uriArray[3]
-		if !httpRegexp.MatchString(protocol) {
+		if !httpRegexp.MatchString(protocol) && !tcpRegexp.MatchString(protocol) {
 			return -1
 		}
 		if portInt, err := strconv.ParseInt(port, 10, 64); err == nil {

--- a/src/fullerite/util/nerve_config_test.go
+++ b/src/fullerite/util/nerve_config_test.go
@@ -74,7 +74,7 @@ func getTestNerveConfig() []byte {
 	                    "rise": 1,
 	                    "timeout": 6,
 	                    "type": "http",
-	                    "uri": "/http/example_service.another/13752/status"
+	                    "uri": "/tcp/example_service.another/13752/status"
 	                }
 	            ],
 	            "host": "10.56.5.21",


### PR DESCRIPTION
Our GRPC service is described as TCP. That's why nerve was not populating it in the list of services running in the machine, so that our new collector could receive its metrics.

I wasn't too sure if TCP was ignored by design. Please let me know if this may break anything.