### PR TITLE
Fix prometheus handler parse errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 FULLERITE      := fullerite
 BEATIT         := beatit
-VERSION        := 0.6.87
+VERSION        := 0.6.88
 SRCDIR         := src
 GLIDE          := glide
 HANDLER_DIR    := $(SRCDIR)/fullerite/handler

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "beatit"
-	version = "0.6.87"
+	version = "0.6.88"
 	desc    = "Stress test fullerite handlers"
 )
 

--- a/src/fullerite/collector/prometheus.go
+++ b/src/fullerite/collector/prometheus.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	// Fullerite version
-	version = "0.6.87"
+	version = "0.6.88"
 
 	// Prometheus parser can process metrics in `application/openmetrics-text` and `text/plain` formats
 	acceptHeader = `application/openmetrics-text; version=0.0.1,text/plain;version=0.0.4;q=0.5,*/*;q=0.1`

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "fullerite"
-	version = "0.6.87"
+	version = "0.6.88"
 	desc    = "Diamond compatible metrics collector"
 )
 


### PR DESCRIPTION
Fixes the time attached to metrics to be in the correct format for Prometheus.

Fixes the key names in dimensions to be able to deal with - in key names, which is used / needed by some fullerite collectors.

Fix the issues with outputting a type statement for fullerite_collector_datapoints multiple times by just throwing away that metric. Prometheus has it's own meta metrics

Fix logging as error to log as warn instead - this still shows up in the default log level that we run with, but avoids triggering the logging hook and registering collector errors.