### PR TITLE
Only set version in the Makefile and not 3 times

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,11 +66,11 @@ deps:
 
 $(FULLERITE): $(SOURCES) deps
 	@echo Building $(FULLERITE)...
-	@go build -o bin/$(FULLERITE) $@
+	@go build -ldflags '-X main.version=$(VERSION)' -o bin/$(FULLERITE) $@
 
 $(BEATIT): $(BEATIT_SOURCES)
 	@echo Building $(BEATIT)...
-	@go build -o bin/$(BEATIT) fullerite/beatit
+	@go build -ldflags '-X main.version=$(VERSION)' -o bin/$(BEATIT) fullerite/beatit
 
 go:
 	uname -a |grep -qE '^Linux.*x86_64' && curl -s https://dl.google.com/go/go1.13.linux-amd64.tar.gz | tar xz

--- a/src/fullerite/beatit/main.go
+++ b/src/fullerite/beatit/main.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	name    = "beatit"
-	version = "0.6.88"
-	desc    = "Stress test fullerite handlers"
+	name = "beatit"
+	desc = "Stress test fullerite handlers"
 )
+
+// Set by the Makefile at build time
+var version string
 
 var log = logrus.WithFields(logrus.Fields{"app": "fullerite"})
 

--- a/src/fullerite/main.go
+++ b/src/fullerite/main.go
@@ -16,10 +16,12 @@ import (
 )
 
 const (
-	name    = "fullerite"
-	version = "0.6.88"
-	desc    = "Diamond compatible metrics collector"
+	name = "fullerite"
+	desc = "Diamond compatible metrics collector"
 )
+
+// Set by the Makefile at build time
+var version string
 
 var log = logrus.WithFields(logrus.Fields{"app": "fullerite"})
 


### PR DESCRIPTION
Pass the version as build arg rather than write it in 3 different places.

It still prints the right version:
```
drolando@dev41-uswest1adevc fullerite (git only_set_version_once) ✓
~>  ./bin/fullerite --version
fullerite version 0.6.88
```