### PR TITLE
[KAFKA-27171] Add backward support for nerve in jolokia collector

### DIFF
--- a/src/diamond/collectors/jolokia/dimension_reader.py
+++ b/src/diamond/collectors/jolokia/dimension_reader.py
@@ -207,7 +207,7 @@ class NerveDimensionReader(DimensionReader):
         for dim, regex in dim_generators.items():
             matches = regex.findall(host_id)
             if len(matches) > 0:
-                generated[dim] = matches[0]
+                generated[str(dim)] = matches[0]
         return generated
 
 
@@ -258,7 +258,7 @@ DEFAULT_DIMENSION_READER = NoopDimensionReader()
 def get_reader(name):
     """
     Returns the dimension reader for the given name
-    :param name: name of the dimension readereidfcciknhlfduigieigndrknvcrvjckvnjjhbiedfhf
+    :param name: name of the dimension reader
 
     :return: dimension reader by name or ```DEFAULT_DIMENSION_READER```
     """

--- a/src/diamond/collectors/jolokia/jolokia.py
+++ b/src/diamond/collectors/jolokia/jolokia.py
@@ -271,10 +271,10 @@ class JolokiaCollector(diamond.collector.Collector):
         port = self.config['port']
         # read for all the hosts in one go to optimize
         host_dimensions = self.dimension_reader.read(hosts)
-        for host in hosts:
+        for host_id, host in hosts.items():
             # host custom dimension is set for each host. This is accessible to different
             # collectors to use and attach dimension to their metrics for a host
-            self.host_custom_dimensions = host_dimensions.get(host, {})
+            self.host_custom_dimensions = host_dimensions.get(host_id, {})
             listing = self.list_request(host, port)
             try:
                 domains = listing['value'] if listing['status'] == 200 else {}

--- a/src/diamond/collectors/jolokia/nerve.py
+++ b/src/diamond/collectors/jolokia/nerve.py
@@ -1,0 +1,11 @@
+import json
+
+NERVE_CONFIG_FILEPATH = '/etc/nerve/nerve.conf.json'
+
+
+def read():
+    try:
+        with open(NERVE_CONFIG_FILEPATH, 'r') as f:
+            return json.load(f), None
+    except Exception as e:
+        return None, e

--- a/src/diamond/collectors/jolokia/test/fixtures/nerve.json
+++ b/src/diamond/collectors/jolokia/test/fixtures/nerve.json
@@ -1,0 +1,546 @@
+{
+  "heartbeat_path": "/var/run/nerve/heartbeat",
+  "instance_id": "10-40-19-94-uswest1cdevc",
+  "services": {
+    "cassandra_dev.main.norcal-devc:10.93.118.202.9042": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "cassandra_dev.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/cassandra_dev.main/35588/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 35588,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/cassandra_dev.main"
+    },
+    "cassandra_dev.main.norcal-devc:10.93.118.202.9042.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.118.202",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/cassandra_dev.main/9042/status"
+        }
+      ],
+      "host": "10.93.118.202",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 9042,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/cassandra_dev.main"
+    },
+    "cassandra_dev.main.pnw-devc:10.93.118.202.9042": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "cassandra_dev.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/cassandra_dev.main/35588/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 35588,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/envoy/global/cassandra_dev.main"
+    },
+    "cassandra_dev.main.pnw-devc:10.93.118.202.9042.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.118.202",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/cassandra_dev.main/9042/status"
+        }
+      ],
+      "host": "10.93.118.202",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 9042,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/smartstack/global/cassandra_dev.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.117.39.8888": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "compute-infra-test-service.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/https/compute-infra-test-service.main/40373/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 40373,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/compute-infra-test-service.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.117.39.8888.v2.new": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.117.39",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/http/compute-infra-test-service.main/8888/status"
+        }
+      ],
+      "host": "10.93.117.39",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 8888,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/compute-infra-test-service.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.117.64.8888": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "compute-infra-test-service.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/https/compute-infra-test-service.main/40907/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 40907,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/compute-infra-test-service.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.117.64.8888.v2.new": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.117.64",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/http/compute-infra-test-service.main/8888/status"
+        }
+      ],
+      "host": "10.93.117.64",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 8888,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/compute-infra-test-service.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.126.48.8888": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "compute-infra-test-service.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/https/compute-infra-test-service.main/42380/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 42380,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/compute-infra-test-service.main"
+    },
+    "compute-infra-test-service.main.norcal-devc:10.93.126.48.8888.v2.new": {
+      "check_interval": 2.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.126.48",
+          "open_timeout": 1.0,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 1.0,
+          "type": "http",
+          "uri": "/http/compute-infra-test-service.main/8888/status"
+        }
+      ],
+      "host": "10.93.126.48",
+      "labels": {
+        "superregion:norcal-devc": ""
+      },
+      "port": 8888,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/compute-infra-test-service.main"
+    },
+    "kafka-buff-low.main.norcal-devc:10.93.120.2.9092": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "kafka-buff-low.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-buff-low.main/46329/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 46329,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/kafka-buff-low.main"
+    },
+    "kafka-buff-low.main.norcal-devc:10.93.120.2.9092.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.120.2",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-buff-low.main/9092/status"
+        }
+      ],
+      "host": "10.93.120.2",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 9092,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/kafka-buff-low.main"
+    },
+    "kafka-buff-low.main.pnw-devc:10.93.120.2.9092": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "kafka-buff-low.main"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-buff-low.main/46329/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 46329,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/envoy/global/kafka-buff-low.main"
+    },
+    "kafka-buff-low.main.pnw-devc:10.93.120.2.9092.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.120.2",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-buff-low.main/9092/status"
+        }
+      ],
+      "host": "10.93.120.2",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 9092,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/smartstack/global/kafka-buff-low.main"
+    },
+    "kafka-k8s.testcluster.norcal-devc:10.93.121.57.9092": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "kafka-k8s.testcluster"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-k8s.testcluster/42309/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 42309,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/envoy/global/kafka-k8s.testcluster"
+    },
+    "kafka-k8s.testcluster.norcal-devc:10.93.121.57.9092.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.121.57",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-k8s.testcluster/9092/status"
+        }
+      ],
+      "host": "10.93.121.57",
+      "labels": {
+        "region:sf-devc": "",
+        "region:uswest1-devc": ""
+      },
+      "port": 9092,
+      "weight": 10,
+      "zk_hosts": [
+        "10.40.11.190:22181",
+        "10.40.28.93:22181",
+        "10.40.10.202:22181",
+        "10.40.26.152:22181"
+      ],
+      "zk_path": "/smartstack/global/kafka-k8s.testcluster"
+    },
+    "kafka-k8s.testcluster.pnw-devc:10.93.121.57.9092": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {
+            "Host": "kafka-k8s.testcluster"
+          },
+          "host": "10.40.19.94",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-k8s.testcluster/42309/status"
+        }
+      ],
+      "host": "10.40.19.94",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 42309,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/envoy/global/kafka-k8s.testcluster"
+    },
+    "kafka-k8s.testcluster.pnw-devc:10.93.121.57.9092.v2.new": {
+      "check_interval": 7.0,
+      "checks": [
+        {
+          "fall": 2,
+          "headers": {},
+          "host": "10.93.121.57",
+          "open_timeout": 6,
+          "port": 6666,
+          "rise": 1,
+          "timeout": 6,
+          "type": "http",
+          "uri": "/tcp/kafka-k8s.testcluster/9092/status"
+        }
+      ],
+      "host": "10.93.121.57",
+      "labels": {
+        "region:uswest2-devc": ""
+      },
+      "port": 9092,
+      "weight": 10,
+      "zk_hosts": [
+        "10.81.16.240:22181",
+        "10.81.22.142:22181",
+        "10.81.25.26:22181"
+      ],
+      "zk_path": "/smartstack/global/kafka-k8s.testcluster"
+    }
+  }
+}

--- a/src/diamond/collectors/jolokia/test/test_readers.py
+++ b/src/diamond/collectors/jolokia/test/test_readers.py
@@ -45,4 +45,4 @@ class TestHostReader(HostReader):
         pass
 
     def read(self):
-        return self.hosts
+        return {host: host for host in self.hosts}

--- a/src/diamond/collectors/jolokia/test/testhost_reader.py
+++ b/src/diamond/collectors/jolokia/test/testhost_reader.py
@@ -8,7 +8,7 @@ from test import get_collector_config
 from test import unittest
 
 import host_reader
-from host_reader import StandaloneHostReader, KubernetesHostReader
+from host_reader import StandaloneHostReader, KubernetesHostReader, NerveHostReader
 from mock import Mock
 from mock import patch
 
@@ -26,9 +26,69 @@ class TestStandaloneHostReader(CollectorTestCase):
         config = {'host': '10.1.1.2'}
         self.host_reader.configure(config)
 
-        expected = ["10.1.1.2"]
+        expected = {"10.1.1.2": "10.1.1.2"}
         actual = self.host_reader.read()
         self.assertEquals(expected, actual)
+
+
+class TestNerveHostReader(CollectorTestCase):
+    def setUp(self):
+        self.config = get_collector_config('JolokiaCollector', {})
+        self.host_reader = NerveHostReader()
+
+    def test_import(self):
+        self.assertTrue(NerveHostReader)
+
+    def test_should_filter_hosts_success(self):
+        def se():
+            return json.loads(self.getFixture('nerve.json').getvalue()), None
+
+        with patch("nerve.read", Mock(side_effect=se)):
+            self.config['spec'] = {
+                'host_id_regex': '^(cassandra_[\\w_-]+)',
+            }
+            self.host_reader.configure(self.config)
+            actual = self.host_reader.read()
+            expected = {
+                "cassandra_dev.main.norcal-devc:10.93.118.202.9042": "10.40.19.94",
+                "cassandra_dev.main.norcal-devc:10.93.118.202.9042.v2.new": "10.93.118.202",
+                "cassandra_dev.main.pnw-devc:10.93.118.202.9042": "10.40.19.94",
+                "cassandra_dev.main.pnw-devc:10.93.118.202.9042.v2.new": "10.93.118.202"
+            }
+            self.assertEquals(expected, actual)
+
+    def test_should_not_fail_when_spec_absent(self):
+        def se():
+            return json.loads(self.getFixture('nerve.json').getvalue()), None
+
+        with patch("nerve.read", Mock(side_effect=se)):
+            self.host_reader.configure(self.config)
+            actual = self.host_reader.read()
+            self.assertEquals({}, actual)
+
+    def test_should_return_empty_list_when_regex_does_not_match(self):
+        def se():
+            return json.loads(self.getFixture('nerve.json').getvalue()), None
+
+        with patch("nerve.read", Mock(side_effect=se)):
+            self.config['spec'] = {
+                'host_id_regex': '^(should_not_match_[\\w_-]+)',
+            }
+            self.host_reader.configure(self.config)
+            actual = self.host_reader.read()
+            self.assertEquals({}, actual)
+
+    def test_should_not_fail_when_nerve_read_error(self):
+        def se():
+            return None, IOError("some error")
+
+        with patch("nerve.read", Mock(side_effect=se)):
+            self.config['spec'] = {
+                'host_id_regex': '^(cassandra_[\\w_-]+)',
+            }
+            self.host_reader.configure(self.config)
+            actual = self.host_reader.read()
+            self.assertEquals({}, actual)
 
 
 class TestKubernetesHostReader(CollectorTestCase):
@@ -51,7 +111,7 @@ class TestKubernetesHostReader(CollectorTestCase):
                 }}
             self.host_reader.configure(self.config)
             actual = self.host_reader.read()
-            self.assertEquals(["172.23.0.42"], actual)
+            self.assertEquals({"172.23.0.42": "172.23.0.42"}, actual)
 
     def test_should_filter_hosts_partial_match(self):
         def se():
@@ -65,7 +125,7 @@ class TestKubernetesHostReader(CollectorTestCase):
                 }}
             self.host_reader.configure(self.config)
             actual = self.host_reader.read()
-            self.assertEquals([], actual)
+            self.assertEquals({}, actual)
 
     def test_should_not_fail_when_spec_absent(self):
         def se():
@@ -74,7 +134,7 @@ class TestKubernetesHostReader(CollectorTestCase):
         with patch("kubernetes.Kubelet.list_pods", Mock(side_effect=se)):
             self.host_reader.configure(self.config)
             actual = self.host_reader.read()
-            self.assertEquals([], actual)
+            self.assertEquals({}, actual)
 
     def test_should_return_empty_list_when_no_label_selectors(self):
         def se():
@@ -84,7 +144,7 @@ class TestKubernetesHostReader(CollectorTestCase):
             self.config['spec'] = {'label_selector': {}}
             self.host_reader.configure(self.config)
             actual = self.host_reader.read()
-            self.assertEquals([], actual)
+            self.assertEquals({}, actual)
 
     def test_should_not_fail_when_kubelet_is_not_reachable(self):
         def se():
@@ -98,12 +158,13 @@ class TestKubernetesHostReader(CollectorTestCase):
                 }}
             self.host_reader.configure(self.config)
             actual = self.host_reader.read()
-            self.assertEquals([], actual)
+            self.assertEquals({}, actual)
 
 
 class TestHostReader(CollectorTestCase):
     def test_should_get_by_mode(self):
         self.assertEqual(type(KubernetesHostReader()), type(host_reader.get_by_mode('kubernetes')))
+        self.assertEqual(type(NerveHostReader()), type(host_reader.get_by_mode('nerve')))
         self.assertEqual(type(StandaloneHostReader()), type(host_reader.get_by_mode('standalone')))
 
     def test_should_return_default_reader_for_invalid_mode(self):

--- a/src/diamond/collectors/jolokia/test/testjolokia.py
+++ b/src/diamond/collectors/jolokia/test/testjolokia.py
@@ -49,44 +49,6 @@ class TestJolokiaCollector(CollectorTestCase):
         self.assertPublishedMany(publish_mock, metrics)
 
     @patch.object(Collector, 'publish')
-    def test_should_work_in_mutiple_hosts_mode(self, publish_mock):
-        port = self.collector.config['port']
-        host_reader = self.collector.host_reader
-        hosts = test_hosts()
-        self.collector.config['multiple_hosts_mode'] = True
-        self.collector.host_reader = TestHostReader(hosts)
-        requested_list_urls = []
-
-        def se(url):
-            list_urls = [
-                'http://%s:%s/jolokia/list' % (host, port)
-                for host in hosts
-            ]
-            if any(_url in url for _url in list_urls):
-                requested_list_urls.append(url)
-                return self.getFixture('listing')
-            else:
-                return self.getFixture('stats')
-
-        patch_urlopen = patch('urllib2.urlopen', Mock(side_effect=se))
-
-        with patch_urlopen:
-            self.collector.collect()
-        self.collector.config['mutiple_hosts_mode'] = False
-        self.collector.host_reader = host_reader
-
-        self.assertTrue(all(
-            "%s:%s" % (h, port) in requested_list_urls[i]
-            for i, h in enumerate(hosts)
-        ))
-
-        metrics = self.get_metrics()
-        self.setDocExample(collector=self.collector.__class__.__name__,
-                           metrics=metrics,
-                           defaultpath=self.collector.config['url_path'])
-        self.assertPublishedMany(publish_mock, metrics, 2)
-
-    @patch.object(Collector, 'publish')
     def test_real_data_with_rewrite(self, publish_mock):
         def se(url):
             if 'http://localhost:8778/jolokia/list' in url:


### PR DESCRIPTION
**Context**
These changes enable nerve support in jolokia collector. An example nerve configuration will look like 
```json
{
  "mode": "nerve",
  "spec": {
    "dimensions": {
      "nerve": {
        "cassandra_cluster": "^cassandra_([\\w_-]+).",
        "cassandra_instance": "^cassandra_[\\w_-]+.([\\w_-]+)."
      }
    },
    "host_id_regex": "^cassandra_[\\w_-]+"
  }
}
```
**Testing**
Fixed existing test cases and added new test cases

**Note**
This is an extension of https://github.com/Yelp/fullerite/pull/443
