### PR TITLE
Never output bad metric names which Prometheus will be unable to parse

### DIFF
--- a/src/fullerite/handler/prometheus.go
+++ b/src/fullerite/handler/prometheus.go
@@ -204,11 +204,15 @@ func addPrometheusMetric(m metric.Metric) {
 		return
 	}
 
-	name := fmt.Sprintf("%s_%s", collectorName, getMetricKey(m.Name))
-	labels := dimensionsToString(m.Dimensions)
-	pm := NewPrometheusMetric(m)
-	t := m.MetricType
-	c.StoreMetric(name, labels, t, pm)
+	name := getMetricKey(m.Name)
+	if nameMatcher.MatchString(name) {
+		labels := dimensionsToString(m.Dimensions)
+		pm := NewPrometheusMetric(m)
+		t := m.MetricType
+		c.StoreMetric(name, labels, t, pm)
+	} else {
+        defaultLog.WithFields(l.Fields{"handler": "prometheus"}).Errorf("Non prometheus compatible metric name encountered: '%s'", name)
+    }
 }
 
 // PrometheustableRead is the ntry point from internal metric server, this function dumps the types and text output


### PR DESCRIPTION
This change adds back metric name checking so that we won't store or output any metrics whos names are not compatible with Prometheus. This is a safety net to stop one collector which outputs crazy stuff from breaking all Prometheus collection of Fullerite metrics from a host.

I have also made the metric name output just be the metric name, rather than ${collector}_${metricname} - we already add the collector as a dimension, so I don't think there's any value in making it also part of the metric name (and in fact doing so goes against the Prometheus recommendations for how to name metrics).

This means that metric names should translate 1:1 (sans characters which are removed or turned into _ to make the metric names Prom compatible) which will make transition easier for people as they know the metric names that they're interested in already, but probably don't know or care about the collector. Not adding the collector name means you can use autocomplete to find the Prometheus metric name.