### PR TITLE
Disable flaky test

### DIFF
--- a/src/fullerite/handler/handler_test.go
+++ b/src/fullerite/handler/handler_test.go
@@ -149,6 +149,7 @@ func TestRecordTimings(t *testing.T) {
 }
 
 func TestHandlerRunFlushInterval(t *testing.T) {
+	t.Skip("This test is flaky on overloaded hosts (jenkins)")
 	var mu sync.Mutex
 	base := BaseHandler{}
 	base.log = l.WithField("testing", "basehandler_flush")


### PR DESCRIPTION
This test fails often in jenkins. I think it's because those hosts are always overloaded and this test seems to rely on things happening in a specific time window