### PR TITLE
[KAFKA-25711] Making custom dimension name str instead of unicode

### DIFF
--- a/src/diamond/collectors/jolokia/dimension_reader.py
+++ b/src/diamond/collectors/jolokia/dimension_reader.py
@@ -129,7 +129,7 @@ class KubernetesDimensionReader(DimensionReader):
             if label_value is not None:
                 matches = label_regex.regex.findall(label_value)
                 if len(matches) > 0:
-                    generated[dim] = string.replace(matches[0], "--", "_", -1)
+                    generated[str(dim)] = string.replace(matches[0], "--", "_", -1)
         return generated
 
 


### PR DESCRIPTION
**Context**
Diamond metrics expect the dimension name to be [unicode](https://github.com/Yelp/fullerite/blob/master/src/diamond/metric.py#L67). Because we were reading dimension name from the conf file, dimension name were unicode and due to this they were filtered out [here](https://github.com/Yelp/fullerite/blob/master/src/diamond/metric.py#L67) when creating `diamond.Metric`. This change makes dimension name `str`

**Testing**
```
make test
```
```
  py27: commands succeeded
  congratulations :)
Testing fullerite
ok  	fullerite	12.028s	coverage: 48.9% of statements
ok  	fullerite/beatit	1.012s	coverage: 20.9% of statements
ok  	fullerite/collector	19.287s	coverage: 69.3% of statements
ok  	fullerite/config	(cached)	coverage: 67.5% of statements
ok  	fullerite/handler	7.035s	coverage: 57.1% of statements
?   	fullerite/internalserver	[no test files]
ok  	fullerite/metric	(cached)	coverage: 53.6% of statements
ok  	fullerite/util	1.074s	coverage: 67.6% of statements
ok  	fullerite/dropwizard	(cached)	coverage: 89.0% of statements
```