### PR TITLE
Fixed disk stats for docker stats.

### DIFF
--- a/src/fullerite/collector/docker_stats_test.go
+++ b/src/fullerite/collector/docker_stats_test.go
@@ -244,6 +244,9 @@ func TestDockerStatsBuildMetricsWithEmitDiskMetrics(t *testing.T) {
                 "SizeRw": 1234,
                 "SizeRootFs": 5678,
                 "Config": {
+"Labels": {
+                        "io.kubernetes.container.name": "test_name"
+                },
                         "Env": [
                                 "MESOS_TASK_ID=my--service.main.blablagit6bdsadnoise",
                                 "PAASTA_INSTANCE=test_instance",
@@ -298,6 +301,7 @@ func TestDockerStatsBuildMetricsWithEmitDiskMetrics(t *testing.T) {
 		"instance_name": "main",
 	}
 	expectedDimsDisk := map[string]string{
+		"container_name":       "test_name",
 		"container_mount_path": "test_path",
 		"paasta_service":       "test_service",
 		"paasta_instance":      "test_instance",


### PR DESCRIPTION
Manually validated the values. Added container_name as a dimension (after discussion with Valeriy) to separate the metrics if someone wants to see the individual values in cases they are being averaged.

Tested on the below node:

https://app.signalfx.com/#/chart/v2/ET4Ya41AgAA?groupId=ETaRtKqAgAA&configId=ETaRtlHAYAA&sources%5B%5D=hostname:10-40-19-94-uswest1cdevc